### PR TITLE
fix: make ./run-local.sh actually boot the full stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ use-cases/*/.github/skills/
 use-cases/*/.github/prompts/
 use-cases/*/.github/instructions/
 use-cases/*/.github/agents/
+use-cases/*/.agents/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,29 @@ services:
       retries: 10
       start_period: 5s
 
+  hosted-agent:
+    build:
+      context: .
+      dockerfile: src/hosted-agent/Dockerfile
+    ports:
+      - "8088:8088"
+    environment:
+      LOCAL_MODE: "true"
+      COPILOT_GITHUB_TOKEN: ${COPILOT_GITHUB_TOKEN}
+      GITHUB_TOKEN: ${COPILOT_GITHUB_TOKEN}
+      BLOB_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
+      BLOB_SKILLS_CONTAINER: skills
+      LOCAL_DATA_DIR: /data
+      APM_USE_CASES_ROOT: /app/use-cases
+      ENVIRONMENT: development
+      APM_ENABLED: "true"
+    volumes:
+      - ./.local/hosted-agent:/data
+      - ./use-cases:/app/use-cases
+    depends_on:
+      azurite:
+        condition: service_healthy
+
   backend:
     build:
       context: .
@@ -22,6 +45,7 @@ services:
     environment:
       LOCAL_MODE: "true"
       COPILOT_GITHUB_TOKEN: ${COPILOT_GITHUB_TOKEN}
+      FOUNDRY_AGENT_INVOCATIONS_ENDPOINT: "http://hosted-agent:8088/invocations"
       BLOB_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
       BLOB_SKILLS_CONTAINER: skills
       LOCAL_DATA_DIR: /data
@@ -33,3 +57,5 @@ services:
     depends_on:
       azurite:
         condition: service_healthy
+      hosted-agent:
+        condition: service_started

--- a/src/backend/app/services/foundry_agent_proxy.py
+++ b/src/backend/app/services/foundry_agent_proxy.py
@@ -35,9 +35,16 @@ class FoundryAgentProxy:
                 f"/endpoint/protocols/invocations?api-version={api_version}"
             )
 
-        self._credential = DefaultAzureCredential()
+        # In local mode the hosted agent is an unauthenticated localhost stub;
+        # skip the Azure credential entirely (container has no `az` CLI / MSI).
+        self._local_mode = settings.is_local_mode
+        self._credential = None if self._local_mode else DefaultAzureCredential()
         self._http_session: aiohttp.ClientSession | None = None
-        logger.info("FoundryAgentProxy endpoint: %s", self._endpoint)
+        logger.info(
+            "FoundryAgentProxy endpoint: %s (local_mode=%s)",
+            self._endpoint,
+            self._local_mode,
+        )
 
     async def start(self) -> None:
         self._http_session = aiohttp.ClientSession()
@@ -45,9 +52,12 @@ class FoundryAgentProxy:
     async def stop(self) -> None:
         if self._http_session:
             await self._http_session.close()
-        await self._credential.close()
+        if self._credential is not None:
+            await self._credential.close()
 
-    async def _get_token(self) -> str:
+    async def _get_token(self) -> str | None:
+        if self._credential is None:
+            return None
         token = await self._credential.get_token(_AI_SCOPE)
         return token.token
 
@@ -87,11 +97,12 @@ class FoundryAgentProxy:
 
         token = await self._get_token()
         headers = {
-            "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
             "Accept": "text/event-stream",
             "Foundry-Features": "HostedAgents=V1Preview",
         }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
         payload = {
             "input": input_text,
             "conversationId": conversation_id,


### PR DESCRIPTION
# fix: make `./run-local.sh` actually boot the full stack

## Problem

The shipped `docker-compose.yml` declares only `azurite` and `backend`, but
the backend has a hard precondition at [`src/backend/app/main.py:83`](src/backend/app/main.py#L83):

```python
if not settings.foundry_agent_invocations_endpoint and not settings.foundry_project_endpoint:
    raise RuntimeError(
        "Missing required configuration: set FOUNDRY_AGENT_INVOCATIONS_ENDPOINT "
        "or FOUNDRY_PROJECT_ENDPOINT + FOUNDRY_AGENT_NAME"
    )
```

So out of the box, `./run-local.sh` builds successfully, starts azurite +
backend, then the backend exits with code 3 before serving a single request:

```
backend-1  | RuntimeError: Missing required configuration: set FOUNDRY_AGENT_INVOCATIONS_ENDPOINT or FOUNDRY_PROJECT_ENDPOINT + FOUNDRY_AGENT_NAME
backend-1  | ERROR:    Application startup failed. Exiting.
backend-1 exited with code 3
```

The README's "Full Local Mode (No Azure Required)" section implies this
just works. It doesn't — until you deploy to Foundry there is nothing for
the backend to proxy to.

## Fix (3 small changes)

1. **Add the missing `hosted-agent` service to `docker-compose.yml`.**
   Same `src/hosted-agent/Dockerfile` we already ship to production, run
   with `LOCAL_MODE=true` + `COPILOT_GITHUB_TOKEN` so the embedded
   `CopilotClient` authenticates via GitHub, plus the Azurite connection
   string so it loads use-cases from the same emulator the backend uses.

2. **Wire the backend at it** via
   `FOUNDRY_AGENT_INVOCATIONS_ENDPOINT=http://hosted-agent:8088/invocations`.
   Path discovered by inspecting `azure-ai-agentserver-invocations` —
   `InvocationAgentServerHost` registers `POST /invocations` as the
   protocol entry point.

3. **Bypass `DefaultAzureCredential` in `FoundryAgentProxy` when
   `LOCAL_MODE` is true.** Inside the backend container the credential
   chain has no usable source (no `az` CLI, no MSI), so it would block
   indefinitely or fail. The local hosted-agent stub doesn't validate the
   bearer token anyway, so both `_get_token()` and the `Authorization`
   header become no-ops in local mode.

Also extends `.gitignore` to cover `use-cases/*/.agents/` — the new APM CLI
(`apm-cli >= 0.14`) materialises skills there instead of `.github/skills/`,
which the existing pattern already ignored.

## How to test

```bash
cp .env.local.example .env.local
# Set COPILOT_GITHUB_TOKEN=$(gh auth token)  — requires Copilot access
./run-local.sh

# In another shell:
curl -s http://localhost:8000/health
curl -s http://localhost:8000/api/use-cases | jq '.useCases[].name'

CONV=$(uuidgen)
curl -s -X POST http://localhost:8000/api/conversations \
  -H 'Content-Type: application/json' \
  -d "{\"id\":\"$CONV\",\"userId\":\"demo\",\"title\":\"smoke\",\"useCase\":\"generic\"}"

curl -s -N -X POST http://localhost:8000/api/agent/chat \
  -H 'Content-Type: application/json' \
  -d "{\"conversationId\":\"$CONV\",\"message\":\"hello\",\"useCase\":\"generic\"}"
```

Expected: backend stays up, `/api/use-cases` returns the 4 shipped personas,
chat stream emits `thought`, `content`, `usage`, `done` events.

## Files

- [`docker-compose.yml`](docker-compose.yml) — `hosted-agent` service + wiring
- [`src/backend/app/services/foundry_agent_proxy.py`](src/backend/app/services/foundry_agent_proxy.py) — local-mode auth bypass
- [`.gitignore`](.gitignore) — cover `use-cases/*/.agents/`

## Out of scope

- The frontend dev server is not part of compose (current README says run
  `npm run dev` in `src/frontend/` separately — unchanged here).
- The `/api/agent/user-input` endpoint still returns 501 — wire-up for
  the multi-turn `ask_user` flow is a follow-up.

## Risk

- Production deploys via `azd up` are unaffected — `FOUNDRY_AGENT_INVOCATIONS_ENDPOINT`
  is only set in the new compose service; production reads
  `FOUNDRY_PROJECT_ENDPOINT` via Bicep as before.
- The credential bypass is strictly gated on `settings.is_local_mode`,
  which auto-detects to `False` whenever `COSMOS_DB_ENDPOINT` is set
  (i.e. in prod), so the hosted-agent path is unchanged in cloud.
