### PR TITLE
feat: run Kratos locally without any Azure services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,3 +57,14 @@ NEXT_PUBLIC_MSAL_AUTHORITY=
 
 # Local Development Only (never commit .env)
 # All production secrets are in Key Vault via Managed Identity
+
+# ── Local Mode (run without Azure services) ─────────────────────────────────
+# When LOCAL_MODE=true (or when COSMOS_DB_ENDPOINT is empty), the backend
+# uses SQLite instead of Cosmos DB, Azurite/conn-string blob instead of MSI,
+# and a GitHub Copilot token instead of Microsoft Foundry.
+# See README "Run locally without Azure" and docker-compose.yml for details.
+LOCAL_MODE=
+COPILOT_GITHUB_TOKEN=
+LOCAL_DATA_DIR=.local
+# Azurite default (uncomment to use the docker-compose azurite service):
+# BLOB_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+# GitHub Copilot token — get one at https://github.com/settings/tokens
+COPILOT_GITHUB_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ venv/
 env/
 .env
 .env.local
+.local/
 
 # Node.js / Next.js
 node_modules/

--- a/README.md
+++ b/README.md
@@ -109,6 +109,61 @@ npm run dev
 
 ---
 
+## Run locally without Azure
+
+You can run the full backend + frontend on your laptop with **zero Azure services**. A GitHub Copilot token replaces Microsoft Foundry, a SQLite file replaces Cosmos DB, and [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite) replaces Blob Storage. `LOCAL_MODE` auto-enables whenever `COSMOS_DB_ENDPOINT` is empty, so the same codebase works in both environments without edits.
+
+### Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) — runs the `azurite` + `backend` containers.
+- A **GitHub Copilot token** with the `Copilot` scope — create one at [github.com/settings/tokens](https://github.com/settings/tokens).
+- [Node.js 20+](https://nodejs.org/) — only if you want to run the frontend locally (it is not containerised).
+
+### Quick start
+
+```bash
+cp .env.local.example .env.local
+# Edit .env.local: set COPILOT_GITHUB_TOKEN=ghu_xxx
+./run-local.sh          # or .\run-local.ps1 on Windows
+```
+
+The helper scripts copy the env file and run `docker compose up --build`. If you prefer, you can skip them and run `docker compose up --build` directly.
+
+### What the helper starts
+
+| Service | URL | Purpose |
+|---|---|---|
+| backend | http://localhost:8000 | FastAPI + Copilot SDK |
+| azurite | http://localhost:10000 | Local Blob (skills + apm manifests) |
+| *(frontend, optional)* | http://localhost:3000 | `cd src/frontend && npm install && npm run dev` |
+
+### Data locations
+
+Everything persists on the host so restarts are cheap:
+
+- `.local/backend/kratos.db` — SQLite file with conversations, messages, settings, and session mappings.
+- `.local/azurite/` — emulated blob account (skill blobs).
+- `use-cases/` is bind-mounted into the backend container — edits on the host show up immediately.
+
+### Switching between local and Azure modes
+
+Auto-detection uses `COSMOS_DB_ENDPOINT` as the switch:
+
+- **Local:** leave `COSMOS_DB_ENDPOINT` empty (or set `LOCAL_MODE=true`).
+- **Azure:** set `LOCAL_MODE=false` (or just remove it) and populate `COSMOS_DB_ENDPOINT`, `FOUNDRY_ENDPOINT`, and `BLOB_STORAGE_ENDPOINT`.
+
+### What still works
+
+- **MCP servers** configured via `use-cases/{uc}/.mcp.json`.
+- **Skill enable/disable** and `SKILL.md` edits via `/api/admin/skills/*`.
+
+### Limitations
+
+- **App Insights / Foundry Traces** are disabled — telemetry still runs locally via the OTel console exporter.
+- **No Foundry guardrails** — the GitHub Copilot endpoint handles safety instead.
+
+---
+
 ## Project Structure
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:latest
+    command: azurite --blobHost 0.0.0.0 --loose --skipApiVersionCheck
+    ports:
+      - "10000:10000"
+    volumes:
+      - ./.local/azurite:/data
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"require('net').createConnection(10000,'127.0.0.1').on('connect',()=>process.exit(0)).on('error',()=>process.exit(1))\""]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
+  backend:
+    build:
+      context: .
+      dockerfile: src/backend/Dockerfile
+    ports:
+      - "8000:8000"
+    environment:
+      LOCAL_MODE: "true"
+      COPILOT_GITHUB_TOKEN: ${COPILOT_GITHUB_TOKEN}
+      BLOB_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
+      BLOB_SKILLS_CONTAINER: skills
+      LOCAL_DATA_DIR: /data
+      ENVIRONMENT: development
+      APM_ENABLED: "true"
+    volumes:
+      - ./.local/backend:/data
+      - ./use-cases:/app/use-cases
+    depends_on:
+      azurite:
+        condition: service_healthy

--- a/run-local.ps1
+++ b/run-local.ps1
@@ -1,0 +1,15 @@
+#!/usr/bin/env pwsh
+# Bootstrap kratos-agent in fully local mode (Azurite + SQLite).
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+Set-Location -Path $PSScriptRoot
+
+if (-not (Test-Path ".env.local")) {
+    Copy-Item ".env.local.example" ".env.local"
+    Write-Host "Created .env.local from template." -ForegroundColor Yellow
+    Write-Host "Edit .env.local and set COPILOT_GITHUB_TOKEN before continuing." -ForegroundColor Yellow
+    exit 1
+}
+
+docker compose --env-file .env.local up --build

--- a/run-local.sh
+++ b/run-local.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Bootstrap kratos-agent in fully local mode (Azurite + SQLite).
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [ ! -f .env.local ]; then
+    cp .env.local.example .env.local
+    echo "Created .env.local from template."
+    echo "Edit .env.local and set COPILOT_GITHUB_TOKEN before continuing."
+    exit 1
+fi
+
+docker compose --env-file .env.local up --build

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -14,7 +14,7 @@ RUN npm install -g @github/copilot@latest faker-mcp-server@latest \
     && rm -rf /root/.npm /tmp/*
 
 # ── Layer 3: Playwright Chromium + system deps for PDF rendering ──
-RUN npx -y playwright install --with-deps chromium \
+RUN npx -y playwright install --with-deps chromium\
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # ── Layer 4: Python dependencies (cached unless pyproject.toml changes) ──

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -43,6 +43,23 @@ class Settings(BaseSettings):
     # Cosmos DB database
     cosmos_db_database: str = "kratos-agent"
 
+    # Local mode — run the backend without any Azure services.
+    #   * SQLite replaces Cosmos DB (persistence under ``local_data_dir``)
+    #   * GitHub OAuth token replaces Foundry / Managed Identity for the model call
+    #   * Azurite (or any blob connection string) replaces MSI-backed blob
+    # ``local_mode`` defaults to True when ``cosmos_db_endpoint`` is empty.
+    local_mode: bool | None = None  # None → auto-detect; True/False → explicit override
+    copilot_github_token: str = ""
+    local_data_dir: str = ".local"
+    blob_storage_connection_string: str = ""  # set for Azurite / local emulators
+
+    @property
+    def is_local_mode(self) -> bool:
+        """True when the backend should run without Azure services."""
+        if self.local_mode is not None:
+            return self.local_mode
+        return not self.cosmos_db_endpoint
+
     model_config = {"env_file": ".env", "extra": "ignore"}
 
 

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -1,15 +1,27 @@
 """FastAPI application entry point."""
 
 import logging
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import AsyncGenerator
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import get_settings
 from app.observability import instrument_fastapi_app, setup_telemetry
-from app.routers import admin_analysis, admin_mcp, admin_prompt, admin_skills, agent, conversations, copilot_studio, files, health, settings, use_cases
+from app.routers import (
+    admin_analysis,
+    admin_mcp,
+    admin_prompt,
+    admin_skills,
+    agent,
+    conversations,
+    copilot_studio,
+    files,
+    health,
+    settings,
+    use_cases,
+)
 from app.services.blob_skill_service import BlobSkillService
 from app.services.copilot_agent import CopilotAgent
 from app.services.cosmos_service import CosmosService
@@ -17,7 +29,7 @@ from app.services.skill_registry import SkillRegistry
 
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s %(levelname)s %(name)s %(message)s',
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
 )
 # Silence chatty Azure SDK HTTP loggers — they log full request/response headers at INFO
 logging.getLogger("azure.cosmos").setLevel(logging.WARNING)
@@ -60,6 +72,11 @@ async def lifespan(application: FastAPI) -> AsyncGenerator[None, None]:
         logger.error("Blob storage is not configured — no skills will be available")
     else:
         try:
+            # In local/dev mode Azurite starts empty — seed use-case folders
+            # from the repository so all personas show up in the UI.
+            seeded = await blob_skill_service.seed_from_local()
+            if seeded:
+                logger.info("Seeded %d use-case(s) into blob: %s", len(seeded), seeded)
             use_case_names = await blob_skill_service.list_use_cases()
             for uc_name in use_case_names:
                 registry = SkillRegistry()
@@ -87,6 +104,7 @@ async def lifespan(application: FastAPI) -> AsyncGenerator[None, None]:
     # Cleanup
     await copilot_agent.stop()
     await blob_skill_service.close()
+    await cosmos_service.close()
     logger.info("Kratos Agent Service shutting down")
 
 

--- a/src/backend/app/services/blob_skill_service.py
+++ b/src/backend/app/services/blob_skill_service.py
@@ -13,6 +13,7 @@ can read SKILL.md files from disk.  The admin API writes back to blob.
 Uses Azure Managed Identity for passwordless authentication.
 """
 
+import contextlib
 import logging
 from pathlib import Path
 
@@ -26,6 +27,23 @@ logger = logging.getLogger(__name__)
 _USE_CASES_PREFIX = "use-cases/"
 
 
+def _parse_account_name(conn_str: str) -> str:
+    """Extract ``AccountName`` from an Azure Storage connection string.
+
+    Args:
+        conn_str: A Storage connection string (``key=value;`` pairs).
+
+    Returns:
+        The account name if present, otherwise ``"unknown"``. The account key
+        is never returned so it is safe to include in logs.
+    """
+    for part in conn_str.split(";"):
+        key, sep, value = part.partition("=")
+        if sep and key.strip().lower() == "accountname":
+            return value.strip()
+    return "unknown"
+
+
 class BlobSkillService:
     """Manages use-case and skill storage in Azure Blob Storage."""
 
@@ -36,20 +54,40 @@ class BlobSkillService:
         self._credential: DefaultAzureCredential | None = None
 
     async def initialize(self) -> None:
-        """Initialize the blob container client."""
+        """Initialize the blob container client.
+
+        Prefers ``blob_storage_connection_string`` (e.g. Azurite) when set.
+        Falls back to ``blob_storage_endpoint`` + ``DefaultAzureCredential``
+        (Managed Identity / dev Entra ID). If neither is configured the
+        service no-ops.
+        """
+        conn_str = self.settings.blob_storage_connection_string
         endpoint = self.settings.blob_storage_endpoint
         container = self.settings.blob_skills_container
-        if not endpoint:
-            logger.warning("Blob storage endpoint not configured — skill persistence disabled")
+
+        if conn_str:
+            self._container_client = ContainerClient.from_connection_string(conn_str, container_name=container)
+            account = _parse_account_name(conn_str)
+            logger.info(
+                "Blob skill service initialized (connection string, account=%s) container=%s",
+                account,
+                container,
+            )
+        elif endpoint:
+            self._credential = DefaultAzureCredential()
+            self._container_client = ContainerClient(
+                account_url=endpoint,
+                container_name=container,
+                credential=self._credential,
+            )
+            logger.info("Blob skill service initialized — endpoint=%s container=%s", endpoint, container)
+        else:
+            logger.warning("Blob storage not configured — skill persistence disabled")
             return
 
-        self._credential = DefaultAzureCredential()
-        self._container_client = ContainerClient(
-            account_url=endpoint,
-            container_name=container,
-            credential=self._credential,
-        )
-        logger.info("Blob skill service initialized — endpoint=%s container=%s", endpoint, container)
+        with contextlib.suppress(Exception):
+            await self._container_client.create_container()
+            # Container likely already exists
 
     @property
     def is_available(self) -> bool:
@@ -71,6 +109,40 @@ class BlobSkillService:
             if parts and parts[0]:
                 names.add(parts[0])
         return sorted(names)
+
+    async def seed_from_local(self) -> list[str]:
+        """Upload each local use-case folder to blob if it isn't already present.
+
+        Used in local/dev mode where Azurite starts empty but the repository
+        ships several use-case directories under ``use-cases/``. Only folders
+        that contain a ``SYSTEM_PROMPT.md`` are considered. Returns the list of
+        use-case names that were newly seeded.
+        """
+        if not self._container_client or not self.local_base_dir.is_dir():
+            return []
+        existing = set(await self.list_use_cases())
+        seeded: list[str] = []
+        # APM-materialised output must never leak into blob.
+        _skip_dir_parts = {"apm_modules", ".github", "__pycache__", ".pytest_cache"}
+        for uc_dir in sorted(self.local_base_dir.iterdir()):
+            if not uc_dir.is_dir() or uc_dir.name in existing:
+                continue
+            if not (uc_dir / "SYSTEM_PROMPT.md").is_file():
+                continue
+            uploaded = 0
+            for path in uc_dir.rglob("*"):
+                if not path.is_file():
+                    continue
+                rel_parts = path.relative_to(uc_dir).parts
+                if any(part in _skip_dir_parts for part in rel_parts[:-1]):
+                    continue
+                rel = "/".join(rel_parts)
+                blob_path = f"{_USE_CASES_PREFIX}{uc_dir.name}/{rel}"
+                await self.upload_file(blob_path, path.read_bytes())
+                uploaded += 1
+            logger.info("Seeded use-case '%s' to blob (%d files)", uc_dir.name, uploaded)
+            seeded.append(uc_dir.name)
+        return seeded
 
     async def download_system_prompt(self, use_case: str) -> str | None:
         """Download the SYSTEM_PROMPT.md for a use-case."""
@@ -163,11 +235,10 @@ class BlobSkillService:
         if not self._container_client:
             return
         blob_path = f"{_USE_CASES_PREFIX}{use_case}/skills/{skill_name}/{file_path}"
-        try:
+        with contextlib.suppress(Exception):
+            # Already deleted or doesn't exist
             blob = self._container_client.get_blob_client(blob_path)
             await blob.delete_blob()
-        except Exception:
-            pass  # Already deleted or doesn't exist
 
     async def upload_mcp_config(self, use_case: str, content: bytes) -> None:
         """Upload the .mcp.json config for a use-case."""

--- a/src/backend/app/services/copilot_agent.py
+++ b/src/backend/app/services/copilot_agent.py
@@ -6,14 +6,15 @@ Uses DefaultAzureCredential for keyless auth to Microsoft Foundry.
 """
 
 import asyncio
-from importlib.metadata import version
 import json
 import logging
 import os
 import re
 import time
 import uuid
-from typing import TYPE_CHECKING, AsyncGenerator
+from collections.abc import AsyncGenerator
+from importlib.metadata import version
+from typing import TYPE_CHECKING
 
 from azure.identity.aio import ManagedIdentityCredential, get_bearer_token_provider
 from copilot import CopilotClient, PermissionRequestResult
@@ -24,6 +25,8 @@ try:
     _HAS_CLI_CREDENTIAL = True
 except ImportError:
     _HAS_CLI_CREDENTIAL = False
+import contextlib
+
 from opentelemetry import context as otel_context
 from opentelemetry import trace
 
@@ -84,7 +87,7 @@ def _resolve_skill_display_name(event_data, fallback: str = "skill") -> str:
     return fallback
 
 
-def prettyToolName(name: str) -> str:
+def pretty_tool_name(name: str) -> str:
     """Convert tool_name to 'Tool Name' for display."""
     return " ".join(w.capitalize() for w in name.replace("-", "_").split("_"))
 
@@ -156,7 +159,7 @@ class CopilotAgent:
         self.settings = settings
         self._client: CopilotClient | None = None
         self._registries: dict[str, object] = {}  # use_case -> SkillRegistry
-        self._cosmos_service: "CosmosService | None" = None
+        self._cosmos_service: CosmosService | None = None
         self._sessions: dict[str, object] = {}
         self._conversation_use_cases: dict[str, str] = {}  # conv_id -> use_case
         self._system_prompt: str = DEFAULT_SYSTEM_PROMPT
@@ -230,6 +233,21 @@ class CopilotAgent:
             return registry.get_enabled_tool_names()
         return None
 
+    def _resolve_skill_source(self, conversation_id: str, tool_name: str) -> str:
+        """Best-effort lookup of ``Skill.source`` for a given tool/skill name.
+
+        Returns an empty string when the registry is unavailable or no matching
+        skill is found (e.g. builtin tools that predate the registry).
+        """
+        registry = self._get_registry(conversation_id)
+        if registry is None:
+            return ""
+        skills = getattr(registry, "skills", None) or {}
+        for skill in skills.values():
+            if getattr(skill, "tool_name", None) == tool_name or getattr(skill, "name", None) == tool_name:
+                return getattr(skill, "source", "") or ""
+        return ""
+
     def _get_system_prompt(self, conversation_id: str) -> str:
         """Get the system prompt for a conversation's use-case."""
         registry = self._get_registry(conversation_id)
@@ -238,7 +256,7 @@ class CopilotAgent:
             prompt = registry.system_prompt
             m = re.match(r"^---\s*\n.*?\n---\s*\n?", prompt, re.DOTALL)
             if m:
-                prompt = prompt[m.end():].strip()
+                prompt = prompt[m.end() :].strip()
             return prompt
         return self._system_prompt
 
@@ -254,10 +272,8 @@ class CopilotAgent:
         are removed, preventing resume attempts for sessions that used the old prompt.
         """
         for session in self._sessions.values():
-            try:
+            with contextlib.suppress(Exception):
                 await session.disconnect()
-            except Exception:
-                pass
         self._system_prompt = value
         self._sessions.clear()
         self._registered_handlers.clear()
@@ -275,10 +291,8 @@ class CopilotAgent:
         for cid in conv_ids:
             session = self._sessions.pop(cid, None)
             if session:
-                try:
+                with contextlib.suppress(Exception):
                     await session.disconnect()
-                except Exception:
-                    pass
             self._registered_handlers.discard(cid)
             self._queues.pop(cid, None)
             if self._cosmos_service:
@@ -288,27 +302,38 @@ class CopilotAgent:
     async def start(self) -> None:
         """Initialize the Copilot CLI client. Called once on app startup.
 
-        Uses ManagedIdentityCredential (prod) with AzureCLICredential fallback (dev)
-        instead of DefaultAzureCredential, which probes many credential sources
-        sequentially and adds significant latency on each token acquisition.
-        """
-        if _HAS_CLI_CREDENTIAL:
-            self._credential = ChainedTokenCredential(
-                ManagedIdentityCredential(),
-                AzureCLICredential(),
-            )
-        else:
-            self._credential = ManagedIdentityCredential()
-        scope = "https://cognitiveservices.azure.com/.default"
-        self._token_provider = get_bearer_token_provider(self._credential, scope)
+        In cloud mode, uses ManagedIdentityCredential (prod) with AzureCLICredential
+        fallback (dev) instead of DefaultAzureCredential, which probes many credential
+        sources sequentially and adds significant latency on each token acquisition.
 
-        # Pre-warm: acquire the first token now so user requests don't pay the cost
-        try:
-            t0 = time.monotonic()
-            await self._credential.get_token(scope)
-            logger.info("Token pre-warmed successfully in %.1fms", (time.monotonic() - t0) * 1000)
-        except Exception:
-            logger.warning("Token pre-warm failed — first request will be slower", exc_info=True)
+        In local mode (``settings.is_local_mode``), skips Azure credential setup and
+        relies on the Copilot SDK's default GitHub-hosted model. A ``GITHUB_TOKEN``
+        environment variable is exported from ``settings.copilot_github_token`` when
+        set (and not already present in the environment) so the SDK can authenticate.
+        """
+        local_mode = self.settings.is_local_mode
+
+        if local_mode:
+            if self.settings.copilot_github_token and not os.environ.get("GITHUB_TOKEN"):
+                os.environ["GITHUB_TOKEN"] = self.settings.copilot_github_token
+        else:
+            if _HAS_CLI_CREDENTIAL:
+                self._credential = ChainedTokenCredential(
+                    ManagedIdentityCredential(),
+                    AzureCLICredential(),
+                )
+            else:
+                self._credential = ManagedIdentityCredential()
+            scope = "https://cognitiveservices.azure.com/.default"
+            self._token_provider = get_bearer_token_provider(self._credential, scope)
+
+            # Pre-warm: acquire the first token now so user requests don't pay the cost
+            try:
+                t0 = time.monotonic()
+                await self._credential.get_token(scope)
+                logger.info("Token pre-warmed successfully in %.1fms", (time.monotonic() - t0) * 1000)
+            except Exception:
+                logger.warning("Token pre-warm failed — first request will be slower", exc_info=True)
 
         self._client = CopilotClient()
         await self._client.start()
@@ -316,36 +341,46 @@ class CopilotAgent:
         # Emit a create_agent span so Foundry Traces tab can discover this agent.
         # Foundry looks for plural gen_ai.agents.id / gen_ai.agents.name;
         # OTel spec uses singular gen_ai.agent.id — emit both.
+        span_attrs: dict = {
+            "gen_ai.operation.name": "create_agent",
+            "gen_ai.request.model": self.settings.foundry_model_deployment,
+            "gen_ai.agent.id": "kratos-agent",
+            "gen_ai.agent.name": "kratos-agent",
+            "gen_ai.agents.id": "kratos-agent",
+            "gen_ai.agents.name": "kratos-agent",
+            "gen_ai.agent.version": "0.1.0",
+        }
+        if local_mode:
+            span_attrs["gen_ai.system"] = "github"
+            span_attrs["gen_ai.provider.name"] = "github"
+            span_attrs["server.address"] = "api.githubcopilot.com"
+        else:
+            span_attrs["gen_ai.system"] = "openai"
+            span_attrs["gen_ai.provider.name"] = "azure.ai.openai"
+            span_attrs["server.address"] = self.settings.foundry_endpoint
         with tracer.start_as_current_span(
             "create_agent kratos-agent",
             kind=trace.SpanKind.CLIENT,
-            attributes={
-                "gen_ai.operation.name": "create_agent",
-                "gen_ai.system": "openai",
-                "gen_ai.provider.name": "azure.ai.openai",
-                "gen_ai.request.model": self.settings.foundry_model_deployment,
-                "gen_ai.agent.id": "kratos-agent",
-                "gen_ai.agent.name": "kratos-agent",
-                "gen_ai.agents.id": "kratos-agent",
-                "gen_ai.agents.name": "kratos-agent",
-                "gen_ai.agent.version": "0.1.0",
-                "server.address": self.settings.foundry_endpoint,
-            },
+            attributes=span_attrs,
         ):
             pass
 
-        logger.info(
-            "CopilotClient started (Managed Identity auth, sdk_version=%s)",
-            version("github-copilot-sdk"),
-        )
+        if local_mode:
+            logger.info(
+                "CopilotClient started (local mode — GitHub token auth, sdk_version=%s)",
+                version("github-copilot-sdk"),
+            )
+        else:
+            logger.info(
+                "CopilotClient started (Managed Identity auth, sdk_version=%s)",
+                version("github-copilot-sdk"),
+            )
 
     async def stop(self) -> None:
         """Shutdown all sessions and the CLI client. Called on app shutdown."""
         for session in self._sessions.values():
-            try:
+            with contextlib.suppress(Exception):
                 await session.disconnect()
-            except Exception:
-                pass
         self._sessions.clear()
         self._registered_handlers.clear()
         self._queues.clear()
@@ -370,10 +405,8 @@ class CopilotAgent:
 
         # Drop all existing sessions so they get recreated with the new config
         for session in self._sessions.values():
-            try:
+            with contextlib.suppress(Exception):
                 await session.disconnect()
-            except Exception:
-                pass
         self._sessions.clear()
         self._registered_handlers.clear()
         self._queues.clear()
@@ -385,7 +418,32 @@ class CopilotAgent:
             await self._cosmos_service.delete_all_session_mappings()
         logger.info("Config updated — all sessions reset")
 
-    def _build_session_config(self, enabled_tools: list, skill_dirs: list, system_prompt: str, mcp_servers: dict | None = None) -> dict:
+    def _build_provider_config(self) -> dict | None:
+        """Return the Azure provider dict for cloud mode, or ``None`` in local mode.
+
+        In local mode the Copilot SDK falls back to its default GitHub-hosted model
+        and authenticates via the ``GITHUB_TOKEN`` / ``COPILOT_GITHUB_TOKEN`` env var.
+
+        Returns:
+            A provider configuration dict suitable for ``CopilotClient`` sessions
+            when running against Azure OpenAI, or ``None`` when running in local
+            (GitHub-hosted) mode.
+        """
+        if self.settings.is_local_mode:
+            return None
+        return {
+            "type": "azure",
+            "base_url": f"{self.settings.foundry_endpoint.rstrip('/')}/openai/deployments/{self.settings.foundry_model_deployment}",  # noqa: E501
+            "token_provider": self._token_provider,
+            "wire_api": "completions",
+            "azure": {
+                "api_version": "2024-10-21",
+            },
+        }
+
+    def _build_session_config(
+        self, enabled_tools: list, skill_dirs: list, system_prompt: str, mcp_servers: dict | None = None
+    ) -> dict:
         """Build the shared session config dict used for both create and resume."""
         config = {
             "model": self.settings.foundry_model_deployment,
@@ -396,18 +454,12 @@ class CopilotAgent:
                 "mode": "replace",
                 "content": system_prompt,
             },
-            "provider": {
-                "type": "azure",
-                "base_url": f"{self.settings.foundry_endpoint.rstrip('/')}/openai/deployments/{self.settings.foundry_model_deployment}",
-                "token_provider": self._token_provider,
-                "wire_api": "completions",
-                "azure": {
-                    "api_version": "2024-10-21",
-                },
-            },
             "on_permission_request": lambda req, ctx: PermissionRequestResult(kind="approved"),
             "on_user_input_request": self._handle_user_input_request,
         }
+        provider = self._build_provider_config()
+        if provider is not None:
+            config["provider"] = provider
         if mcp_servers:
             config["mcp_servers"] = mcp_servers
         return config
@@ -429,17 +481,19 @@ class CopilotAgent:
         # Push the request event to the SSE queue
         q = self._queues.get(conversation_id)
         if q:
-            q.put_nowait(UserInputRequestEvent(
-                requestId=request_id,
-                question=request.get("question", ""),
-                choices=request.get("choices", []),
-                allowFreeform=request.get("allowFreeform", True),
-            ))
+            q.put_nowait(
+                UserInputRequestEvent(
+                    requestId=request_id,
+                    question=request.get("question", ""),
+                    choices=request.get("choices", []),
+                    allowFreeform=request.get("allowFreeform", True),
+                )
+            )
 
         # Wait for the user to respond (timeout 5 minutes)
         try:
             answer = await asyncio.wait_for(future, timeout=300.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             self._user_input_futures.pop(request_id, None)
             return {"answer": "No response provided", "wasFreeform": True}
         finally:
@@ -474,8 +528,10 @@ class CopilotAgent:
 
         logger.info(
             "Session config for conversation=%s: mcp_servers=%s skill_dirs=%d tools=%d",
-            conversation_id, list(mcp_servers.keys()) if mcp_servers else "none",
-            len(skill_dirs), len(enabled_tools),
+            conversation_id,
+            list(mcp_servers.keys()) if mcp_servers else "none",
+            len(skill_dirs),
+            len(enabled_tools),
         )
 
         system_prompt = self._get_system_prompt(conversation_id)
@@ -495,12 +551,16 @@ class CopilotAgent:
                 elapsed_ms = (time.monotonic() - t0) * 1000
                 logger.info(
                     "Resumed SDK session=%s for conversation=%s elapsed=%.0fms",
-                    sdk_session_id, conversation_id, elapsed_ms,
+                    sdk_session_id,
+                    conversation_id,
+                    elapsed_ms,
                 )
             except Exception:
                 logger.warning(
                     "Failed to resume SDK session=%s for conversation=%s — creating new",
-                    sdk_session_id, conversation_id, exc_info=True,
+                    sdk_session_id,
+                    conversation_id,
+                    exc_info=True,
                 )
                 session = None
 
@@ -511,9 +571,7 @@ class CopilotAgent:
 
             # Persist the new SDK session ID to Cosmos DB
             if self._cosmos_service and hasattr(session, "session_id"):
-                await self._cosmos_service.upsert_session_mapping(
-                    conversation_id, session.session_id
-                )
+                await self._cosmos_service.upsert_session_mapping(conversation_id, session.session_id)
 
             logger.info(
                 "Created SDK session=%s for conversation=%s model=%s custom_tools=%s elapsed=%.0fms",
@@ -534,27 +592,28 @@ class CopilotAgent:
     ) -> AsyncGenerator[ThoughtEvent | ToolCallEvent | ContentEvent | ErrorEvent | UserInputRequestEvent, None]:
         """Send a message and stream SDK events as typed SSE events."""
 
-        _content_recording = os.environ.get(
-            "AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED", ""
-        ).lower() == "true" or os.environ.get(
-            "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", ""
-        ).lower() == "true"
+        _content_recording = (
+            os.environ.get("AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED", "").lower() == "true"
+            or os.environ.get("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "").lower() == "true"
+        )
 
+        _local_mode = self.settings.is_local_mode
+        _invoke_span_attrs: dict = {
+            "gen_ai.operation.name": "invoke_agent",
+            "gen_ai.system": "github" if _local_mode else "openai",
+            "gen_ai.provider.name": "github" if _local_mode else "azure.ai.openai",
+            "gen_ai.request.model": self.settings.foundry_model_deployment,
+            "gen_ai.agent.id": "kratos-agent",
+            "gen_ai.agent.name": "kratos-agent",
+            "gen_ai.agents.id": "kratos-agent",
+            "gen_ai.agents.name": "kratos-agent",
+            "gen_ai.agent.version": "0.1.0",
+            "gen_ai.conversation.id": conversation_id,
+            "server.address": "api.githubcopilot.com" if _local_mode else self.settings.foundry_endpoint,
+        }
         with tracer.start_as_current_span(
             "invoke_agent kratos-agent",
-            attributes={
-                "gen_ai.operation.name": "invoke_agent",
-                "gen_ai.system": "openai",
-                "gen_ai.provider.name": "azure.ai.openai",
-                "gen_ai.request.model": self.settings.foundry_model_deployment,
-                "gen_ai.agent.id": "kratos-agent",
-                "gen_ai.agent.name": "kratos-agent",
-                "gen_ai.agents.id": "kratos-agent",
-                "gen_ai.agents.name": "kratos-agent",
-                "gen_ai.agent.version": "0.1.0",
-                "gen_ai.conversation.id": conversation_id,
-                "server.address": self.settings.foundry_endpoint,
-            },
+            attributes=_invoke_span_attrs,
         ) as span:
             queue: asyncio.Queue = asyncio.Queue()
             self._queues[conversation_id] = queue
@@ -629,8 +688,12 @@ class CopilotAgent:
                             elif etype in ("assistant.usage", "session.usage_info"):
                                 # Capture token usage from the model
                                 data = event.data
-                                prompt_t = int(getattr(data, "prompt_tokens", 0) or getattr(data, "input_tokens", 0) or 0)
-                                completion_t = int(getattr(data, "completion_tokens", 0) or getattr(data, "output_tokens", 0) or 0)
+                                prompt_t = int(
+                                    getattr(data, "prompt_tokens", 0) or getattr(data, "input_tokens", 0) or 0
+                                )
+                                completion_t = int(
+                                    getattr(data, "completion_tokens", 0) or getattr(data, "output_tokens", 0) or 0
+                                )
                                 total_t = int(getattr(data, "total_tokens", 0) or 0) or (prompt_t + completion_t)
 
                                 # Extract reasoning tokens from completion_tokens_details
@@ -648,30 +711,54 @@ class CopilotAgent:
                                 usage["total"] += total_t
                                 self._usage[cid] = usage
                                 logger.info(
-                                    "Usage conversation=%s prompt_tokens=%d completion_tokens=%d reasoning_tokens=%d total=%d",
-                                    cid, prompt_t, completion_t, reasoning_t, total_t,
+                                    "Usage conversation=%s prompt_tokens=%d completion_tokens=%d reasoning_tokens=%d total=%d",  # noqa: E501
+                                    cid,
+                                    prompt_t,
+                                    completion_t,
+                                    reasoning_t,
+                                    total_t,
                                 )
                                 if total_t > 0:
-                                    q.put_nowait(UsageEvent(
-                                        promptTokens=usage["prompt"],
-                                        completionTokens=usage["completion"],
-                                        reasoningTokens=usage["reasoning"],
-                                        totalTokens=usage["total"],
-                                    ))
+                                    q.put_nowait(
+                                        UsageEvent(
+                                            promptTokens=usage["prompt"],
+                                            completionTokens=usage["completion"],
+                                            reasoningTokens=usage["reasoning"],
+                                            totalTokens=usage["total"],
+                                        )
+                                    )
 
                             elif etype == "tool.execution_start":
-                                tool_name = getattr(event.data, "tool_name", None) or getattr(event.data, "name", None) or "unknown"
+                                tool_name = (
+                                    getattr(event.data, "tool_name", None)
+                                    or getattr(event.data, "name", None)
+                                    or "unknown"
+                                )
                                 # Resolve actual skill name for the generic "skill" meta-tool
                                 if tool_name == "skill":
                                     tool_name = _resolve_skill_display_name(event.data, fallback="skill")
-                                    logger.info("Resolved skill display name: %s (attrs=%s)", tool_name, {a: repr(getattr(event.data, a, None)) for a in dir(event.data) if not a.startswith('_')})
+                                    logger.info(
+                                        "Resolved skill display name: %s (attrs=%s)",
+                                        tool_name,
+                                        {
+                                            a: repr(getattr(event.data, a, None))
+                                            for a in dir(event.data)
+                                            if not a.startswith("_")
+                                        },
+                                    )
                                 self._tool_counters[cid] = self._tool_counters.get(cid, 0) + 1
                                 _pending_tools.append(tool_name)
-                                logger.info("Tool start conversation=%s tool=%s pending=%s", cid, tool_name, _pending_tools)
+                                logger.info(
+                                    "Tool start conversation=%s tool=%s pending=%s", cid, tool_name, _pending_tools
+                                )
 
                                 # Create a child span nested under the invoke_agent span
                                 raw_input_str = str(getattr(event.data, "input", "") or "")
-                                tool_call_id = getattr(event.data, "call_id", None) or getattr(event.data, "id", None) or str(uuid.uuid4())[:12]
+                                tool_call_id = (
+                                    getattr(event.data, "call_id", None)
+                                    or getattr(event.data, "id", None)
+                                    or str(uuid.uuid4())[:12]
+                                )
                                 parent_ctx = self._span_contexts.get(cid)
                                 tool_span = tracer.start_span(
                                     f"execute_tool {tool_name}",
@@ -688,7 +775,7 @@ class CopilotAgent:
                                 _tool_spans[tool_name] = tool_span
                                 _tool_span_stack.append((tool_name, tool_span))
                                 # Emit descriptive thought (not just "Calling tool: X")
-                                display = prettyToolName(tool_name)
+                                display = pretty_tool_name(tool_name)
                                 raw_input = getattr(event.data, "input", None)
                                 detail = ""
                                 if raw_input:
@@ -696,20 +783,26 @@ class CopilotAgent:
                                     # Try to extract a query or key param for context
                                     for key in ("query", "code", "prompt", "message", "text"):
                                         import re as _re
+
                                         m = _re.search(rf'["\']?{key}["\']?\s*[:=]\s*["\']([^"\']+)["\']', input_str)
                                         if m:
                                             snippet = m.group(1)[:80]
                                             detail = f": {snippet}{'…' if len(m.group(1)) > 80 else ''}"
                                             break
-                                q.put_nowait(ThoughtEvent(
-                                    content=f"{display}{detail}",
-                                    iteration=0,
-                                ))
-                                q.put_nowait(ToolCallEvent(
-                                    skillName=tool_name,
-                                    status="started",
-                                    input=_extract_tool_value(getattr(event.data, "input", "")),
-                                ))
+                                q.put_nowait(
+                                    ThoughtEvent(
+                                        content=f"{display}{detail}",
+                                        iteration=0,
+                                    )
+                                )
+                                q.put_nowait(
+                                    ToolCallEvent(
+                                        skillName=tool_name,
+                                        status="started",
+                                        input=_extract_tool_value(getattr(event.data, "input", "")),
+                                        source=self._resolve_skill_source(cid, tool_name),
+                                    )
+                                )
 
                             elif etype == "tool.execution_complete":
                                 # SDK often doesn't include tool_name on complete events,
@@ -730,12 +823,18 @@ class CopilotAgent:
                                     tool_name = _pending_tools.pop(0)
                                 else:
                                     tool_name = "unknown"
-                                duration_ms = int(getattr(event.data, "duration_ms", 0) or getattr(event.data, "duration", 0) or 0)
+                                duration_ms = int(
+                                    getattr(event.data, "duration_ms", 0) or getattr(event.data, "duration", 0) or 0
+                                )
                                 success = getattr(event.data, "success", None)
                                 error = getattr(event.data, "error", None)
                                 logger.info(
                                     "Tool complete conversation=%s tool=%s success=%r duration_ms=%s error=%r",
-                                    cid, tool_name, success, duration_ms, error,
+                                    cid,
+                                    tool_name,
+                                    success,
+                                    duration_ms,
+                                    error,
                                 )
 
                                 # End the corresponding tool span
@@ -746,10 +845,15 @@ class CopilotAgent:
                                 if tool_span is not None:
                                     # Remove from stack by identity
                                     _tool_span_stack[:] = [(n, s) for n, s in _tool_span_stack if s is not tool_span]
-                                    output_str = str(getattr(event.data, "output", "") or getattr(event.data, "result", ""))[:2000]
+                                    output_str = str(
+                                        getattr(event.data, "output", "") or getattr(event.data, "result", "")
+                                    )[:2000]
                                     tool_span.set_attribute("gen_ai.tool.call.result", output_str)
                                     if error:
-                                        tool_span.set_attribute("error.type", type(error).__name__ if not isinstance(error, str) else "tool_error")
+                                        tool_span.set_attribute(
+                                            "error.type",
+                                            type(error).__name__ if not isinstance(error, str) else "tool_error",
+                                        )
                                         tool_span.set_status(trace.StatusCode.ERROR, str(error))
                                     elif success is False:
                                         tool_span.set_attribute("error.type", "tool_execution_failed")
@@ -757,12 +861,17 @@ class CopilotAgent:
                                     else:
                                         tool_span.set_status(trace.StatusCode.OK)
                                     tool_span.end()
-                                q.put_nowait(ToolCallEvent(
-                                    skillName=tool_name,
-                                    status="completed" if success is not False else "failed",
-                                    output=_extract_tool_value(getattr(event.data, "output", "") or getattr(event.data, "result", ""))[:2000],
-                                    durationMs=duration_ms,
-                                ))
+                                q.put_nowait(
+                                    ToolCallEvent(
+                                        skillName=tool_name,
+                                        status="completed" if success is not False else "failed",
+                                        output=_extract_tool_value(
+                                            getattr(event.data, "output", "") or getattr(event.data, "result", "")
+                                        )[:2000],
+                                        durationMs=duration_ms,
+                                        source=self._resolve_skill_source(cid, tool_name),
+                                    )
+                                )
 
                             elif etype == "session.idle":
                                 # End any orphaned tool spans
@@ -778,8 +887,12 @@ class CopilotAgent:
                                 model_start = self._model_response_start.get(cid)
                                 model_latency = int((time.monotonic() - model_start) * 1000) if model_start else 0
                                 logger.info(
-                                    "Session idle conversation=%s tool_events=%s tokens=%s ttft=%dms model_latency=%dms",
-                                    cid, tc, usage, ttft, model_latency,
+                                    "Session idle conversation=%s tool_events=%s tokens=%s ttft=%dms model_latency=%dms",  # noqa: E501
+                                    cid,
+                                    tc,
+                                    usage,
+                                    ttft,
+                                    model_latency,
                                 )
                                 q.put_nowait(None)  # sentinel — stream is done
 
@@ -796,18 +909,27 @@ class CopilotAgent:
                                     cid,
                                     str(getattr(event.data, "message", "Unknown error")),
                                 )
-                                q.put_nowait(ErrorEvent(
-                                    message=str(getattr(event.data, "message", "Unknown error")),
-                                    code="SDK_ERROR",
-                                ))
+                                q.put_nowait(
+                                    ErrorEvent(
+                                        message=str(getattr(event.data, "message", "Unknown error")),
+                                        code="SDK_ERROR",
+                                    )
+                                )
                                 q.put_nowait(None)
 
                             else:
                                 # Log unhandled events so we can discover new event types
                                 logger.info(
                                     "Unhandled SDK event type=%s conversation=%s data_attrs=%s",
-                                    etype, cid,
-                                    {a: repr(getattr(event.data, a, None))[:100] for a in dir(event.data) if not a.startswith('_')} if event.data else "no_data",
+                                    etype,
+                                    cid,
+                                    {
+                                        a: repr(getattr(event.data, a, None))[:100]
+                                        for a in dir(event.data)
+                                        if not a.startswith("_")
+                                    }
+                                    if event.data
+                                    else "no_data",
                                 )
                         except Exception:
                             logger.exception("Error in session event handler conversation=%s", cid)
@@ -858,7 +980,15 @@ class CopilotAgent:
                     full_response = "".join(self._response_parts.get(conversation_id, []))
                     span.set_attribute(
                         "gen_ai.output.messages",
-                        json.dumps([{"role": "assistant", "parts": [{"type": "text", "content": full_response[:4000]}], "finish_reason": "stop"}]),
+                        json.dumps(
+                            [
+                                {
+                                    "role": "assistant",
+                                    "parts": [{"type": "text", "content": full_response[:4000]}],
+                                    "finish_reason": "stop",
+                                }
+                            ]
+                        ),
                     )
                 if tool_events == 0:
                     logger.warning(
@@ -870,9 +1000,9 @@ class CopilotAgent:
                 # Record GenAI metrics (token usage + operation duration)
                 _metric_attrs = {
                     "gen_ai.operation.name": "invoke_agent",
-                    "gen_ai.provider.name": "azure.ai.openai",
+                    "gen_ai.provider.name": "github" if _local_mode else "azure.ai.openai",
                     "gen_ai.request.model": self.settings.foundry_model_deployment,
-                    "server.address": self.settings.foundry_endpoint,
+                    "server.address": "api.githubcopilot.com" if _local_mode else self.settings.foundry_endpoint,
                 }
                 if usage.get("prompt", 0):
                     token_usage_histogram.record(usage["prompt"], {**_metric_attrs, "gen_ai.token.type": "input"})
@@ -881,7 +1011,7 @@ class CopilotAgent:
                 elapsed_s = time.monotonic() - self._send_time
                 operation_duration_histogram.record(elapsed_s, _metric_attrs)
 
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 span.set_attribute("error.type", "timeout")
                 span.set_status(trace.StatusCode.ERROR, "Agent timed out")
                 logger.warning("Agent timed out for conversation=%s", conversation_id)

--- a/src/backend/app/services/cosmos_service.py
+++ b/src/backend/app/services/cosmos_service.py
@@ -1,13 +1,21 @@
 """Cosmos DB service for conversation, message, and skill persistence.
 
-Uses Azure Managed Identity for passwordless authentication.
+Uses Azure Managed Identity for passwordless authentication when a Cosmos DB
+endpoint is configured. When no endpoint is configured (``is_local_mode``),
+persistence falls back to a local SQLite database so the full backend is
+usable for development without any Azure dependency.
+
 Partition keys: conversations -> /userId, messages -> /conversationId, skills -> /name
 """
 
+import contextlib
+import json
 import logging
 import time
+from pathlib import Path
 from typing import Any
 
+import aiosqlite
 from azure.cosmos.aio import CosmosClient
 from azure.cosmos.exceptions import CosmosHttpResponseError
 from azure.identity.aio import DefaultAzureCredential
@@ -22,7 +30,12 @@ _SLOW_OPERATION_THRESHOLD_MS = 500
 
 
 class CosmosService:
-    """Manages conversation, message, and skill persistence in Azure Cosmos DB."""
+    """Manages conversation, message, and skill persistence.
+
+    Backed by Azure Cosmos DB in production, or a local SQLite database when
+    ``settings.cosmos_db_endpoint`` is empty. The public API is identical
+    between the two backends.
+    """
 
     def __init__(self, settings: Settings) -> None:
         self.settings = settings
@@ -31,11 +44,22 @@ class CosmosService:
         self._messages_container: Any = None
         self._settings_container: Any = None
         self._sessions_container: Any = None
+        self._sqlite_db: aiosqlite.Connection | None = None
+
+    def _using_sqlite(self) -> bool:
+        """Return True when the SQLite backend is active."""
+        return self._sqlite_db is not None
 
     async def initialize(self) -> None:
-        """Initialize Cosmos DB client and containers."""
+        """Initialize the configured backend.
+
+        If ``settings.cosmos_db_endpoint`` is set, initialises an Azure Cosmos
+        DB client with managed identity. Otherwise, opens a local SQLite
+        database at ``{local_data_dir}/kratos.db`` and creates the schema on
+        first run.
+        """
         if not self.settings.cosmos_db_endpoint:
-            logger.warning("Cosmos DB endpoint not configured -- persistence disabled")
+            await self._sqlite_initialize()
             return
 
         credential = DefaultAzureCredential()
@@ -63,7 +87,107 @@ class CosmosService:
 
         logger.info("Cosmos DB initialized -- database=%s", self.settings.cosmos_db_database)
 
+    async def close(self) -> None:
+        """Release backend resources (currently: the SQLite connection)."""
+        if self._sqlite_db is not None:
+            try:
+                await self._sqlite_db.close()
+            finally:
+                self._sqlite_db = None
+
+    # ─── SQLite backend ───────────────────────────────────────────────────────
+
+    _SQLITE_TABLES = ("conversations", "messages", "settings", "session_mappings")
+
+    async def _sqlite_initialize(self) -> None:
+        """Open the local SQLite database and create the schema if missing."""
+        data_dir = Path(self.settings.local_data_dir)
+        data_dir.mkdir(parents=True, exist_ok=True)
+        db_path = data_dir / "kratos.db"
+
+        db = await aiosqlite.connect(str(db_path), isolation_level=None)
+        await db.execute("PRAGMA journal_mode=WAL")
+        await db.execute("PRAGMA foreign_keys=ON")
+
+        for table in self._SQLITE_TABLES:
+            await db.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {table} (
+                    id TEXT NOT NULL,
+                    partition_key TEXT NOT NULL,
+                    data TEXT NOT NULL,
+                    PRIMARY KEY (id, partition_key)
+                )
+                """
+            )
+        await db.execute("CREATE INDEX IF NOT EXISTS idx_conversations_pk ON conversations(partition_key)")
+        await db.execute("CREATE INDEX IF NOT EXISTS idx_messages_pk ON messages(partition_key, data)")
+        await db.commit()
+
+        self._sqlite_db = db
+        logger.info("Cosmos local (SQLite) backend at %s", db_path)
+
+    async def _sqlite_upsert(self, table: str, item_id: str, partition_key: str, doc: dict[str, Any]) -> None:
+        """Insert or replace a JSON document in ``table``."""
+        assert self._sqlite_db is not None
+        await self._sqlite_db.execute(
+            f"INSERT OR REPLACE INTO {table} (id, partition_key, data) VALUES (?, ?, ?)",  # noqa: S608
+            (item_id, partition_key, json.dumps(doc)),
+        )
+        await self._sqlite_db.commit()
+
+    async def _sqlite_read(self, table: str, item_id: str, partition_key: str) -> dict[str, Any] | None:
+        """Read a single JSON document by ``(id, partition_key)``."""
+        assert self._sqlite_db is not None
+        cursor = await self._sqlite_db.execute(
+            f"SELECT data FROM {table} WHERE id = ? AND partition_key = ?",  # noqa: S608
+            (item_id, partition_key),
+        )
+        row = await cursor.fetchone()
+        await cursor.close()
+        return json.loads(row[0]) if row else None
+
+    async def _sqlite_query_by_partition(self, table: str, partition_key: str) -> list[dict[str, Any]]:
+        """Return every JSON document in ``table`` with the given partition key."""
+        assert self._sqlite_db is not None
+        cursor = await self._sqlite_db.execute(
+            f"SELECT data FROM {table} WHERE partition_key = ?",  # noqa: S608
+            (partition_key,),
+        )
+        rows = await cursor.fetchall()
+        await cursor.close()
+        return [json.loads(r[0]) for r in rows]
+
+    async def _sqlite_query_all(self, table: str) -> list[dict[str, Any]]:
+        """Return every JSON document in ``table`` regardless of partition."""
+        assert self._sqlite_db is not None
+        cursor = await self._sqlite_db.execute(f"SELECT data FROM {table}")  # noqa: S608
+        rows = await cursor.fetchall()
+        await cursor.close()
+        return [json.loads(r[0]) for r in rows]
+
+    async def _sqlite_delete(self, table: str, item_id: str, partition_key: str) -> None:
+        """Delete a document from ``table`` by ``(id, partition_key)``."""
+        assert self._sqlite_db is not None
+        await self._sqlite_db.execute(
+            f"DELETE FROM {table} WHERE id = ? AND partition_key = ?",  # noqa: S608
+            (item_id, partition_key),
+        )
+        await self._sqlite_db.commit()
+
+    async def _sqlite_truncate(self, table: str) -> None:
+        """Delete all rows from ``table``."""
+        assert self._sqlite_db is not None
+        await self._sqlite_db.execute(f"DELETE FROM {table}")  # noqa: S608
+        await self._sqlite_db.commit()
+
+    # ─── Conversations ────────────────────────────────────────────────────────
+
     async def upsert_conversation(self, conversation: Conversation) -> None:
+        if self._using_sqlite():
+            doc = conversation.model_dump(mode="json")
+            await self._sqlite_upsert("conversations", conversation.id, conversation.userId, doc)
+            return
         if not self._conversations_container:
             return
         start = time.monotonic()
@@ -78,34 +202,45 @@ class CosmosService:
                 logger.warning("Slow Cosmos operation: upsert_conversation took %.0f ms", elapsed_ms)
 
     async def get_conversation(self, conversation_id: str, user_id: str) -> Conversation | None:
+        if self._using_sqlite():
+            row = await self._sqlite_read("conversations", conversation_id, user_id)
+            return Conversation(**row) if row else None
         if not self._conversations_container:
             return None
         try:
-            item = await self._conversations_container.read_item(
-                item=conversation_id, partition_key=user_id
-            )
+            item = await self._conversations_container.read_item(item=conversation_id, partition_key=user_id)
             return Conversation(**item)
         except Exception:
             return None
 
     async def list_conversations(self, user_id: str) -> list[Conversation]:
+        if self._using_sqlite():
+            rows = await self._sqlite_query_by_partition("conversations", user_id)
+            conversations = [Conversation(**r) for r in rows]
+            conversations.sort(key=lambda c: c.updatedAt, reverse=True)
+            return conversations
         if not self._conversations_container:
             return []
         query = "SELECT * FROM c WHERE c.userId = @userId ORDER BY c.updatedAt DESC"
         params: list[dict[str, str]] = [{"name": "@userId", "value": user_id}]
-        items = self._conversations_container.query_items(
-            query=query, parameters=params, partition_key=user_id
-        )
+        items = self._conversations_container.query_items(query=query, parameters=params, partition_key=user_id)
         return [Conversation(**item) async for item in items]
 
     async def delete_conversation(self, conversation_id: str, user_id: str) -> None:
+        if self._using_sqlite():
+            await self._sqlite_delete("conversations", conversation_id, user_id)
+            return
         if not self._conversations_container:
             return
-        await self._conversations_container.delete_item(
-            item=conversation_id, partition_key=user_id
-        )
+        await self._conversations_container.delete_item(item=conversation_id, partition_key=user_id)
+
+    # ─── Messages ─────────────────────────────────────────────────────────────
 
     async def upsert_message(self, message: Message) -> None:
+        if self._using_sqlite():
+            doc = message.model_dump(mode="json")
+            await self._sqlite_upsert("messages", message.id, message.conversationId, doc)
+            return
         if not self._messages_container:
             return
         start = time.monotonic()
@@ -120,6 +255,11 @@ class CosmosService:
                 logger.warning("Slow Cosmos operation: upsert_message took %.0f ms", elapsed_ms)
 
     async def list_messages(self, conversation_id: str) -> list[Message]:
+        if self._using_sqlite():
+            rows = await self._sqlite_query_by_partition("messages", conversation_id)
+            messages = [Message(**r) for r in rows]
+            messages.sort(key=lambda m: m.createdAt)
+            return messages
         if not self._messages_container:
             return []
         start = time.monotonic()
@@ -138,17 +278,21 @@ class CosmosService:
 
     async def get_setting(self, setting_id: str) -> dict | None:
         """Read a setting by id. Partition key is /category."""
+        if self._using_sqlite():
+            return await self._sqlite_read("settings", setting_id, "system")
         if not self._settings_container:
             return None
         try:
-            return await self._settings_container.read_item(
-                item=setting_id, partition_key="system"
-            )
+            return await self._settings_container.read_item(item=setting_id, partition_key="system")
         except Exception:
             return None
 
     async def upsert_setting(self, setting: dict) -> dict:
         """Create or update a setting document."""
+        if self._using_sqlite():
+            setting_id = setting["id"]
+            await self._sqlite_upsert("settings", setting_id, "system", setting)
+            return setting
         if not self._settings_container:
             return setting
         await self._settings_container.upsert_item(setting)
@@ -156,53 +300,58 @@ class CosmosService:
 
     async def delete_setting(self, setting_id: str) -> None:
         """Delete a setting document by id."""
+        if self._using_sqlite():
+            await self._sqlite_delete("settings", setting_id, "system")
+            return
         if not self._settings_container:
             return
-        try:
-            await self._settings_container.delete_item(
-                item=setting_id, partition_key="system"
-            )
-        except Exception:
-            pass
+        with contextlib.suppress(Exception):
+            await self._settings_container.delete_item(item=setting_id, partition_key="system")
 
     # ─── Sessions (SDK session ID mapping) ────────────────────────────────────
 
     async def upsert_session_mapping(self, conversation_id: str, sdk_session_id: str) -> None:
         """Store the SDK session ID for a conversation."""
-        if not self._sessions_container:
-            return
         doc = {
             "id": conversation_id,
             "conversationId": conversation_id,
             "sdkSessionId": sdk_session_id,
         }
+        if self._using_sqlite():
+            await self._sqlite_upsert("session_mappings", conversation_id, conversation_id, doc)
+            return
+        if not self._sessions_container:
+            return
         await self._sessions_container.upsert_item(doc)
 
     async def get_session_mapping(self, conversation_id: str) -> str | None:
         """Return the SDK session ID for a conversation, or None."""
+        if self._using_sqlite():
+            row = await self._sqlite_read("session_mappings", conversation_id, conversation_id)
+            return row.get("sdkSessionId") if row else None
         if not self._sessions_container:
             return None
         try:
-            item = await self._sessions_container.read_item(
-                item=conversation_id, partition_key=conversation_id
-            )
+            item = await self._sessions_container.read_item(item=conversation_id, partition_key=conversation_id)
             return item.get("sdkSessionId")
         except Exception:
             return None
 
     async def delete_session_mapping(self, conversation_id: str) -> None:
         """Delete the session mapping for a conversation."""
+        if self._using_sqlite():
+            await self._sqlite_delete("session_mappings", conversation_id, conversation_id)
+            return
         if not self._sessions_container:
             return
-        try:
-            await self._sessions_container.delete_item(
-                item=conversation_id, partition_key=conversation_id
-            )
-        except Exception:
-            pass
+        with contextlib.suppress(Exception):
+            await self._sessions_container.delete_item(item=conversation_id, partition_key=conversation_id)
 
     async def delete_all_session_mappings(self) -> None:
         """Delete all stored SDK session mappings (called on prompt/config resets)."""
+        if self._using_sqlite():
+            await self._sqlite_truncate("session_mappings")
+            return
         if not self._sessions_container:
             return
         try:
@@ -211,11 +360,7 @@ class CosmosService:
                 enable_cross_partition_query=True,
             )
             async for item in items:
-                try:
-                    await self._sessions_container.delete_item(
-                        item=item["id"], partition_key=item["conversationId"]
-                    )
-                except Exception:
-                    pass
+                with contextlib.suppress(Exception):
+                    await self._sessions_container.delete_item(item=item["id"], partition_key=item["conversationId"])
         except Exception:
             logger.warning("Failed to purge all session mappings from Cosmos", exc_info=True)


### PR DESCRIPTION
See https://github.com/charendt/kratos-agent/pull/1 for full description (reposting here against upstream).

**Stacked with follow-up APM PR.**

Adds a local/dev mode that swaps every Azure dependency for a local equivalent — GitHub Copilot token (vs Foundry), SQLite (vs Cosmos DB), Azurite (vs Blob Storage). Auto-detected when COSMOS_DB_ENDPOINT is empty or LOCAL_MODE=true. No change to the prod path when Azure env vars are set.

Try it: cp .env.local.example .env.local, set COPILOT_GITHUB_TOKEN, then ./run-local.ps1 (or .sh).