### PR TITLE
feat(evals+traces): per-use-case eval runs + OTel trace panel + UX overhaul

### DIFF
--- a/.copilot/skills/e2e-smoke/.gitignore
+++ b/.copilot/skills/e2e-smoke/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+playwright-report/
+test-results/
+.playwright/
+*.log

--- a/.copilot/skills/e2e-smoke/SKILL.md
+++ b/.copilot/skills/e2e-smoke/SKILL.md
@@ -30,6 +30,7 @@ load per use-case, chat round-trips, evals API, and traces API.
 | `04-evals.spec.ts` | `/api/use-cases/{uc}/evals/runs` | At least one completed validation run exists; per-run detail returns scenarios array |
 | `05-traces.spec.ts` | `/api/traces/operations` | ≥1 operation in lookback window; per-operation detail returns spans |
 | `06-ui.spec.ts` | browser | Frontend loads, use-case picker is interactive, EvalsAdminPanel + TracesAdminPanel tabs render without JS errors |
+| `07-regression.spec.ts` | pre-existing core | `/api/use-cases` schema + all 5 use-cases present, `/api/settings` Foundry config, conversation CRUD round-trip, `/api/admin/skills` catalogue + detail, `/api/admin/system-prompt` content. Guards against regressions in surfaces the evals/tracing branch did NOT touch |
 
 ## Inputs (env vars)
 

--- a/.copilot/skills/e2e-smoke/SKILL.md
+++ b/.copilot/skills/e2e-smoke/SKILL.md
@@ -29,8 +29,9 @@ load per use-case, chat round-trips, evals API, and traces API.
 | `03-chat.spec.ts` | `/api/agent/chat` SSE | Sends a tiny prompt, asserts a non-empty assistant response inside `CHAT_TIMEOUT_MS` |
 | `04-evals.spec.ts` | `/api/use-cases/{uc}/evals/runs` | At least one completed validation run exists; per-run detail returns scenarios array |
 | `05-traces.spec.ts` | `/api/traces/operations` | ≥1 operation in lookback window; per-operation detail returns spans |
-| `06-ui.spec.ts` | browser | Frontend loads, use-case picker is interactive, EvalsAdminPanel + TracesAdminPanel tabs render without JS errors |
+| `06-ui.spec.ts` | browser | Frontend loads without console errors (smoke gate) |
 | `07-regression.spec.ts` | pre-existing core | `/api/use-cases` schema + all 5 use-cases present, `/api/settings` Foundry config, conversation CRUD round-trip, `/api/admin/skills` catalogue + detail, `/api/admin/system-prompt` content. Guards against regressions in surfaces the evals/tracing branch did NOT touch |
+| `08-ux.spec.ts` | browser, interactive | **The UX itself.** Persona selector lists all 5 use-cases & switches value; landing textarea + Send button starts a chat and the assistant responds; Skills admin opens; every admin tab (Skills / System Prompt / APM / Evals / Traces) renders its header; "Generate Scenarios" modal opens + closes; Traces "Refresh" renders ops/summary/empty-state |
 
 ## Inputs (env vars)
 

--- a/.copilot/skills/e2e-smoke/SKILL.md
+++ b/.copilot/skills/e2e-smoke/SKILL.md
@@ -1,0 +1,80 @@
+# e2e-smoke — Playwright-driven live smoke tests for kratos-agent
+
+A repo-local Playwright skill that exercises a deployed kratos-agent
+environment end-to-end: frontend renders, backend /health, scenarios
+load per use-case, chat round-trips, evals API, and traces API.
+
+## When to use
+
+- After every `azd deploy backend` / `azd deploy hosted-agent` / `azd deploy web`
+  to confirm the deployment is healthy from a real client.
+- Before opening a PR that touches `src/backend`, `src/frontend`, `src/hosted-agent`,
+  or the eval / traces surface.
+- After granting / changing Foundry RBAC, to confirm the hosted agent and the
+  agent-service can still talk to the model.
+- In CI as the post-deploy gate (recommended).
+
+## When NOT to use
+
+- Local-only frontend dev work — `next dev` + targeted manual click is faster.
+- Pure backend unit changes — prefer `uv run pytest` in `src/backend`.
+- Static type / lint checks — those have their own runners.
+
+## What it tests
+
+| Spec | Surface | Asserts |
+|------|---------|---------|
+| `01-health.spec.ts` | API + SWA | `/health` 200, frontend HTML serves, runtime `config.json` points at expected backend |
+| `02-scenarios.spec.ts` | `/api/use-cases/{uc}/evals/scenarios` | Every use-case returns ≥1 scenario; required shape (`name`, `prompt`, `expected_signal_keywords`) |
+| `03-chat.spec.ts` | `/api/agent/chat` SSE | Sends a tiny prompt, asserts a non-empty assistant response inside `CHAT_TIMEOUT_MS` |
+| `04-evals.spec.ts` | `/api/use-cases/{uc}/evals/runs` | At least one completed validation run exists; per-run detail returns scenarios array |
+| `05-traces.spec.ts` | `/api/traces/operations` | ≥1 operation in lookback window; per-operation detail returns spans |
+| `06-ui.spec.ts` | browser | Frontend loads, use-case picker is interactive, EvalsAdminPanel + TracesAdminPanel tabs render without JS errors |
+
+## Inputs (env vars)
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `KRATOS_FRONTEND_URL` | `https://mango-bay-04ed10b03.7.azurestaticapps.net` | SWA URL |
+| `KRATOS_BACKEND_URL` | `https://ca-agent-jep3w6qugjoda.blacktree-6e513e92.swedencentral.azurecontainerapps.io` | Container Apps URL |
+| `KRATOS_USE_CASES` | `generic,insurance,retail-banking,wealth-management,sales-account-review` | Comma-separated |
+| `CHAT_TIMEOUT_MS` | `60000` | Chat round-trip ceiling |
+| `TRACES_LOOKBACK_HOURS` | `6` | App Insights query window |
+| `SKIP_BROWSER` | unset | Set to `1` to skip browser tests (CI / no-chromium hosts) |
+
+The defaults match the **fruocco-2** deployment used by the current pilot;
+point `KRATOS_*_URL` at a different env to retarget.
+
+## Run it
+
+```bash
+cd .copilot/skills/e2e-smoke
+./run.sh                                  # install (first run) + run all specs
+./run.sh --grep "chat"                    # filter
+KRATOS_BACKEND_URL=... ./run.sh           # different env
+SKIP_BROWSER=1 ./run.sh                   # API-only mode
+```
+
+The wrapper installs `npm` deps + Chromium on first run only (cached in
+`node_modules/` + the playwright user dir). Results land in
+`playwright-report/` and `test-results/` — both gitignored.
+
+## Conventions
+
+- TypeScript Playwright with `@playwright/test`.
+- One spec = one concern; specs are independent (no shared fixture state) so
+  Playwright's `fullyParallel: true` works.
+- Assertions are content-aware: `/health` checks the actual JSON shape, not
+  just status code. Chat assertion requires non-empty body, not just 200.
+- Browser tests are gated on `SKIP_BROWSER` for CI on hosts without Chromium.
+- Auth is assumed off (`admin_auth_enabled=false` on the deployment); add
+  Easy Auth bearer logic here when that changes.
+
+## Known limitations
+
+- Foundry agent cold-start can spike `/api/agent/chat` above 60s on the
+  very first call after 15 min idle. The spec already retries once with
+  a 30 s warmup ping; bump `CHAT_TIMEOUT_MS` if your environment is colder.
+- Traces lookback default is 2h to match the typical pilot session; the
+  test gracefully skips assertions if zero operations exist in that
+  window (so it doesn't false-fail before any real chat has happened).

--- a/.copilot/skills/e2e-smoke/package-lock.json
+++ b/.copilot/skills/e2e-smoke/package-lock.json
@@ -1,0 +1,111 @@
+{
+  "name": "kratos-e2e-smoke",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kratos-e2e-smoke",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@playwright/test": "^1.48.0",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/.copilot/skills/e2e-smoke/package.json
+++ b/.copilot/skills/e2e-smoke/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "kratos-e2e-smoke",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Playwright e2e smoke tests for kratos-agent (frontend + API + chat + evals + traces)",
+  "type": "module",
+  "scripts": {
+    "install:browsers": "playwright install chromium",
+    "test": "playwright test",
+    "test:api": "SKIP_BROWSER=1 playwright test",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/.copilot/skills/e2e-smoke/playwright.config.ts
+++ b/.copilot/skills/e2e-smoke/playwright.config.ts
@@ -21,12 +21,12 @@ export default defineConfig({
     video: "retain-on-failure",
   },
   projects: SKIP_BROWSER
-    ? [{ name: "api-only", testIgnore: /06-ui\.spec\.ts$/ }]
+    ? [{ name: "api-only", testIgnore: /(06-ui|08-ux)\.spec\.ts$/ }]
     : [
-        { name: "api-only", testIgnore: /06-ui\.spec\.ts$/ },
+        { name: "api-only", testIgnore: /(06-ui|08-ux)\.spec\.ts$/ },
         {
           name: "browser",
-          testMatch: /06-ui\.spec\.ts$/,
+          testMatch: /(06-ui|08-ux)\.spec\.ts$/,
           use: { ...devices["Desktop Chrome"] },
         },
       ],

--- a/.copilot/skills/e2e-smoke/playwright.config.ts
+++ b/.copilot/skills/e2e-smoke/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const SKIP_BROWSER = process.env.SKIP_BROWSER === "1";
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [
+    ["list"],
+    ["html", { open: "never", outputFolder: "playwright-report" }],
+    ["json", { outputFile: "test-results/results.json" }],
+  ],
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: SKIP_BROWSER
+    ? [{ name: "api-only", testIgnore: /06-ui\.spec\.ts$/ }]
+    : [
+        { name: "api-only", testIgnore: /06-ui\.spec\.ts$/ },
+        {
+          name: "browser",
+          testMatch: /06-ui\.spec\.ts$/,
+          use: { ...devices["Desktop Chrome"] },
+        },
+      ],
+});

--- a/.copilot/skills/e2e-smoke/run.sh
+++ b/.copilot/skills/e2e-smoke/run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# kratos-agent e2e-smoke runner.
+#
+# Installs deps + chromium on first run (cached afterwards), then executes
+# the Playwright suite. Any extra args are forwarded to `playwright test`.
+#
+# Usage:
+#   ./run.sh                       # all specs, default fruocco-2 endpoints
+#   ./run.sh --grep "chat"         # filter to chat spec
+#   SKIP_BROWSER=1 ./run.sh        # API-only mode (no chromium)
+#   KRATOS_BACKEND_URL=https://...  KRATOS_FRONTEND_URL=https://... ./run.sh
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [[ ! -d node_modules/@playwright/test ]]; then
+  echo "[e2e-smoke] installing npm dependencies …"
+  npm install --no-audit --no-fund --silent
+fi
+
+if [[ -z "${SKIP_BROWSER:-}" ]]; then
+  PW_BIN="./node_modules/.bin/playwright"
+  if ! "$PW_BIN" install --dry-run chromium >/dev/null 2>&1; then
+    echo "[e2e-smoke] installing chromium for Playwright …"
+    "$PW_BIN" install chromium
+  fi
+fi
+
+echo "[e2e-smoke] frontend = ${KRATOS_FRONTEND_URL:-default}"
+echo "[e2e-smoke] backend  = ${KRATOS_BACKEND_URL:-default}"
+echo "[e2e-smoke] use-cases = ${KRATOS_USE_CASES:-default}"
+echo "[e2e-smoke] skip-browser = ${SKIP_BROWSER:-0}"
+
+exec ./node_modules/.bin/playwright test "$@"

--- a/.copilot/skills/e2e-smoke/tests/01-health.spec.ts
+++ b/.copilot/skills/e2e-smoke/tests/01-health.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect, request } from "@playwright/test";
+import { BACKEND_URL, FRONTEND_URL } from "./helpers";
+
+test.describe("health & runtime config", () => {
+  test("backend /health returns ok", async () => {
+    const api = await request.newContext();
+    const resp = await api.get(`${BACKEND_URL}/health`);
+    expect(resp.status(), `backend /health status`).toBe(200);
+    const body = await resp.json();
+    expect(body, "health JSON shape").toMatchObject({ status: expect.any(String) });
+  });
+
+  test("frontend root serves HTML", async () => {
+    const api = await request.newContext();
+    const resp = await api.get(`${FRONTEND_URL}/`);
+    expect(resp.status(), "frontend root status").toBe(200);
+    const html = await resp.text();
+    expect(html.toLowerCase()).toContain("<!doctype html>");
+  });
+
+  test("frontend /config.json points at the same backend host", async () => {
+    const api = await request.newContext();
+    const resp = await api.get(`${FRONTEND_URL}/config.json`);
+    expect(resp.status(), "config.json status").toBe(200);
+    const cfg = await resp.json();
+    expect(cfg, "config.json shape").toHaveProperty("apiUrl");
+    expect(
+      cfg.apiUrl.replace(/\/$/, ""),
+      "frontend apiUrl should match KRATOS_BACKEND_URL",
+    ).toBe(BACKEND_URL.replace(/\/$/, ""));
+  });
+});

--- a/.copilot/skills/e2e-smoke/tests/02-scenarios.spec.ts
+++ b/.copilot/skills/e2e-smoke/tests/02-scenarios.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect, request } from "@playwright/test";
+import { BACKEND_URL, USE_CASES } from "./helpers";
+
+test.describe("evals scenarios per use-case", () => {
+  for (const useCase of USE_CASES) {
+    test(`${useCase}: scenarios endpoint returns >= 1 scenario`, async () => {
+      const api = await request.newContext();
+      const resp = await api.get(
+        `${BACKEND_URL}/api/use-cases/${useCase}/evals/scenarios`,
+      );
+      expect(resp.status(), `${useCase} scenarios status`).toBe(200);
+      const body = await resp.json();
+      expect(body, "scenarios body shape").toHaveProperty("scenarios");
+      const scenarios = body.scenarios as unknown[];
+      expect(scenarios.length, `${useCase}: should have >= 1 scenario`).toBeGreaterThan(0);
+
+      const first = scenarios[0] as Record<string, unknown>;
+      expect(first.name, `${useCase}: scenario.name`).toBeTruthy();
+      expect(
+        first.input_message,
+        `${useCase}: scenario.input_message`,
+      ).toBeTruthy();
+    });
+  }
+});

--- a/.copilot/skills/e2e-smoke/tests/03-chat.spec.ts
+++ b/.copilot/skills/e2e-smoke/tests/03-chat.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from "@playwright/test";
+import { chatOnce, CHAT_TIMEOUT_MS } from "./helpers";
+
+test.describe("chat round-trip", () => {
+  test.setTimeout(CHAT_TIMEOUT_MS * 2 + 30_000);
+
+  test("agent responds to a tiny prompt for the 'generic' use-case", async () => {
+    // Best-effort warmup; tolerate cold-start.
+    await chatOnce("ping", "generic", 30_000).catch(() => undefined);
+
+    const { text, ok, status } = await chatOnce(
+      "Reply with exactly one short sentence confirming you are online.",
+      "generic",
+    );
+
+    expect(
+      ok,
+      `chat should succeed (status=${status}, text snippet="${text.slice(0, 200)}")`,
+    ).toBe(true);
+    expect(
+      text.trim().length,
+      "assistant response should be non-empty",
+    ).toBeGreaterThan(0);
+  });
+});

--- a/.copilot/skills/e2e-smoke/tests/04-evals.spec.ts
+++ b/.copilot/skills/e2e-smoke/tests/04-evals.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect, request } from "@playwright/test";
+import { BACKEND_URL, USE_CASES } from "./helpers";
+
+test.describe("evals runs", () => {
+  test("at least one use-case has runs (any status); detail endpoint reachable", async () => {
+    const api = await request.newContext();
+
+    let totalRuns = 0;
+    let probedDetail = false;
+    const summaries: string[] = [];
+
+    for (const useCase of USE_CASES) {
+      const resp = await api.get(
+        `${BACKEND_URL}/api/use-cases/${useCase}/evals/runs`,
+      );
+      expect(resp.status(), `${useCase} runs status`).toBe(200);
+      const body = await resp.json();
+      const runs: any[] = body.runs ?? [];
+      totalRuns += runs.length;
+      summaries.push(`${useCase}=${runs.length}`);
+
+      if (!probedDetail && runs.length > 0) {
+        const runId = runs[0].run_id;
+        const detail = await api.get(
+          `${BACKEND_URL}/api/use-cases/${useCase}/evals/runs/${runId}`,
+        );
+        expect(detail.status(), `${useCase}/${runId} detail status`).toBe(200);
+        const detailBody = await detail.json();
+        expect(detailBody, `${useCase}/${runId} detail shape`).toHaveProperty("run_id", runId);
+        probedDetail = true;
+      }
+    }
+
+    expect(
+      totalRuns,
+      `total run count across use-cases: ${summaries.join(", ")}`,
+    ).toBeGreaterThan(0);
+    expect(probedDetail, "at least one run detail probed").toBe(true);
+  });
+});

--- a/.copilot/skills/e2e-smoke/tests/05-traces.spec.ts
+++ b/.copilot/skills/e2e-smoke/tests/05-traces.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect, request } from "@playwright/test";
+import { BACKEND_URL, TRACES_LOOKBACK_HOURS } from "./helpers";
+
+test.describe("traces", () => {
+  test("operations list returns; per-op detail returns spans (skip if empty window)", async () => {
+    const api = await request.newContext();
+
+    const listResp = await api.get(
+      `${BACKEND_URL}/api/traces/operations?hours=${TRACES_LOOKBACK_HOURS}`,
+    );
+    expect(listResp.status(), "operations list status").toBe(200);
+    const list = await listResp.json();
+    expect(list, "operations list shape").toHaveProperty("operations");
+    const ops: any[] = list.operations ?? [];
+
+    if (ops.length === 0) {
+      test.info().annotations.push({
+        type: "skip-reason",
+        description: `Zero operations in last ${TRACES_LOOKBACK_HOURS}h — likely AppIn ingestion delay or no recent chats`,
+      });
+      test.skip(true, "no trace operations in window");
+      return;
+    }
+
+    expect(ops[0], "op has operation_id").toHaveProperty("operation_id");
+
+    const opId = ops[0].operation_id;
+    const detailResp = await api.get(
+      `${BACKEND_URL}/api/traces/operations/${opId}?hours=${TRACES_LOOKBACK_HOURS}`,
+    );
+    expect(detailResp.status(), `op ${opId} detail status`).toBe(200);
+    const detail = await detailResp.json();
+    expect(detail, "op detail shape").toHaveProperty("operation_id", opId);
+    expect(Array.isArray(detail.spans), "spans must be an array").toBe(true);
+    expect(detail.spans.length, "spans array should be non-empty").toBeGreaterThan(0);
+  });
+});

--- a/.copilot/skills/e2e-smoke/tests/06-ui.spec.ts
+++ b/.copilot/skills/e2e-smoke/tests/06-ui.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+import { FRONTEND_URL } from "./helpers";
+
+test.describe("UI smoke (browser)", () => {
+  test("home page renders without console errors", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(`pageerror: ${err.message}`));
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(`console.error: ${msg.text()}`);
+    });
+
+    await page.goto(FRONTEND_URL, { waitUntil: "domcontentloaded" });
+    await expect(page).toHaveTitle(/.+/);
+
+    await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => undefined);
+
+    const bodyText = (await page.locator("body").innerText()).toLowerCase();
+    expect(
+      bodyText.length,
+      "body should have visible text after hydration",
+    ).toBeGreaterThan(50);
+
+    const cspNoise = errors.filter(
+      (e) => !/csp|content security policy|favicon|hydration/i.test(e),
+    );
+    expect(cspNoise, `unexpected JS errors: ${cspNoise.join(" | ")}`).toEqual([]);
+  });
+});

--- a/.copilot/skills/e2e-smoke/tests/07-regression.spec.ts
+++ b/.copilot/skills/e2e-smoke/tests/07-regression.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression coverage for kratos-agent surfaces that pre-date the
+ * evals + tracing branch. These specs assert that the existing
+ * use-case catalogue, conversation CRUD, skills admin, and settings
+ * surfaces still behave correctly after the changes shipped in
+ * `feat/evals-and-tracing`.
+ *
+ * Specs in 01-05 cover the NEW surface (evals, traces, chat); this
+ * spec exists so a future change can't quietly break the pre-existing
+ * core kratos-agent contract.
+ */
+import { test, expect, request } from "@playwright/test";
+import { BACKEND_URL, USE_CASES } from "./helpers";
+
+test.describe("regression: core kratos-agent surfaces", () => {
+  test("GET /api/use-cases returns every configured use-case with schema", async () => {
+    const api = await request.newContext();
+    const resp = await api.get(`${BACKEND_URL}/api/use-cases`);
+    expect(resp.status(), "/api/use-cases status").toBe(200);
+    const body = await resp.json();
+    expect(body, "shape").toHaveProperty("useCases");
+    const cases: any[] = body.useCases;
+    const names = cases.map((c) => c.name);
+    for (const expected of USE_CASES) {
+      expect(names, `use-case '${expected}' missing`).toContain(expected);
+    }
+    const first = cases[0];
+    expect(first.displayName, "displayName").toBeTruthy();
+    expect(first.description, "description").toBeTruthy();
+    expect(
+      typeof first.skillCount,
+      "skillCount type",
+    ).toBe("number");
+    expect(Array.isArray(first.sampleQuestions), "sampleQuestions array").toBe(true);
+  });
+
+  test("GET /api/settings returns Foundry config shape", async () => {
+    const api = await request.newContext();
+    const resp = await api.get(`${BACKEND_URL}/api/settings`);
+    expect(resp.status(), "/api/settings status").toBe(200);
+    const body = await resp.json();
+    expect(body, "settings shape").toHaveProperty("foundryEndpoint");
+    expect(body, "settings shape").toHaveProperty("foundryModelDeployment");
+    expect(
+      typeof body.configured,
+      "configured flag is boolean",
+    ).toBe("boolean");
+    expect(
+      body.foundryEndpoint.startsWith("https://"),
+      `foundryEndpoint should be https (got ${body.foundryEndpoint})`,
+    ).toBe(true);
+  });
+
+  test("conversation CRUD round-trip: POST -> GET -> list -> DELETE", async () => {
+    const api = await request.newContext();
+
+    const created = await api.post(`${BACKEND_URL}/api/conversations`, {
+      data: { useCase: "generic", title: "e2e-smoke regression" },
+    });
+    expect(created.status(), "create conversation status").toBeLessThan(300);
+    const conv = await created.json();
+    expect(conv.id, "conversation.id present").toBeTruthy();
+    expect(conv.useCase, "conversation.useCase preserved").toBe("generic");
+
+    const id = conv.id;
+    try {
+      const fetched = await api.get(`${BACKEND_URL}/api/conversations/${id}`);
+      expect(fetched.status(), "GET conversation by id").toBe(200);
+      const fetchedBody = await fetched.json();
+      expect(fetchedBody.id, "GET returns same id").toBe(id);
+
+      const list = await api.get(`${BACKEND_URL}/api/conversations`);
+      expect(list.status(), "list conversations status").toBe(200);
+      const listBody = await list.json();
+      const ids: string[] = (listBody.conversations || []).map((c: any) => c.id);
+      expect(ids, "newly-created conversation must appear in list").toContain(id);
+
+      const msgs = await api.get(`${BACKEND_URL}/api/conversations/${id}/messages`);
+      expect(msgs.status(), "messages endpoint status").toBe(200);
+    } finally {
+      const del = await api.delete(`${BACKEND_URL}/api/conversations/${id}`);
+      expect(
+        [200, 204].includes(del.status()),
+        `DELETE conversation expected 200/204, got ${del.status()}`,
+      ).toBe(true);
+    }
+  });
+
+  test("admin/skills catalogue returns >=1 skill with descriptor", async () => {
+    const api = await request.newContext();
+    const resp = await api.get(`${BACKEND_URL}/api/admin/skills`);
+    expect(resp.status(), "admin/skills status").toBe(200);
+    const body = await resp.json();
+    const skills: any[] = body.skills || [];
+    expect(skills.length, "skills count").toBeGreaterThan(0);
+
+    const sample = skills[0];
+    expect(sample.name, "skill.name").toBeTruthy();
+    expect(sample.description, "skill.description").toBeTruthy();
+
+    const detail = await api.get(
+      `${BACKEND_URL}/api/admin/skills/${encodeURIComponent(sample.name)}`,
+    );
+    expect(detail.status(), `GET admin/skills/${sample.name}`).toBe(200);
+    const detailBody = await detail.json();
+    expect(detailBody.name, "detail.name matches list").toBe(sample.name);
+  });
+
+  test("admin/system-prompt returns content", async () => {
+    const api = await request.newContext();
+    const resp = await api.get(`${BACKEND_URL}/api/admin/system-prompt`);
+    expect(resp.status(), "system-prompt status").toBe(200);
+    const body = await resp.json();
+    expect(body.content, "system-prompt.content").toBeTruthy();
+    expect(
+      typeof body.content === "string" && body.content.length > 50,
+      "system-prompt should be non-trivially long",
+    ).toBe(true);
+  });
+});

--- a/.copilot/skills/e2e-smoke/tests/08-ux.spec.ts
+++ b/.copilot/skills/e2e-smoke/tests/08-ux.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * UX smoke — the parts that ACTUALLY matter to users: real clicks, real
+ * typing, real navigation. API contract is covered by 01-07; this spec
+ * exercises the rendered surface end-to-end through Chromium so a CSS
+ * regression, wrong selector, broken modal, or dead button can't ship.
+ *
+ * Runs only when SKIP_BROWSER is unset (default).
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { FRONTEND_URL, USE_CASES } from "./helpers";
+
+async function gotoHome(page: Page) {
+  await page.goto(FRONTEND_URL, { waitUntil: "domcontentloaded" });
+  // Wait for runtime config + use-cases to land — landing input is the gate.
+  await page
+    .getByPlaceholder("Ask me anything...")
+    .waitFor({ state: "visible", timeout: 30_000 });
+  // Give Next.js client hydration time to attach React event handlers.
+  await page
+    .waitForLoadState("networkidle", { timeout: 20_000 })
+    .catch(() => undefined);
+}
+
+async function openSkillsAdmin(page: Page) {
+  // Sidebar may be collapsed on narrow viewports; ensure visible first.
+  const sidebar = page.locator('aside[aria-label="Conversation sidebar"]');
+  await sidebar.waitFor({ state: "visible" });
+  // The sidebar footer button that opens the admin panel is labeled
+  // "Agent Manager" (not "Skills" — that's the FIRST TAB inside the panel).
+  const agentManagerBtn = page.getByRole("button", { name: "Agent Manager" });
+  await agentManagerBtn.waitFor({ state: "visible", timeout: 10_000 });
+  await agentManagerBtn.click();
+  // Wait for the admin shell — the nav rendering "Evals" tab is a unique marker.
+  // If the click didn't propagate due to a hydration race, retry once via JS.
+  try {
+    await page.getByRole("button", { name: /^Evals$/ }).waitFor({ timeout: 5_000 });
+  } catch {
+    await agentManagerBtn.click({ force: true });
+    await page.getByRole("button", { name: /^Evals$/ }).waitFor({ timeout: 10_000 });
+  }
+}
+
+test.describe("UX — interactive flows", () => {
+  test("home loads with all 5 use-cases in the persona selector", async ({ page }) => {
+    await gotoHome(page);
+    const persona = page.locator('select[aria-label="Select agent persona"]');
+    await expect(persona, "persona <select> visible").toBeVisible();
+    const optionValues = await persona.locator("option").evaluateAll((opts) =>
+      opts.map((o) => (o as HTMLOptionElement).value),
+    );
+    for (const uc of USE_CASES) {
+      expect(optionValues, `option for '${uc}' present`).toContain(uc);
+    }
+  });
+
+  test("switching persona updates the persona selector value", async ({ page }) => {
+    await gotoHome(page);
+    const persona = page.locator('select[aria-label="Select agent persona"]');
+    await persona.selectOption("insurance");
+    await expect(persona).toHaveValue("insurance");
+    await persona.selectOption("retail-banking");
+    await expect(persona).toHaveValue("retail-banking");
+  });
+
+  test("landing textarea + send button triggers a chat and an assistant reply renders", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    await gotoHome(page);
+
+    const persona = page.locator('select[aria-label="Select agent persona"]');
+    await persona.selectOption("generic");
+
+    const input = page.getByPlaceholder("Ask me anything...");
+    const probe = `e2e-${Date.now().toString(36)} reply with exactly: ok`;
+    await input.fill(probe);
+
+    // The send button uses aria-label="Send message" inside the landing card.
+    await page.getByRole("button", { name: "Send message" }).first().click();
+
+    // Once the chat starts, the same prompt appears in BOTH the sidebar
+    // (truncated conversation title) and the main chat bubble — use .last()
+    // to target the most recent rendering, which is the chat bubble.
+    await expect(
+      page.getByText(probe, { exact: false }).last(),
+      "user message bubble rendered",
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Wait for the assistant's reply: once the agent finishes streaming, the
+    // ChatWindow's send button label flips from "Sending message" back to
+    // "Send message". That's the unambiguous "done" signal.
+    await page
+      .getByRole("button", { name: "Sending message" })
+      .waitFor({ state: "visible", timeout: 30_000 })
+      .catch(() => undefined);
+    await expect(
+      page.getByRole("button", { name: "Send message" }),
+      "send button returns to non-streaming state after assistant reply",
+    ).toBeVisible({ timeout: 120_000 });
+
+    // Sanity: <main> should have grown well beyond just the user prompt.
+    const mainText = await page.locator("main").innerText();
+    expect(
+      mainText.length,
+      `main should contain more than the user prompt (got ${mainText.length} chars)`,
+    ).toBeGreaterThan(probe.length + 5);
+  });
+
+  test("Skills admin panel: every tab renders its heading", async ({ page }) => {
+    await gotoHome(page);
+    await openSkillsAdmin(page);
+
+    const expectedTabs: { label: string; heading: RegExp }[] = [
+      { label: "Skills", heading: /^Skills$|Create Skill/i },
+      { label: "System Prompt", heading: /System Prompt/i },
+      { label: "APM", heading: /APM/i },
+      { label: "Evals", heading: /Evaluations|Evals/i },
+      { label: "Traces", heading: /Traces/i },
+    ];
+
+    for (const { label, heading } of expectedTabs) {
+      await page.getByRole("button", { name: new RegExp(`^${label}$`) }).click();
+      // Header h1/h2 should reflect the current tab — tolerate either.
+      await expect(
+        page.locator("h1, h2").filter({ hasText: heading }).first(),
+        `tab '${label}' header should match ${heading}`,
+      ).toBeVisible({ timeout: 10_000 });
+    }
+  });
+
+  test("Evals tab: 'Generate Scenarios' button opens modal then dismisses", async ({
+    page,
+  }) => {
+    await gotoHome(page);
+    await openSkillsAdmin(page);
+    await page.getByRole("button", { name: /^Evals$/ }).click();
+
+    // Wait for the toolbar to render the Generate Scenarios button.
+    const generateBtn = page
+      .getByRole("button", { name: /Generate Scenarios/i })
+      .first();
+    await generateBtn.waitFor({ state: "visible", timeout: 10_000 });
+    await generateBtn.click();
+
+    // Modal must surface a way to close (Cancel button, X aria-label="Close",
+    // or clicking outside). Assert any of those reveals a Close affordance.
+    const closeAffordances = page.getByRole("button", {
+      name: /^(Close|Cancel|×)$/i,
+    });
+    await expect(
+      closeAffordances.first(),
+      "modal should expose a Close/Cancel affordance",
+    ).toBeVisible({ timeout: 5_000 });
+
+    await closeAffordances.first().click();
+    // After close, the Generate Scenarios button should still be visible
+    // (we're back on the Evals tab).
+    await expect(generateBtn, "back on Evals tab after closing modal").toBeVisible();
+  });
+
+  test("Traces tab: Refresh button executes and renders either ops or empty state", async ({
+    page,
+  }) => {
+    await gotoHome(page);
+    await openSkillsAdmin(page);
+    await page.getByRole("button", { name: /^Traces$/ }).click();
+
+    const refreshBtn = page.getByRole("button", { name: /^Refresh$/ }).first();
+    await refreshBtn.waitFor({ state: "visible", timeout: 10_000 });
+    await refreshBtn.click();
+
+    // Acceptable outcome (any of):
+    //   - at least one operation row rendered (matches operation id chip / time)
+    //   - the explicit empty state "No operations found"
+    //   - a summary card with token / latency stats visible
+    await expect(
+      page
+        .getByText(/No operations found|operations|total operations|avg latency/i)
+        .first(),
+      "Traces panel must render either ops, summary, or empty state",
+    ).toBeVisible({ timeout: 20_000 });
+  });
+});

--- a/.copilot/skills/e2e-smoke/tests/helpers.ts
+++ b/.copilot/skills/e2e-smoke/tests/helpers.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared helpers + env-derived URLs used by every spec.
+ */
+export const FRONTEND_URL =
+  process.env.KRATOS_FRONTEND_URL ||
+  "https://mango-bay-04ed10b03.7.azurestaticapps.net";
+
+export const BACKEND_URL =
+  process.env.KRATOS_BACKEND_URL ||
+  "https://ca-agent-jep3w6qugjoda.blacktree-6e513e92.swedencentral.azurecontainerapps.io";
+
+export const USE_CASES = (
+  process.env.KRATOS_USE_CASES ||
+  "generic,insurance,retail-banking,wealth-management,sales-account-review"
+)
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+export const CHAT_TIMEOUT_MS = Number(process.env.CHAT_TIMEOUT_MS || 60_000);
+export const TRACES_LOOKBACK_HOURS = Number(process.env.TRACES_LOOKBACK_HOURS || 6);
+
+/**
+ * Stream-aware POST to /api/agent/chat that aggregates the SSE response into
+ * a single concatenated text. The backend yields lines like:
+ *   data: {"event":"content","data":{"content":"..."}}
+ *   data: {"event":"done"}
+ * We collect every content chunk and return the concatenated string.
+ */
+export async function chatOnce(
+  prompt: string,
+  useCase: string,
+  timeoutMs = CHAT_TIMEOUT_MS,
+): Promise<{ text: string; ok: boolean; status: number }> {
+  const conversationId = `e2e-smoke-${Date.now()}`;
+  const ac = new AbortController();
+  const to = setTimeout(() => ac.abort(), timeoutMs);
+
+  try {
+    const resp = await fetch(`${BACKEND_URL}/api/agent/chat`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+      },
+      body: JSON.stringify({
+        message: prompt,
+        useCase: useCase,
+        conversationId: conversationId,
+      }),
+      signal: ac.signal,
+    });
+
+    if (!resp.ok || !resp.body) {
+      const body = resp.body ? await resp.text() : "";
+      return { text: body, ok: false, status: resp.status };
+    }
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let collected = "";
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith("data:")) continue;
+        const payload = trimmed.slice(5).trim();
+        if (!payload || payload === "[DONE]") continue;
+        try {
+          const evt = JSON.parse(payload);
+          const ev = evt.event ?? evt.type;
+          if (ev === "content") {
+            collected += evt.data?.content ?? evt.content ?? "";
+          } else if (ev === "done") {
+            return { text: collected, ok: true, status: resp.status };
+          } else if (ev === "error") {
+            return {
+              text: collected + `\n[error: ${evt.data?.message ?? evt.message ?? "unknown"}]`,
+              ok: false,
+              status: resp.status,
+            };
+          }
+        } catch {
+          /* ignore non-JSON keepalive lines */
+        }
+      }
+    }
+    return { text: collected, ok: collected.length > 0, status: resp.status };
+  } finally {
+    clearTimeout(to);
+  }
+}

--- a/.copilot/skills/e2e-smoke/tsconfig.json
+++ b/.copilot/skills/e2e-smoke/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "types": ["node"]
+  },
+  "include": ["tests/**/*.ts", "playwright.config.ts"]
+}

--- a/README.md
+++ b/README.md
@@ -439,6 +439,72 @@ The UI shows real-time execution details per message:
 
 ---
 
+## Evals & Tracing
+
+Per-use-case evaluation harness and an App-Insights waterfall trace inspector — both surfaced as admin tabs in the UI and exposed via CLI for CI.
+
+### Per-Use-Case Eval Scenarios
+
+Each use-case carries its own eval suite under `use-cases/<name>/evals/`:
+
+```
+use-cases/insurance/evals/
+  eval_config.json          ← evaluator list + judge model
+  scenarios/                ← committed JSON scenarios
+    load-customer-profile.json
+    policy-wording-lookup.json
+    ...
+  results/                  ← run output (gitignored)
+```
+
+Each scenario declares an `input_message`, `expected_behavior`, `expected_tool_calls`, and the Foundry evaluator set to apply (e.g. `Relevance`, `Coherence`, `TaskAdherence`, `IntentResolution`, `ToolCallAccuracy`).
+
+### Two Eval Modes
+
+| Mode | Pattern | Speed | Use |
+|------|---------|-------|-----|
+| **validation** | In-process: invoke agent sequentially → score locally with `azure-ai-evaluation` evaluators | Seconds | Fast feedback loop, CI smoke |
+| **foundry** | Full Foundry eval pipeline (same evaluators, hosted scoring) | Minutes | Pre-release runs, shareable Foundry portal links |
+
+Both modes follow the **two-phase invoke + score** pattern from the `foundry-evals` awesome-gbb skill: Phase 1 invokes the hosted agent via `AIProjectClient(...).get_openai_client(agent_name=...)` with a warmup retry loop for cold starts; Phase 2 scores the recorded turns with the evaluators configured in `eval_config.json`.
+
+### LLM-Generated Scenarios
+
+The "Generate Scenarios" modal (or `POST /api/use-cases/{uc}/evals/scenarios/generate`) reads the use-case `SYSTEM_PROMPT.md` and the loaded skill catalog and asks the judge model to draft realistic conversations that exercise the agent. Each draft is hand-reviewable before commit. Industry-realism canons from `threadlight-demo-data-factory` are injected for FSI-shaped use-cases (`insurance`, `retail-banking`, `wealth-management`) so generated data feels plausible.
+
+### Traces Panel
+
+The "Traces" admin tab queries App Insights via `LogsQueryClient` (resource-scoped) and renders a per-operation waterfall classified into `llm / agent / tool / skill / http / platform / error` spans. Filterable by `use_case`, `conversation_id`, `run_id`, and lookback window. Identical UX to `threadlight-vnext`.
+
+Spans carry three custom attributes for the filter:
+
+- `kratos.use_case`
+- `kratos.conversation_id`
+- `kratos.eval_run_id` (only set during eval runs)
+
+These are stamped in `copilot_agent.py` and forwarded to the hosted agent via `x-kratos-*` headers from `foundry_agent_proxy.py`.
+
+### CLI
+
+For CI / scripting:
+
+```bash
+# Generate (and optionally save) scenarios
+BACKEND_URL=https://kratos-be.example.com \
+  python scripts/generate_evals.py --use-case insurance --count 5 --save
+
+# Run validation evals
+python scripts/run_evals.py --use-case insurance --mode validation
+
+# Run hosted Foundry evals
+python scripts/run_evals.py --use-case insurance --mode foundry
+
+# Inspect traces
+python scripts/fetch_traces.py --conversation-id abc123
+```
+
+---
+
 ## Security
 
 | Control | Implementation |

--- a/README.md
+++ b/README.md
@@ -171,6 +171,19 @@ After `azd up`, register the agent in the Foundry portal so traces appear in the
 
 This is the only manual step — it cannot be automated because the Foundry Control Plane creates internal metadata linking the APIM API to the tracing pipeline.
 
+### Validating a Deployment
+
+The repo ships a Playwright-based smoke skill at `.copilot/skills/e2e-smoke/` that asserts the **23 critical surfaces** (health, scenarios, chat, evals, traces, UI, regression, interactive UX) of a deployed instance in ~66s. After every deploy:
+
+```bash
+cd .copilot/skills/e2e-smoke
+KRATOS_BACKEND_URL="https://<your-backend>.azurecontainerapps.io" \
+KRATOS_FRONTEND_URL="https://<your-frontend>.azurestaticapps.net" \
+./run.sh
+```
+
+See [`.copilot/skills/e2e-smoke/SKILL.md`](./.copilot/skills/e2e-smoke/SKILL.md) for the spec catalogue, env-var reference, and tips for running just the API or just the UX project.
+
 ---
 
 ## Local Development
@@ -503,6 +516,13 @@ python scripts/run_evals.py --use-case insurance --mode foundry
 python scripts/fetch_traces.py --conversation-id abc123
 ```
 
+> **API JSON convention.** The backend API uses **camelCase** field names (Pydantic
+> alias generator) — `/api/agent/chat` expects `{message, useCase, conversationId}`,
+> not snake_case. The on-disk eval-scenario format is the exception: it uses
+> `input_message`, `expected_behavior`, `expected_tool_calls` (snake_case) so
+> scenarios stay readable in version control. The `.copilot/skills/e2e-smoke/`
+> Playwright skill encodes both conventions if you want a runnable reference.
+
 ---
 
 ## Security
@@ -708,6 +728,76 @@ All service-to-service auth uses Managed Identity with least-privilege roles:
 | **Total baseline** | **~$265 – $350/month** |
 
 > Model costs (GPT-4o, GPT-5) are usage-dependent and not included in the baseline.
+
+---
+
+## Troubleshooting
+
+Real findings from deploying this repo end-to-end on a fresh Azure subscription. Add to this list as you hit new ones.
+
+### Postdeploy 404 "false alarm" at the tail of every `azd deploy`
+
+**Symptom:** A scary RED block at the tail of every `azd deploy <any-service>` reporting `agents/<key>/versions/<n>` not found, even though the deploy succeeded.
+
+**Cause:** The `azure.ai.agents` azd extension's postdeploy hook fires after **every** `azd deploy` (including unrelated services like `web`) and looks up `agents/<service-key>/versions/<n>` using the SERVICE KEY from `azure.yaml` verbatim, not the agent name.
+
+**Fix in this repo:** `azure.yaml` uses `services.kratos-agent` (matches the agent name in `src/hosted-agent/agent.yaml`). If you fork and rename, keep them aligned.
+
+### `create_version` deduplication — new image, but old code still runs
+
+**Symptom:** You `azd deploy kratos-agent`, the build succeeds, but the running agent serves the previous behaviour. `azd ai agent show` reports a new version but its image digest is identical.
+
+**Cause:** Foundry deduplicates `create_version` when environment variables and metadata are identical — even if the container image tag differs. The `_BUILD_TS` env var in `src/hosted-agent/agent.yaml` (sourced from `KRATOS_BUILD_TS`) is what makes each version unique.
+
+**Fix in this repo:** A `predeploy` hook on `services.kratos-agent` in `azure.yaml` auto-bumps `KRATOS_BUILD_TS` to the current unix timestamp before every deploy. **You shouldn't need to do anything manually.** If you bypass the hook, run `azd env set KRATOS_BUILD_TS $(date +%s)` first.
+
+### Hosted-agent uses `invocations`, not `responses`
+
+**Symptom:** Direct calls to `oai.responses.create()` against the hosted agent return HTTP 400 `invalid_request_error`.
+
+**Cause:** `src/hosted-agent/agent.yaml` declares `protocol: invocations` (not `responses`). Use `AIProjectClient(...).get_openai_client(agent_name="kratos-agent")` — the SDK picks the right transport based on the agent's declared protocol.
+
+This is wired correctly in `src/backend/app/services/eval_service.py` and in the e2e-smoke chat helper. If you write a new client, mirror the invocations pattern.
+
+### 4-identity AcrPull / Foundry User dance on a fresh deploy
+
+**Symptom:** On a brand-new resource group, the hosted agent returns `server_error` on first call. `az role assignment list` shows correct grants on the account-level MI, but the agent's own instance/blueprint identities are missing roles.
+
+**Cause:** Foundry hosted agents have **four** identity surfaces that all need RBAC:
+1. The Foundry project MI (system-assigned on the account)
+2. The deployer/CI MI (Contributor + `User Access Administrator` on the Foundry account)
+3. The **instance** identity (per-agent runtime SP — created at first deploy)
+4. The **blueprint** identity (per-agent platform SP — created at first deploy)
+
+The `azd ai agent` postdeploy hook auto-assigns `Foundry User` (GUID `53ca6127-db72-4b80-b1b0-d745d6d5456d`) to (3) and (4) **if** the deployer has `Azure AI Project Manager` on the project. Confirm with `azd ai agent show` — the `instance_identity.principal_id` and `blueprint.principal_id` should appear in `az role assignment list --assignee <principal_id> --all`.
+
+If empty, grant manually:
+```bash
+ACCT="/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<account>"
+PROJ="$ACCT/projects/<project>"
+FOUNDRY_USER=53ca6127-db72-4b80-b1b0-d745d6d5456d
+for PID in <instance_pid> <blueprint_pid> <project_mi_pid>; do
+  az role assignment create --assignee "$PID" --role "$FOUNDRY_USER" --scope "$ACCT"
+  az role assignment create --assignee "$PID" --role "$FOUNDRY_USER" --scope "$PROJ"
+  az role assignment create --assignee "$PID" --role AcrPull \
+    --scope "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.ContainerRegistry/registries/<acr>"
+done
+```
+
+RBAC propagation takes 5–15 min. Re-run the e2e-smoke skill to confirm.
+
+### `hooks/postdeploy.sh` blocks CI
+
+**Symptom:** `azd up` hangs at the postdeploy step waiting for input.
+
+**Cause:** The script prompts for which use-cases to upload to blob storage.
+
+**Fix:** Set `KRATOS_AUTO_UPLOAD_USE_CASES=1` in the environment before running `azd up` / `azd deploy`. The script will upload **all** use-cases non-interactively. Local devs without the flag get the interactive prompt as before.
+
+```bash
+export KRATOS_AUTO_UPLOAD_USE_CASES=1
+azd up
+```
 
 ---
 

--- a/azure.yaml
+++ b/azure.yaml
@@ -14,7 +14,12 @@ services:
         docker:
             path: ./Dockerfile
             context: ../..
-    hosted-agent:
+    # NOTE: service key MUST match the agent name in src/hosted-agent/agent.yaml
+    # (kratos-agent) — the azure.ai.agents extension's postdeploy hook looks up
+    # agents/<service-key>/versions/<n> using the service key verbatim, so a
+    # mismatch produces a scary RED 404 block at the tail of every azd deploy
+    # (false alarm, deploy actually succeeded). See README → Troubleshooting.
+    kratos-agent:
         project: ./src/hosted-agent
         host: azure.ai.agent
         language: docker
@@ -51,6 +56,20 @@ services:
                       echo "Injected config.json with apiUrl=${AGENT_SERVICE_URL}"
                     fi
 hooks:
+    # Bump KRATOS_BUILD_TS on every azd deploy so Foundry's create_version
+    # does NOT deduplicate against the previous version (env vars must differ
+    # even when the image digest changes). Lives here at the project scope
+    # because the azure.ai.agents extension strips service-level `hooks:`
+    # blocks during deploy. Idempotent; harmless when other services deploy.
+    # See foundry-hosted-agents skill → "create_version deduplication trap".
+    predeploy:
+        name: predeploy
+        kind: sh
+        shell: sh
+        run: |
+            BUILD_TS="$(date +%s)"
+            azd env set KRATOS_BUILD_TS "$BUILD_TS"
+            echo "KRATOS_BUILD_TS=$BUILD_TS (forces new hosted-agent version)"
     postdeploy:
         name: postdeploy
         kind: sh

--- a/azure.yaml
+++ b/azure.yaml
@@ -56,20 +56,6 @@ services:
                       echo "Injected config.json with apiUrl=${AGENT_SERVICE_URL}"
                     fi
 hooks:
-    # Bump KRATOS_BUILD_TS on every azd deploy so Foundry's create_version
-    # does NOT deduplicate against the previous version (env vars must differ
-    # even when the image digest changes). Lives here at the project scope
-    # because the azure.ai.agents extension strips service-level `hooks:`
-    # blocks during deploy. Idempotent; harmless when other services deploy.
-    # See foundry-hosted-agents skill → "create_version deduplication trap".
-    predeploy:
-        name: predeploy
-        kind: sh
-        shell: sh
-        run: |
-            BUILD_TS="$(date +%s)"
-            azd env set KRATOS_BUILD_TS "$BUILD_TS"
-            echo "KRATOS_BUILD_TS=$BUILD_TS (forces new hosted-agent version)"
     postdeploy:
         name: postdeploy
         kind: sh
@@ -83,6 +69,20 @@ hooks:
         run: |
             echo "Post-provisioning: configuring services..."
             echo "Deployment complete."
+    predeploy:
+        # Bump KRATOS_BUILD_TS on every azd deploy so Foundry's create_version
+        # does NOT deduplicate against the previous version (env vars must differ
+        # even when the image digest changes). Lives here at the project scope
+        # because the azure.ai.agents extension strips service-level `hooks:`
+        # blocks during deploy. Idempotent; harmless when other services deploy.
+        # See foundry-hosted-agents skill → "create_version deduplication trap".
+        name: predeploy
+        kind: sh
+        shell: sh
+        run: |
+            BUILD_TS="$(date +%s)"
+            azd env set KRATOS_BUILD_TS "$BUILD_TS"
+            echo "KRATOS_BUILD_TS=$BUILD_TS (forces new hosted-agent version)"
     preprovision:
         name: preprovision
         kind: sh

--- a/hooks/postdeploy.sh
+++ b/hooks/postdeploy.sh
@@ -36,16 +36,23 @@ echo "║  Storage Account: $STORAGE_ACCOUNT"
 echo "║  Container:       $CONTAINER_NAME"
 echo "╚══════════════════════════════════════════════════════════╝"
 echo ""
-echo "Available use-cases:"
-echo ""
-for i in "${!USE_CASES[@]}"; do
-  echo "  $((i + 1)). ${USE_CASES[$i]}"
-done
-echo "  A. All use-cases"
-echo "  S. Skip (do not upload)"
-echo ""
 
-read -r -p "Select use-case(s) to upload (number, A for all, S to skip): " SELECTION
+# Non-interactive mode: KRATOS_AUTO_UPLOAD_USE_CASES=1 uploads ALL use-cases
+# without prompting. Required for CI / non-TTY runs.
+if [[ "${KRATOS_AUTO_UPLOAD_USE_CASES:-0}" == "1" ]]; then
+  echo "🤖 KRATOS_AUTO_UPLOAD_USE_CASES=1 set — uploading ALL use-cases non-interactively."
+  SELECTION="A"
+else
+  echo "Available use-cases:"
+  echo ""
+  for i in "${!USE_CASES[@]}"; do
+    echo "  $((i + 1)). ${USE_CASES[$i]}"
+  done
+  echo "  A. All use-cases"
+  echo "  S. Skip (do not upload)"
+  echo ""
+  read -r -p "Select use-case(s) to upload (number, A for all, S to skip): " SELECTION
+fi
 
 if [[ "$SELECTION" =~ ^[Ss]$ ]]; then
   echo "Skipping skills upload."
@@ -78,14 +85,31 @@ for use_case in "${SELECTED[@]}"; do
   echo ""
   echo "🔄 Uploading '$use_case' → blob://$CONTAINER_NAME/$use_case/ ..."
 
-  # Delete existing blobs for this use-case first (replace, not merge)
-  echo "   Clearing existing blobs under 'use-cases/$use_case/'..."
-  az storage blob delete-batch \
+  # Delete existing blobs for this use-case first (replace, not merge), BUT
+  # preserve eval run history under evals/runs/ — those are runtime artefacts
+  # written by the backend, not source-controlled inputs we ship from the repo.
+  # Without this guard, every postdeploy wipes the entire eval history and
+  # the e2e-smoke `04-evals` spec fails until a fresh validation run is queued.
+  echo "   Clearing existing blobs under 'use-cases/$use_case/' (preserving evals/runs/)..."
+  EXISTING_BLOBS="$(az storage blob list \
     --account-name "$STORAGE_ACCOUNT" \
-    --source "$CONTAINER_NAME" \
-    --pattern "use-cases/$use_case/*" \
+    --container-name "$CONTAINER_NAME" \
+    --prefix "use-cases/$use_case/" \
     --auth-mode login \
-    --only-show-errors 2>/dev/null || true
+    --query "[?!contains(name, '/evals/runs/')].name" \
+    --output tsv 2>/dev/null || true)"
+
+  if [ -n "$EXISTING_BLOBS" ]; then
+    echo "$EXISTING_BLOBS" | while IFS= read -r blob_name; do
+      [ -z "$blob_name" ] && continue
+      az storage blob delete \
+        --account-name "$STORAGE_ACCOUNT" \
+        --container-name "$CONTAINER_NAME" \
+        --name "$blob_name" \
+        --auth-mode login \
+        --only-show-errors 2>/dev/null || true
+    done
+  fi
 
   # Upload all files from the local use-case folder
   az storage blob upload-batch \

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -189,6 +189,7 @@ module agentService './modules/agent-service.bicep' = {
     containerAppsEnvId: containerAppsEnv.outputs.id
     containerRegistryName: containerRegistry.outputs.name
     appInsightsConnectionString: appInsights.outputs.connectionString
+    appInsightsResourceId: appInsights.outputs.id
     cosmosDbEndpoint: cosmosDb.outputs.endpoint
     aiSearchEndpoint: aiSearch.outputs.endpoint
     keyVaultUri: keyVault.outputs.uri
@@ -238,6 +239,7 @@ module roleAssignments './modules/role-assignments.bicep' = {
     aiServicesName: aiFoundry.outputs.name
     keyVaultName: keyVault.outputs.name
     storageAccountName: blobStorage.outputs.name
+    appInsightsName: appInsights.outputs.name
     principalId: principalId
   }
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -34,6 +34,16 @@ param apimPublisherEmail string = 'admin@${environmentName}.com'
 @description('Path prefix for the agent API on the gateway (set during Foundry portal registration)')
 param agentApiPath string = 'kratos-agent'
 
+@description('Location for the Static Web App (must be one of: centralus, eastus2, westus2, westeurope, eastasia)')
+@allowed([
+  'centralus'
+  'eastus2'
+  'westus2'
+  'westeurope'
+  'eastasia'
+])
+param staticWebAppLocation string = 'westeurope'
+
 // ─── Resource Naming ───
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
@@ -223,7 +233,7 @@ module staticWebApp './modules/static-web-app.bicep' = {
   scope: rg
   params: {
     name: !empty(staticWebAppName) ? staticWebAppName : '${abbrs.webStaticSites}${resourceToken}'
-    location: location
+    location: staticWebAppLocation
     tags: tags
   }
 }
@@ -237,6 +247,7 @@ module roleAssignments './modules/role-assignments.bicep' = {
     cosmosDbAccountName: cosmosDb.outputs.name
     aiSearchName: aiSearch.outputs.name
     aiServicesName: aiFoundry.outputs.name
+    aiServicesPrincipalId: aiFoundry.outputs.principalId
     keyVaultName: keyVault.outputs.name
     storageAccountName: blobStorage.outputs.name
     appInsightsName: appInsights.outputs.name

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -251,6 +251,7 @@ module roleAssignments './modules/role-assignments.bicep' = {
     keyVaultName: keyVault.outputs.name
     storageAccountName: blobStorage.outputs.name
     appInsightsName: appInsights.outputs.name
+    containerRegistryName: containerRegistry.outputs.name
     principalId: principalId
   }
 }

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "11292237164153611962"
+      "templateHash": "12984131636732918112"
     }
   },
   "parameters": {
@@ -2421,6 +2421,9 @@
           "appInsightsName": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'app-insights'), '2025-04-01').outputs.name.value]"
           },
+          "containerRegistryName": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-registry'), '2025-04-01').outputs.name.value]"
+          },
           "principalId": {
             "value": "[parameters('principalId')]"
           }
@@ -2432,7 +2435,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.43.8.12551",
-              "templateHash": "10775664444361835591"
+              "templateHash": "17740582200090452759"
             }
           },
           "parameters": {
@@ -2485,6 +2488,13 @@
                 "description": "Application Insights resource name (for Monitoring Reader RBAC)"
               }
             },
+            "containerRegistryName": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Container Registry name (for AcrPull grant to the Foundry hosted-agent MI)"
+              }
+            },
             "principalId": {
               "type": "string",
               "defaultValue": "",
@@ -2502,7 +2512,8 @@
             "azureAIDeveloper": "64702f94-c441-49e6-a78b-ef80e0188fee",
             "cognitiveServicesUser": "a97b65f3-24c7-4388-baec-2e87135dc908",
             "storageBlobDataContributor": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
-            "monitoringReader": "43d0d8ad-25c7-4714-9337-8ba259a9fe05"
+            "monitoringReader": "43d0d8ad-25c7-4714-9337-8ba259a9fe05",
+            "acrPull": "7f951dda-4ed3-4680-a7ca-43fe172d538d"
           },
           "resources": [
             {
@@ -2605,6 +2616,18 @@
               }
             },
             {
+              "condition": "[not(empty(parameters('containerRegistryName')))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('containerRegistryName'))]",
+              "name": "[guid(resourceId('Microsoft.ContainerRegistry/registries', parameters('containerRegistryName')), parameters('aiServicesPrincipalId'), variables('acrPull'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('acrPull'))]",
+                "principalId": "[parameters('aiServicesPrincipalId')]",
+                "principalType": "ServicePrincipal"
+              }
+            },
+            {
               "condition": "[not(empty(parameters('principalId')))]",
               "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
               "apiVersion": "2024-02-15-preview",
@@ -2684,6 +2707,7 @@
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-search')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'app-insights')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'blob-storage')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-registry')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'cosmos-db')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'key-vault')]",
         "[subscriptionResourceId('Microsoft.Resources/resourceGroups', format('rg-{0}', parameters('environmentName')))]"

--- a/infra/main.json
+++ b/infra/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.33.93.31351",
-      "templateHash": "3379904064295773469"
+      "version": "0.43.8.12551",
+      "templateHash": "11292237164153611962"
     }
   },
   "parameters": {
@@ -47,6 +47,14 @@
       "type": "string",
       "defaultValue": ""
     },
+    "aiServicesName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "bingSearchName": {
+      "type": "string",
+      "defaultValue": ""
+    },
     "keyVaultName": {
       "type": "string",
       "defaultValue": ""
@@ -71,13 +79,41 @@
       "type": "string",
       "defaultValue": ""
     },
-    "foundryEndpoint": {
+    "storageAccountName": {
       "type": "string",
       "defaultValue": ""
     },
-    "foundryModelDeployment": {
+    "aiGatewayName": {
       "type": "string",
-      "defaultValue": "gpt-4o"
+      "defaultValue": ""
+    },
+    "apimPublisherEmail": {
+      "type": "string",
+      "defaultValue": "[format('admin@{0}.com', parameters('environmentName'))]",
+      "metadata": {
+        "description": "Publisher email for the AI Gateway (APIM)"
+      }
+    },
+    "agentApiPath": {
+      "type": "string",
+      "defaultValue": "kratos-agent",
+      "metadata": {
+        "description": "Path prefix for the agent API on the gateway (set during Foundry portal registration)"
+      }
+    },
+    "staticWebAppLocation": {
+      "type": "string",
+      "defaultValue": "westeurope",
+      "allowedValues": [
+        "centralus",
+        "eastus2",
+        "westus2",
+        "westeurope",
+        "eastasia"
+      ],
+      "metadata": {
+        "description": "Location for the Static Web App (must be one of: centralus, eastus2, westus2, westeurope, eastasia)"
+      }
     }
   },
   "variables": {
@@ -93,7 +129,10 @@
       "networkNetworkSecurityGroups": "nsg-",
       "operationalInsightsWorkspaces": "log-",
       "searchSearchServices": "srch-",
-      "webStaticSites": "stapp-"
+      "cognitiveServicesAccounts": "oai-",
+      "bingSearchAccounts": "bing-",
+      "webStaticSites": "stapp-",
+      "storageAccounts": "st"
     },
     "abbrs": "[variables('$fxv#0')]",
     "resourceToken": "[toLower(uniqueString(subscription().id, parameters('environmentName'), parameters('location')))]",
@@ -112,7 +151,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "network",
       "resourceGroup": "[format('rg-{0}', parameters('environmentName'))]",
       "properties": {
@@ -135,8 +174,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "7884183006100563045"
+              "version": "0.43.8.12551",
+              "templateHash": "15282120546862513117"
             }
           },
           "parameters": {
@@ -225,7 +264,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "log-analytics",
       "resourceGroup": "[format('rg-{0}', parameters('environmentName'))]",
       "properties": {
@@ -248,8 +287,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "715463662490201918"
+              "version": "0.43.8.12551",
+              "templateHash": "16656169793928770158"
             }
           },
           "parameters": {
@@ -306,7 +345,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "app-insights",
       "resourceGroup": "[format('rg-{0}', parameters('environmentName'))]",
       "properties": {
@@ -323,7 +362,7 @@
             "value": "[variables('tags')]"
           },
           "logAnalyticsWorkspaceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'log-analytics'), '2022-09-01').outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'log-analytics'), '2025-04-01').outputs.id.value]"
           }
         },
         "template": {
@@ -332,8 +371,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "3305752030983042964"
+              "version": "0.43.8.12551",
+              "templateHash": "10651574049460754328"
             }
           },
           "parameters": {
@@ -404,7 +443,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "key-vault",
       "resourceGroup": "[format('rg-{0}', parameters('environmentName'))]",
       "properties": {
@@ -424,7 +463,10 @@
             "value": "[parameters('principalId')]"
           },
           "subnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'network'), '2022-09-01').outputs.privateEndpointSubnetId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'network'), '2025-04-01').outputs.privateEndpointSubnetId.value]"
+          },
+          "vnetId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'network'), '2025-04-01').outputs.id.value]"
           }
         },
         "template": {
@@ -433,8 +475,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "2144517667780992388"
+              "version": "0.43.8.12551",
+              "templateHash": "13860132387323606432"
             }
           },
           "parameters": {
@@ -468,6 +510,12 @@
               "type": "string",
               "metadata": {
                 "description": "Subnet ID for private endpoint"
+              }
+            },
+            "vnetId": {
+              "type": "string",
+              "metadata": {
+                "description": "VNet ID for DNS zone link"
               }
             }
           },
@@ -518,6 +566,47 @@
               "dependsOn": [
                 "[resourceId('Microsoft.KeyVault/vaults', parameters('name'))]"
               ]
+            },
+            {
+              "type": "Microsoft.Network/privateDnsZones",
+              "apiVersion": "2020-06-01",
+              "name": "privatelink.vaultcore.azure.net",
+              "location": "global",
+              "tags": "[parameters('tags')]"
+            },
+            {
+              "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+              "apiVersion": "2020-06-01",
+              "name": "[format('{0}/{1}', 'privatelink.vaultcore.azure.net', format('{0}-vnet-link', parameters('name')))]",
+              "location": "global",
+              "properties": {
+                "virtualNetwork": {
+                  "id": "[parameters('vnetId')]"
+                },
+                "registrationEnabled": false
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.vaultcore.azure.net')]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+              "apiVersion": "2023-09-01",
+              "name": "[format('{0}/{1}', format('{0}-pe', parameters('name')), 'default')]",
+              "properties": {
+                "privateDnsZoneConfigs": [
+                  {
+                    "name": "keyvault-dns",
+                    "properties": {
+                      "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.vaultcore.azure.net')]"
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.vaultcore.azure.net')]",
+                "[resourceId('Microsoft.Network/privateEndpoints', format('{0}-pe', parameters('name')))]"
+              ]
             }
           ],
           "outputs": {
@@ -543,7 +632,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "cosmos-db",
       "resourceGroup": "[format('rg-{0}', parameters('environmentName'))]",
       "properties": {
@@ -560,10 +649,13 @@
             "value": "[variables('tags')]"
           },
           "subnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'network'), '2022-09-01').outputs.privateEndpointSubnetId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'network'), '2025-04-01').outputs.privateEndpointSubnetId.value]"
+          },
+          "vnetId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'network'), '2025-04-01').outputs.id.value]"
           },
           "keyVaultName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'key-vault'), '2022-09-01').outputs.name.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'key-vault'), '2025-04-01').outputs.name.value]"
           }
         },
         "template": {
@@ -572,8 +664,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "1916402458255207228"
+              "version": "0.43.8.12551",
+              "templateHash": "6938681821268502169"
             }
           },
           "parameters": {
@@ -600,6 +692,12 @@
               "type": "string",
               "metadata": {
                 "description": "Subnet ID for private endpoint"
+              }
+            },
+            "vnetId": {
+              "type": "string",
+              "metadata": {
+                "description": "VNet ID for DNS zone link"
               }
             },
             "keyVaultName": {
@@ -722,6 +820,76 @@
               ]
             },
             {
+              "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
+              "apiVersion": "2024-02-15-preview",
+              "name": "[format('{0}/{1}/{2}', parameters('name'), 'kratos-agent', 'settings')]",
+              "properties": {
+                "resource": {
+                  "id": "settings",
+                  "partitionKey": {
+                    "paths": [
+                      "/category"
+                    ],
+                    "kind": "Hash",
+                    "version": 2
+                  },
+                  "indexingPolicy": {
+                    "indexingMode": "consistent",
+                    "automatic": true,
+                    "includedPaths": [
+                      {
+                        "path": "/*"
+                      }
+                    ],
+                    "excludedPaths": [
+                      {
+                        "path": "/\"_etag\"/?"
+                      }
+                    ]
+                  },
+                  "defaultTtl": -1
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('name'), 'kratos-agent')]"
+              ]
+            },
+            {
+              "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
+              "apiVersion": "2024-02-15-preview",
+              "name": "[format('{0}/{1}/{2}', parameters('name'), 'kratos-agent', 'sessions')]",
+              "properties": {
+                "resource": {
+                  "id": "sessions",
+                  "partitionKey": {
+                    "paths": [
+                      "/conversationId"
+                    ],
+                    "kind": "Hash",
+                    "version": 2
+                  },
+                  "indexingPolicy": {
+                    "indexingMode": "consistent",
+                    "automatic": true,
+                    "includedPaths": [
+                      {
+                        "path": "/*"
+                      }
+                    ],
+                    "excludedPaths": [
+                      {
+                        "path": "/\"_etag\"/?"
+                      }
+                    ]
+                  },
+                  "defaultTtl": -1
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('name'), 'kratos-agent')]"
+              ]
+            },
+            {
               "type": "Microsoft.Network/privateEndpoints",
               "apiVersion": "2023-09-01",
               "name": "[format('{0}-pe', parameters('name'))]",
@@ -745,6 +913,47 @@
               },
               "dependsOn": [
                 "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('name'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/privateDnsZones",
+              "apiVersion": "2020-06-01",
+              "name": "privatelink.documents.azure.com",
+              "location": "global",
+              "tags": "[parameters('tags')]"
+            },
+            {
+              "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+              "apiVersion": "2020-06-01",
+              "name": "[format('{0}/{1}', 'privatelink.documents.azure.com', format('{0}-vnet-link', parameters('name')))]",
+              "location": "global",
+              "properties": {
+                "virtualNetwork": {
+                  "id": "[parameters('vnetId')]"
+                },
+                "registrationEnabled": false
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.documents.azure.com')]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+              "apiVersion": "2023-09-01",
+              "name": "[format('{0}/{1}', format('{0}-pe', parameters('name')), 'default')]",
+              "properties": {
+                "privateDnsZoneConfigs": [
+                  {
+                    "name": "cosmos-dns",
+                    "properties": {
+                      "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.documents.azure.com')]"
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.documents.azure.com')]",
+                "[resourceId('Microsoft.Network/privateEndpoints', format('{0}-pe', parameters('name')))]"
               ]
             }
           ],
@@ -772,7 +981,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "ai-search",
       "resourceGroup": "[format('rg-{0}', parameters('environmentName'))]",
       "properties": {
@@ -789,7 +998,10 @@
             "value": "[variables('tags')]"
           },
           "subnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'network'), '2022-09-01').outputs.privateEndpointSubnetId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'network'), '2025-04-01').outputs.privateEndpointSubnetId.value]"
+          },
+          "vnetId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'network'), '2025-04-01').outputs.id.value]"
           }
         },
         "template": {
@@ -798,8 +1010,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "17592914138369338215"
+              "version": "0.43.8.12551",
+              "templateHash": "1583775518594609852"
             }
           },
           "parameters": {
@@ -826,6 +1038,12 @@
               "type": "string",
               "metadata": {
                 "description": "Subnet ID for private endpoint"
+              }
+            },
+            "vnetId": {
+              "type": "string",
+              "metadata": {
+                "description": "VNet ID for DNS zone link"
               }
             }
           },
@@ -876,6 +1094,47 @@
               "dependsOn": [
                 "[resourceId('Microsoft.Search/searchServices', parameters('name'))]"
               ]
+            },
+            {
+              "type": "Microsoft.Network/privateDnsZones",
+              "apiVersion": "2020-06-01",
+              "name": "privatelink.search.windows.net",
+              "location": "global",
+              "tags": "[parameters('tags')]"
+            },
+            {
+              "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+              "apiVersion": "2020-06-01",
+              "name": "[format('{0}/{1}', 'privatelink.search.windows.net', format('{0}-vnet-link', parameters('name')))]",
+              "location": "global",
+              "properties": {
+                "virtualNetwork": {
+                  "id": "[parameters('vnetId')]"
+                },
+                "registrationEnabled": false
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.search.windows.net')]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+              "apiVersion": "2023-09-01",
+              "name": "[format('{0}/{1}', format('{0}-pe', parameters('name')), 'default')]",
+              "properties": {
+                "privateDnsZoneConfigs": [
+                  {
+                    "name": "search-dns",
+                    "properties": {
+                      "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.search.windows.net')]"
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', 'privatelink.search.windows.net')]",
+                "[resourceId('Microsoft.Network/privateEndpoints', format('{0}-pe', parameters('name')))]"
+              ]
             }
           ],
           "outputs": {
@@ -901,7 +1160,397 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
+      "name": "ai-foundry",
+      "resourceGroup": "[format('rg-{0}', parameters('environmentName'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": "[if(not(empty(parameters('aiServicesName'))), createObject('value', parameters('aiServicesName')), createObject('value', format('{0}{1}', variables('abbrs').cognitiveServicesAccounts, variables('resourceToken'))))]",
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "tags": {
+            "value": "[variables('tags')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.43.8.12551",
+              "templateHash": "7670876345307828086"
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the Microsoft Foundry resource"
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Location"
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Tags"
+              }
+            },
+            "projectName": {
+              "type": "string",
+              "defaultValue": "[format('{0}-proj', parameters('name'))]",
+              "metadata": {
+                "description": "Name of the Foundry project"
+              }
+            },
+            "modelDeploymentName": {
+              "type": "string",
+              "defaultValue": "gpt-54",
+              "metadata": {
+                "description": "Name of the GPT model deployment"
+              }
+            },
+            "modelName": {
+              "type": "string",
+              "defaultValue": "gpt-5.4",
+              "metadata": {
+                "description": "Model name to deploy"
+              }
+            },
+            "modelVersion": {
+              "type": "string",
+              "defaultValue": "2026-03-05",
+              "metadata": {
+                "description": "Model version"
+              }
+            },
+            "modelCapacity": {
+              "type": "int",
+              "defaultValue": 350,
+              "metadata": {
+                "description": "Deployment SKU capacity (thousands of tokens per minute)"
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.CognitiveServices/accounts",
+              "apiVersion": "2025-06-01",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "kind": "AIServices",
+              "sku": {
+                "name": "S0"
+              },
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "properties": {
+                "allowProjectManagement": true,
+                "customSubDomainName": "[parameters('name')]",
+                "publicNetworkAccess": "Enabled",
+                "disableLocalAuth": true
+              }
+            },
+            {
+              "type": "Microsoft.CognitiveServices/accounts/projects",
+              "apiVersion": "2025-06-01",
+              "name": "[format('{0}/{1}', parameters('name'), parameters('projectName'))]",
+              "location": "[parameters('location')]",
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "properties": {},
+              "dependsOn": [
+                "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.CognitiveServices/accounts/deployments",
+              "apiVersion": "2025-06-01",
+              "name": "[format('{0}/{1}', parameters('name'), parameters('modelDeploymentName'))]",
+              "sku": {
+                "name": "GlobalStandard",
+                "capacity": "[parameters('modelCapacity')]"
+              },
+              "properties": {
+                "model": {
+                  "format": "OpenAI",
+                  "name": "[parameters('modelName')]",
+                  "version": "[parameters('modelVersion')]"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "id": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('name'))]"
+            },
+            "name": {
+              "type": "string",
+              "value": "[parameters('name')]"
+            },
+            "endpoint": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('name')), '2025-06-01').endpoint]"
+            },
+            "modelDeploymentName": {
+              "type": "string",
+              "value": "[parameters('modelDeploymentName')]"
+            },
+            "projectName": {
+              "type": "string",
+              "value": "[parameters('projectName')]"
+            },
+            "projectEndpoint": {
+              "type": "string",
+              "value": "[format('{0}api/projects/{1}', reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('name')), '2025-06-01').endpoint, parameters('projectName'))]"
+            },
+            "principalId": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.CognitiveServices/accounts', parameters('name')), '2025-06-01', 'full').identity.principalId]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', format('rg-{0}', parameters('environmentName')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "bing-search",
+      "resourceGroup": "[format('rg-{0}', parameters('environmentName'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": "[if(not(empty(parameters('bingSearchName'))), createObject('value', parameters('bingSearchName')), createObject('value', format('{0}{1}', variables('abbrs').bingSearchAccounts, variables('resourceToken'))))]",
+          "tags": {
+            "value": "[variables('tags')]"
+          },
+          "keyVaultName": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'key-vault'), '2025-04-01').outputs.name.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.43.8.12551",
+              "templateHash": "3807904905790651143"
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the Bing Grounding resource"
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Tags"
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "Key Vault name to store the API key"
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Bing/accounts",
+              "apiVersion": "2020-06-10",
+              "name": "[parameters('name')]",
+              "location": "global",
+              "tags": "[parameters('tags')]",
+              "kind": "Bing.Grounding",
+              "sku": {
+                "name": "G1"
+              }
+            },
+            {
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2023-07-01",
+              "name": "[format('{0}/{1}', parameters('keyVaultName'), 'bing-search-api-key')]",
+              "properties": {
+                "value": "[listKeys(resourceId('Microsoft.Bing/accounts', parameters('name')), '2020-06-10').key1]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Bing/accounts', parameters('name'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "id": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Bing/accounts', parameters('name'))]"
+            },
+            "name": {
+              "type": "string",
+              "value": "[parameters('name')]"
+            },
+            "endpoint": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Bing/accounts', parameters('name')), '2020-06-10').endpoint]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'key-vault')]",
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', format('rg-{0}', parameters('environmentName')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "blob-storage",
+      "resourceGroup": "[format('rg-{0}', parameters('environmentName'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": "[if(not(empty(parameters('storageAccountName'))), createObject('value', parameters('storageAccountName')), createObject('value', format('{0}{1}', variables('abbrs').storageAccounts, variables('resourceToken'))))]",
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "tags": {
+            "value": "[variables('tags')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.43.8.12551",
+              "templateHash": "3607413465083305797"
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the Storage Account"
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Location"
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Tags"
+              }
+            },
+            "skillsContainerName": {
+              "type": "string",
+              "defaultValue": "skills",
+              "metadata": {
+                "description": "Name of the blob container for skills"
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "apiVersion": "2023-05-01",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "kind": "StorageV2",
+              "sku": {
+                "name": "Standard_LRS"
+              },
+              "properties": {
+                "accessTier": "Hot",
+                "allowBlobPublicAccess": false,
+                "allowSharedKeyAccess": false,
+                "minimumTlsVersion": "TLS1_2",
+                "supportsHttpsTrafficOnly": true,
+                "networkAcls": {
+                  "defaultAction": "Allow",
+                  "bypass": "AzureServices"
+                }
+              }
+            },
+            {
+              "type": "Microsoft.Storage/storageAccounts/blobServices",
+              "apiVersion": "2023-05-01",
+              "name": "[format('{0}/{1}', parameters('name'), 'default')]",
+              "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+              "apiVersion": "2023-05-01",
+              "name": "[format('{0}/{1}/{2}', parameters('name'), 'default', parameters('skillsContainerName'))]",
+              "properties": {
+                "publicAccess": "None"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/blobServices', parameters('name'), 'default')]"
+              ]
+            }
+          ],
+          "outputs": {
+            "id": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('name'))]"
+            },
+            "name": {
+              "type": "string",
+              "value": "[parameters('name')]"
+            },
+            "endpoint": {
+              "type": "string",
+              "value": "[format('https://{0}.blob.{1}', parameters('name'), environment().suffixes.storage)]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', format('rg-{0}', parameters('environmentName')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
       "name": "container-registry",
       "resourceGroup": "[format('rg-{0}', parameters('environmentName'))]",
       "properties": {
@@ -924,8 +1573,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "12121574313923276256"
+              "version": "0.43.8.12551",
+              "templateHash": "4824718499454323171"
             }
           },
           "parameters": {
@@ -986,7 +1635,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "container-apps-env",
       "resourceGroup": "[format('rg-{0}', parameters('environmentName'))]",
       "properties": {
@@ -1003,10 +1652,10 @@
             "value": "[variables('tags')]"
           },
           "logAnalyticsWorkspaceId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'log-analytics'), '2022-09-01').outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'log-analytics'), '2025-04-01').outputs.id.value]"
           },
           "subnetId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'network'), '2022-09-01').outputs.containerAppsSubnetId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'network'), '2025-04-01').outputs.containerAppsSubnetId.value]"
           }
         },
         "template": {
@@ -1015,8 +1664,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "4027003723698484240"
+              "version": "0.43.8.12551",
+              "templateHash": "12368784576413182182"
             }
           },
           "parameters": {
@@ -1099,7 +1748,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "agent-service",
       "resourceGroup": "[format('rg-{0}', parameters('environmentName'))]",
       "properties": {
@@ -1116,28 +1765,46 @@
             "value": "[variables('tags')]"
           },
           "containerAppsEnvId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-apps-env'), '2022-09-01').outputs.id.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-apps-env'), '2025-04-01').outputs.id.value]"
           },
           "containerRegistryName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-registry'), '2022-09-01').outputs.name.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-registry'), '2025-04-01').outputs.name.value]"
           },
           "appInsightsConnectionString": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'app-insights'), '2022-09-01').outputs.connectionString.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'app-insights'), '2025-04-01').outputs.connectionString.value]"
+          },
+          "appInsightsResourceId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'app-insights'), '2025-04-01').outputs.id.value]"
           },
           "cosmosDbEndpoint": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'cosmos-db'), '2022-09-01').outputs.endpoint.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'cosmos-db'), '2025-04-01').outputs.endpoint.value]"
           },
           "aiSearchEndpoint": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-search'), '2022-09-01').outputs.endpoint.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-search'), '2025-04-01').outputs.endpoint.value]"
           },
           "keyVaultUri": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'key-vault'), '2022-09-01').outputs.uri.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'key-vault'), '2025-04-01').outputs.uri.value]"
           },
           "foundryEndpoint": {
-            "value": "[parameters('foundryEndpoint')]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-foundry'), '2025-04-01').outputs.endpoint.value]"
           },
           "foundryModelDeployment": {
-            "value": "[parameters('foundryModelDeployment')]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-foundry'), '2025-04-01').outputs.modelDeploymentName.value]"
+          },
+          "foundryProjectName": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-foundry'), '2025-04-01').outputs.projectName.value]"
+          },
+          "foundryProjectEndpoint": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-foundry'), '2025-04-01').outputs.projectEndpoint.value]"
+          },
+          "bingSearchEndpoint": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'bing-search'), '2025-04-01').outputs.endpoint.value]"
+          },
+          "blobStorageEndpoint": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'blob-storage'), '2025-04-01').outputs.endpoint.value]"
+          },
+          "staticWebAppUrl": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'static-web-app'), '2025-04-01').outputs.url.value]"
           }
         },
         "template": {
@@ -1146,8 +1813,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "2348234865450473652"
+              "version": "0.43.8.12551",
+              "templateHash": "14003821261957030137"
             }
           },
           "parameters": {
@@ -1188,6 +1855,13 @@
                 "description": "App Insights connection string"
               }
             },
+            "appInsightsResourceId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "App Insights resource ID (for resource-scoped KQL queries from the Traces panel)"
+              }
+            },
             "cosmosDbEndpoint": {
               "type": "string",
               "metadata": {
@@ -1217,9 +1891,73 @@
               "metadata": {
                 "description": "Foundry model deployment name"
               }
+            },
+            "bingSearchEndpoint": {
+              "type": "string",
+              "metadata": {
+                "description": "Bing Search endpoint"
+              }
+            },
+            "foundryProjectName": {
+              "type": "string",
+              "metadata": {
+                "description": "Foundry project name"
+              }
+            },
+            "foundryProjectEndpoint": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Foundry project endpoint (e.g. https://host/api/projects/proj)"
+              }
+            },
+            "foundryAgentName": {
+              "type": "string",
+              "defaultValue": "kratos-agent",
+              "metadata": {
+                "description": "Hosted agent name deployed in Foundry"
+              }
+            },
+            "blobStorageEndpoint": {
+              "type": "string",
+              "metadata": {
+                "description": "Azure Blob Storage endpoint for skills"
+              }
+            },
+            "staticWebAppUrl": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Static Web App URL for CORS (e.g. https://xxx.azurestaticapps.net)"
+              }
             }
           },
+          "variables": {
+            "acrPullRoleId": "7f951dda-4ed3-4680-a7ca-43fe172d538d",
+            "acrName": "[replace(parameters('containerRegistryName'), '-', '')]"
+          },
           "resources": [
+            {
+              "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+              "apiVersion": "2023-01-31",
+              "name": "[format('{0}-acr-pull', parameters('name'))]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]"
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', variables('acrName'))]",
+              "name": "[guid(resourceId('Microsoft.ContainerRegistry/registries', variables('acrName')), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-acr-pull', parameters('name'))), variables('acrPullRoleId'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('acrPullRoleId'))]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-acr-pull', parameters('name'))), '2023-01-31').principalId]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-acr-pull', parameters('name')))]"
+              ]
+            },
             {
               "type": "Microsoft.App/containerApps",
               "apiVersion": "2024-03-01",
@@ -1227,23 +1965,33 @@
               "location": "[parameters('location')]",
               "tags": "[union(parameters('tags'), createObject('azd-service-name', 'agent-service'))]",
               "identity": {
-                "type": "SystemAssigned"
+                "type": "SystemAssigned, UserAssigned",
+                "userAssignedIdentities": {
+                  "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-acr-pull', parameters('name'))))]": {}
+                }
               },
               "properties": {
                 "managedEnvironmentId": "[parameters('containerAppsEnvId')]",
                 "configuration": {
                   "activeRevisionsMode": "Single",
+                  "registries": [
+                    {
+                      "server": "[format('{0}.azurecr.io', variables('acrName'))]",
+                      "identity": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-acr-pull', parameters('name')))]"
+                    }
+                  ],
                   "ingress": {
                     "external": true,
                     "targetPort": 8000,
                     "transport": "http",
                     "corsPolicy": {
-                      "allowedOrigins": [
-                        "*"
-                      ],
+                      "allowedOrigins": "[if(empty(parameters('staticWebAppUrl')), createArray('*'), createArray(parameters('staticWebAppUrl')))]",
                       "allowedMethods": [
                         "GET",
                         "POST",
+                        "PUT",
+                        "PATCH",
+                        "DELETE",
                         "OPTIONS"
                       ],
                       "allowedHeaders": [
@@ -1251,13 +1999,7 @@
                       ],
                       "maxAge": 3600
                     }
-                  },
-                  "registries": [
-                    {
-                      "server": "[format('{0}.azurecr.io', replace(parameters('containerRegistryName'), '-', ''))]",
-                      "identity": "system"
-                    }
-                  ]
+                  }
                 },
                 "template": {
                   "containers": [
@@ -1274,11 +2016,15 @@
                           "value": "[parameters('appInsightsConnectionString')]"
                         },
                         {
+                          "name": "APPLICATION_INSIGHTS_RESOURCE_ID",
+                          "value": "[parameters('appInsightsResourceId')]"
+                        },
+                        {
                           "name": "COSMOS_DB_ENDPOINT",
                           "value": "[parameters('cosmosDbEndpoint')]"
                         },
                         {
-                          "name": "AI_SEARCH_ENDPOINT",
+                          "name": "AZURE_AI_SEARCH_ENDPOINT",
                           "value": "[parameters('aiSearchEndpoint')]"
                         },
                         {
@@ -1294,14 +2040,50 @@
                           "value": "[parameters('foundryModelDeployment')]"
                         },
                         {
+                          "name": "FOUNDRY_PROJECT_NAME",
+                          "value": "[parameters('foundryProjectName')]"
+                        },
+                        {
+                          "name": "FOUNDRY_PROJECT_ENDPOINT",
+                          "value": "[parameters('foundryProjectEndpoint')]"
+                        },
+                        {
+                          "name": "FOUNDRY_AGENT_NAME",
+                          "value": "[parameters('foundryAgentName')]"
+                        },
+                        {
+                          "name": "BING_SEARCH_ENDPOINT",
+                          "value": "[parameters('bingSearchEndpoint')]"
+                        },
+                        {
+                          "name": "BLOB_STORAGE_ENDPOINT",
+                          "value": "[parameters('blobStorageEndpoint')]"
+                        },
+                        {
                           "name": "OTEL_SERVICE_NAME",
                           "value": "kratos-agent-service"
+                        },
+                        {
+                          "name": "AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED",
+                          "value": "true"
+                        },
+                        {
+                          "name": "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT",
+                          "value": "true"
+                        },
+                        {
+                          "name": "ENVIRONMENT",
+                          "value": "production"
+                        },
+                        {
+                          "name": "ALLOWED_ORIGINS",
+                          "value": "[if(empty(parameters('staticWebAppUrl')), '*', parameters('staticWebAppUrl'))]"
                         }
                       ]
                     }
                   ],
                   "scale": {
-                    "minReplicas": 0,
+                    "minReplicas": 1,
                     "maxReplicas": 10,
                     "rules": [
                       {
@@ -1315,7 +2097,11 @@
                     ]
                   }
                 }
-              }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-acr-pull', parameters('name')))]",
+                "[extensionResourceId(resourceId('Microsoft.ContainerRegistry/registries', variables('acrName')), 'Microsoft.Authorization/roleAssignments', guid(resourceId('Microsoft.ContainerRegistry/registries', variables('acrName')), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-acr-pull', parameters('name'))), variables('acrPullRoleId')))]"
+              ]
             }
           ],
           "outputs": {
@@ -1339,18 +2125,183 @@
         }
       },
       "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-foundry')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-search')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'app-insights')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'bing-search')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'blob-storage')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-apps-env')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-registry')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'cosmos-db')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'key-vault')]",
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', format('rg-{0}', parameters('environmentName')))]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'static-web-app')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "ai-gateway",
+      "resourceGroup": "[format('rg-{0}', parameters('environmentName'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": "[if(not(empty(parameters('aiGatewayName'))), createObject('value', parameters('aiGatewayName')), createObject('value', format('{0}{1}-gateway', variables('abbrs').cognitiveServicesAccounts, variables('resourceToken'))))]",
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "tags": {
+            "value": "[variables('tags')]"
+          },
+          "publisherEmail": {
+            "value": "[parameters('apimPublisherEmail')]"
+          },
+          "appInsightsId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'app-insights'), '2025-04-01').outputs.id.value]"
+          },
+          "appInsightsInstrumentationKey": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'app-insights'), '2025-04-01').outputs.instrumentationKey.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.43.8.12551",
+              "templateHash": "13100327646458865897"
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the API Management service"
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Location"
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Tags"
+              }
+            },
+            "publisherEmail": {
+              "type": "string",
+              "metadata": {
+                "description": "Publisher email for APIM"
+              }
+            },
+            "publisherName": {
+              "type": "string",
+              "defaultValue": "[format('{0} AI Gateway', parameters('name'))]",
+              "metadata": {
+                "description": "Publisher name for APIM"
+              }
+            },
+            "appInsightsId": {
+              "type": "string",
+              "metadata": {
+                "description": "Application Insights resource ID"
+              }
+            },
+            "appInsightsInstrumentationKey": {
+              "type": "string",
+              "metadata": {
+                "description": "Application Insights instrumentation key"
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.ApiManagement/service",
+              "apiVersion": "2024-06-01-preview",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "sku": {
+                "name": "BasicV2",
+                "capacity": 1
+              },
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "properties": {
+                "publisherEmail": "[parameters('publisherEmail')]",
+                "publisherName": "[parameters('publisherName')]",
+                "customProperties": {
+                  "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10": "false",
+                  "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls11": "false"
+                }
+              }
+            },
+            {
+              "type": "Microsoft.ApiManagement/service/loggers",
+              "apiVersion": "2024-06-01-preview",
+              "name": "[format('{0}/{1}', parameters('name'), 'appinsights')]",
+              "properties": {
+                "loggerType": "applicationInsights",
+                "credentials": {
+                  "instrumentationKey": "[parameters('appInsightsInstrumentationKey')]"
+                },
+                "resourceId": "[parameters('appInsightsId')]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ApiManagement/service', parameters('name'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.ApiManagement/service/diagnostics",
+              "apiVersion": "2024-06-01-preview",
+              "name": "[format('{0}/{1}', parameters('name'), 'applicationinsights')]",
+              "properties": {
+                "loggerId": "[resourceId('Microsoft.ApiManagement/service/loggers', parameters('name'), 'appinsights')]",
+                "logClientIp": true,
+                "sampling": {
+                  "samplingType": "fixed",
+                  "percentage": 100
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ApiManagement/service', parameters('name'))]",
+                "[resourceId('Microsoft.ApiManagement/service/loggers', parameters('name'), 'appinsights')]"
+              ]
+            }
+          ],
+          "outputs": {
+            "id": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.ApiManagement/service', parameters('name'))]"
+            },
+            "name": {
+              "type": "string",
+              "value": "[parameters('name')]"
+            },
+            "gatewayUrl": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.ApiManagement/service', parameters('name')), '2024-06-01-preview').gatewayUrl]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'app-insights')]",
         "[subscriptionResourceId('Microsoft.Resources/resourceGroups', format('rg-{0}', parameters('environmentName')))]"
       ]
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "static-web-app",
       "resourceGroup": "[format('rg-{0}', parameters('environmentName'))]",
       "properties": {
@@ -1361,7 +2312,7 @@
         "parameters": {
           "name": "[if(not(empty(parameters('staticWebAppName'))), createObject('value', parameters('staticWebAppName')), createObject('value', format('{0}{1}', variables('abbrs').webStaticSites, variables('resourceToken'))))]",
           "location": {
-            "value": "[parameters('location')]"
+            "value": "[parameters('staticWebAppLocation')]"
           },
           "tags": {
             "value": "[variables('tags')]"
@@ -1373,8 +2324,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "8291152561202696392"
+              "version": "0.43.8.12551",
+              "templateHash": "8755442039802663217"
             }
           },
           "parameters": {
@@ -1437,7 +2388,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "role-assignments",
       "resourceGroup": "[format('rg-{0}', parameters('environmentName'))]",
       "properties": {
@@ -1447,19 +2398,28 @@
         "mode": "Incremental",
         "parameters": {
           "agentServicePrincipalId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'agent-service'), '2022-09-01').outputs.principalId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'agent-service'), '2025-04-01').outputs.principalId.value]"
           },
           "cosmosDbAccountName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'cosmos-db'), '2022-09-01').outputs.name.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'cosmos-db'), '2025-04-01').outputs.name.value]"
           },
           "aiSearchName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-search'), '2022-09-01').outputs.name.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-search'), '2025-04-01').outputs.name.value]"
+          },
+          "aiServicesName": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-foundry'), '2025-04-01').outputs.name.value]"
+          },
+          "aiServicesPrincipalId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-foundry'), '2025-04-01').outputs.principalId.value]"
           },
           "keyVaultName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'key-vault'), '2022-09-01').outputs.name.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'key-vault'), '2025-04-01').outputs.name.value]"
           },
-          "containerRegistryName": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-registry'), '2022-09-01').outputs.name.value]"
+          "storageAccountName": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'blob-storage'), '2025-04-01').outputs.name.value]"
+          },
+          "appInsightsName": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'app-insights'), '2025-04-01').outputs.name.value]"
           },
           "principalId": {
             "value": "[parameters('principalId')]"
@@ -1471,8 +2431,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.33.93.31351",
-              "templateHash": "11769998735710185669"
+              "version": "0.43.8.12551",
+              "templateHash": "10775664444361835591"
             }
           },
           "parameters": {
@@ -1494,16 +2454,35 @@
                 "description": "AI Search service name"
               }
             },
+            "aiServicesName": {
+              "type": "string",
+              "metadata": {
+                "description": "Microsoft Foundry resource name"
+              }
+            },
+            "aiServicesPrincipalId": {
+              "type": "string",
+              "metadata": {
+                "description": "Microsoft Foundry system-assigned principal ID (compile-time output from the ai-services module)"
+              }
+            },
             "keyVaultName": {
               "type": "string",
               "metadata": {
                 "description": "Key Vault name"
               }
             },
-            "containerRegistryName": {
+            "storageAccountName": {
               "type": "string",
               "metadata": {
-                "description": "Container Registry name"
+                "description": "Storage Account name for skills blob storage"
+              }
+            },
+            "appInsightsName": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Application Insights resource name (for Monitoring Reader RBAC)"
               }
             },
             "principalId": {
@@ -1518,7 +2497,12 @@
             "cosmosDbDataContributor": "00000000-0000-0000-0000-000000000002",
             "keyVaultSecretsUser": "4633458b-17de-408a-b874-0445c86b69e6",
             "searchIndexDataReader": "1407120a-92aa-4202-b7e9-c0e197c71c8f",
-            "acrPull": "7f951dda-4ed3-4680-a7ca-43fe172d538d"
+            "searchIndexDataContributor": "8ebe5a00-799e-43f5-93ac-243d3dce84a7",
+            "cognitiveServicesOpenAIUser": "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd",
+            "azureAIDeveloper": "64702f94-c441-49e6-a78b-ef80e0188fee",
+            "cognitiveServicesUser": "a97b65f3-24c7-4388-baec-2e87135dc908",
+            "storageBlobDataContributor": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
+            "monitoringReader": "43d0d8ad-25c7-4714-9337-8ba259a9fe05"
           },
           "resources": [
             {
@@ -1534,7 +2518,7 @@
             {
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.KeyVault/vaults/{0}', parameters('keyVaultName'))]",
+              "scope": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]",
               "name": "[guid(resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName')), parameters('agentServicePrincipalId'), variables('keyVaultSecretsUser'))]",
               "properties": {
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('keyVaultSecretsUser'))]",
@@ -1545,7 +2529,7 @@
             {
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.Search/searchServices/{0}', parameters('aiSearchName'))]",
+              "scope": "[resourceId('Microsoft.Search/searchServices', parameters('aiSearchName'))]",
               "name": "[guid(resourceId('Microsoft.Search/searchServices', parameters('aiSearchName')), parameters('agentServicePrincipalId'), variables('searchIndexDataReader'))]",
               "properties": {
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('searchIndexDataReader'))]",
@@ -1556,10 +2540,66 @@
             {
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.ContainerRegistry/registries/{0}', replace(parameters('containerRegistryName'), '-', ''))]",
-              "name": "[guid(resourceId('Microsoft.ContainerRegistry/registries', replace(parameters('containerRegistryName'), '-', '')), parameters('agentServicePrincipalId'), variables('acrPull'))]",
+              "scope": "[resourceId('Microsoft.Search/searchServices', parameters('aiSearchName'))]",
+              "name": "[guid(resourceId('Microsoft.Search/searchServices', parameters('aiSearchName')), parameters('agentServicePrincipalId'), variables('searchIndexDataContributor'))]",
               "properties": {
-                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('acrPull'))]",
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('searchIndexDataContributor'))]",
+                "principalId": "[parameters('agentServicePrincipalId')]",
+                "principalType": "ServicePrincipal"
+              }
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('aiServicesName'))]",
+              "name": "[guid(resourceId('Microsoft.CognitiveServices/accounts', parameters('aiServicesName')), parameters('agentServicePrincipalId'), variables('cognitiveServicesOpenAIUser'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('cognitiveServicesOpenAIUser'))]",
+                "principalId": "[parameters('agentServicePrincipalId')]",
+                "principalType": "ServicePrincipal"
+              }
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('aiServicesName'))]",
+              "name": "[guid(resourceId('Microsoft.CognitiveServices/accounts', parameters('aiServicesName')), parameters('agentServicePrincipalId'), variables('cognitiveServicesUser'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('cognitiveServicesUser'))]",
+                "principalId": "[parameters('agentServicePrincipalId')]",
+                "principalType": "ServicePrincipal"
+              }
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+              "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('agentServicePrincipalId'), variables('storageBlobDataContributor'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('storageBlobDataContributor'))]",
+                "principalId": "[parameters('agentServicePrincipalId')]",
+                "principalType": "ServicePrincipal"
+              }
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+              "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('aiServicesPrincipalId'), variables('storageBlobDataContributor'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('storageBlobDataContributor'))]",
+                "principalId": "[parameters('aiServicesPrincipalId')]",
+                "principalType": "ServicePrincipal"
+              }
+            },
+            {
+              "condition": "[not(empty(parameters('appInsightsName')))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.Insights/components', parameters('appInsightsName'))]",
+              "name": "[guid(resourceId('Microsoft.Insights/components', parameters('appInsightsName')), parameters('agentServicePrincipalId'), variables('monitoringReader'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('monitoringReader'))]",
                 "principalId": "[parameters('agentServicePrincipalId')]",
                 "principalType": "ServicePrincipal"
               }
@@ -1579,10 +2619,58 @@
               "condition": "[not(empty(parameters('principalId')))]",
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.KeyVault/vaults/{0}', parameters('keyVaultName'))]",
+              "scope": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]",
               "name": "[guid(resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName')), parameters('principalId'), variables('keyVaultSecretsUser'))]",
               "properties": {
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('keyVaultSecretsUser'))]",
+                "principalId": "[parameters('principalId')]",
+                "principalType": "User"
+              }
+            },
+            {
+              "condition": "[not(empty(parameters('principalId')))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('aiServicesName'))]",
+              "name": "[guid(resourceId('Microsoft.CognitiveServices/accounts', parameters('aiServicesName')), parameters('principalId'), variables('cognitiveServicesOpenAIUser'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('cognitiveServicesOpenAIUser'))]",
+                "principalId": "[parameters('principalId')]",
+                "principalType": "User"
+              }
+            },
+            {
+              "condition": "[not(empty(parameters('principalId')))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.CognitiveServices/accounts', parameters('aiServicesName'))]",
+              "name": "[guid(resourceId('Microsoft.CognitiveServices/accounts', parameters('aiServicesName')), parameters('principalId'), variables('cognitiveServicesUser'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('cognitiveServicesUser'))]",
+                "principalId": "[parameters('principalId')]",
+                "principalType": "User"
+              }
+            },
+            {
+              "condition": "[not(empty(parameters('principalId')))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+              "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('principalId'), variables('storageBlobDataContributor'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('storageBlobDataContributor'))]",
+                "principalId": "[parameters('principalId')]",
+                "principalType": "User"
+              }
+            },
+            {
+              "condition": "[not(empty(parameters('principalId')))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.Search/searchServices', parameters('aiSearchName'))]",
+              "name": "[guid(resourceId('Microsoft.Search/searchServices', parameters('aiSearchName')), parameters('principalId'), variables('searchIndexDataContributor'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('searchIndexDataContributor'))]",
                 "principalId": "[parameters('principalId')]",
                 "principalType": "User"
               }
@@ -1592,8 +2680,10 @@
       },
       "dependsOn": [
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'agent-service')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-foundry')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-search')]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-registry')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'app-insights')]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'blob-storage')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'cosmos-db')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'key-vault')]",
         "[subscriptionResourceId('Microsoft.Resources/resourceGroups', format('rg-{0}', parameters('environmentName')))]"
@@ -1607,47 +2697,67 @@
     },
     "AZURE_CONTAINER_APPS_ENV_NAME": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-apps-env'), '2022-09-01').outputs.name.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-apps-env'), '2025-04-01').outputs.name.value]"
     },
     "AZURE_CONTAINER_REGISTRY_NAME": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-registry'), '2022-09-01').outputs.name.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-registry'), '2025-04-01').outputs.name.value]"
     },
     "AZURE_CONTAINER_REGISTRY_ENDPOINT": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-registry'), '2022-09-01').outputs.loginServer.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'container-registry'), '2025-04-01').outputs.loginServer.value]"
     },
     "AZURE_COSMOS_DB_ENDPOINT": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'cosmos-db'), '2022-09-01').outputs.endpoint.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'cosmos-db'), '2025-04-01').outputs.endpoint.value]"
     },
     "AZURE_AI_SEARCH_ENDPOINT": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-search'), '2022-09-01').outputs.endpoint.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-search'), '2025-04-01').outputs.endpoint.value]"
     },
     "AZURE_KEY_VAULT_URI": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'key-vault'), '2022-09-01').outputs.uri.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'key-vault'), '2025-04-01').outputs.uri.value]"
     },
     "AZURE_APP_INSIGHTS_CONNECTION_STRING": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'app-insights'), '2022-09-01').outputs.connectionString.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'app-insights'), '2025-04-01').outputs.connectionString.value]"
     },
     "AZURE_STATIC_WEB_APP_URL": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'static-web-app'), '2022-09-01').outputs.url.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'static-web-app'), '2025-04-01').outputs.url.value]"
+    },
+    "AGENT_SERVICE_DIRECT_URL": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'agent-service'), '2025-04-01').outputs.url.value]"
     },
     "AGENT_SERVICE_URL": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'agent-service'), '2022-09-01').outputs.url.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'agent-service'), '2025-04-01').outputs.url.value]"
+    },
+    "AI_GATEWAY_URL": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-gateway'), '2025-04-01').outputs.gatewayUrl.value]"
     },
     "FOUNDRY_ENDPOINT": {
       "type": "string",
-      "value": "[parameters('foundryEndpoint')]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-foundry'), '2025-04-01').outputs.endpoint.value]"
     },
     "FOUNDRY_MODEL_DEPLOYMENT": {
       "type": "string",
-      "value": "[parameters('foundryModelDeployment')]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-foundry'), '2025-04-01').outputs.modelDeploymentName.value]"
+    },
+    "AZURE_AI_PROJECT_ENDPOINT": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'ai-foundry'), '2025-04-01').outputs.projectEndpoint.value]"
+    },
+    "AZURE_BLOB_STORAGE_ENDPOINT": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'blob-storage'), '2025-04-01').outputs.endpoint.value]"
+    },
+    "AZURE_BLOB_STORAGE_ACCOUNT_NAME": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('rg-{0}', parameters('environmentName'))), 'Microsoft.Resources/deployments', 'blob-storage'), '2025-04-01').outputs.name.value]"
     }
   }
 }

--- a/infra/modules/agent-service.bicep
+++ b/infra/modules/agent-service.bicep
@@ -16,6 +16,9 @@ param containerRegistryName string
 @description('App Insights connection string')
 param appInsightsConnectionString string
 
+@description('App Insights resource ID (for resource-scoped KQL queries from the Traces panel)')
+param appInsightsResourceId string = ''
+
 @description('Cosmos DB endpoint')
 param cosmosDbEndpoint string
 
@@ -123,6 +126,7 @@ resource agentService 'Microsoft.App/containerApps@2024-03-01' = {
           }
           env: [
             { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsightsConnectionString }
+            { name: 'APPLICATION_INSIGHTS_RESOURCE_ID', value: appInsightsResourceId }
             { name: 'COSMOS_DB_ENDPOINT', value: cosmosDbEndpoint }
             { name: 'AZURE_AI_SEARCH_ENDPOINT', value: aiSearchEndpoint }
             { name: 'KEY_VAULT_URI', value: keyVaultUri }

--- a/infra/modules/ai-services.bicep
+++ b/infra/modules/ai-services.bicep
@@ -73,3 +73,4 @@ output endpoint string = aiFoundry.properties.endpoint
 output modelDeploymentName string = modelDeployment.name
 output projectName string = project.name
 output projectEndpoint string = '${aiFoundry.properties.endpoint}api/projects/${project.name}'
+output principalId string = aiFoundry.identity.principalId

--- a/infra/modules/role-assignments.bicep
+++ b/infra/modules/role-assignments.bicep
@@ -16,6 +16,9 @@ param keyVaultName string
 @description('Storage Account name for skills blob storage')
 param storageAccountName string
 
+@description('Application Insights resource name (for Monitoring Reader RBAC)')
+param appInsightsName string = ''
+
 @description('Deploying user principal ID')
 param principalId string = ''
 
@@ -28,6 +31,7 @@ var cognitiveServicesOpenAIUser = '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'
 var azureAIDeveloper = '64702f94-c441-49e6-a78b-ef80e0188fee'
 var cognitiveServicesUser = 'a97b65f3-24c7-4388-baec-2e87135dc908'
 var storageBlobDataContributor = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+var monitoringReader = '43d0d8ad-25c7-4714-9337-8ba259a9fe05'
 
 // ─── References ───
 resource cosmosDb 'Microsoft.DocumentDB/databaseAccounts@2024-02-15-preview' existing = {
@@ -48,6 +52,10 @@ resource aiServices 'Microsoft.CognitiveServices/accounts@2024-10-01' existing =
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
   name: storageAccountName
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = if (!empty(appInsightsName)) {
+  name: appInsightsName
 }
 
 // ─── Agent Service → Cosmos DB ───
@@ -137,6 +145,17 @@ resource aiServicesStorageRole 'Microsoft.Authorization/roleAssignments@2022-04-
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributor)
     principalId: aiServices.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// ─── Agent Service → Application Insights (Monitoring Reader for Traces panel KQL) ───
+resource agentAppInsightsRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(appInsightsName)) {
+  name: guid(appInsights.id, agentServicePrincipalId, monitoringReader)
+  scope: appInsights
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', monitoringReader)
+    principalId: agentServicePrincipalId
     principalType: 'ServicePrincipal'
   }
 }

--- a/infra/modules/role-assignments.bicep
+++ b/infra/modules/role-assignments.bicep
@@ -10,6 +10,9 @@ param aiSearchName string
 @description('Microsoft Foundry resource name')
 param aiServicesName string
 
+@description('Microsoft Foundry system-assigned principal ID (compile-time output from the ai-services module)')
+param aiServicesPrincipalId string
+
 @description('Key Vault name')
 param keyVaultName string
 
@@ -140,11 +143,11 @@ resource agentStorageRole 'Microsoft.Authorization/roleAssignments@2022-04-01' =
 
 // ─── AI Services (Hosted Agent) → Blob Storage ───
 resource aiServicesStorageRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(storageAccount.id, aiServices.identity.principalId, storageBlobDataContributor)
+  name: guid(storageAccount.id, aiServicesPrincipalId, storageBlobDataContributor)
   scope: storageAccount
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributor)
-    principalId: aiServices.identity.principalId
+    principalId: aiServicesPrincipalId
     principalType: 'ServicePrincipal'
   }
 }

--- a/infra/modules/role-assignments.bicep
+++ b/infra/modules/role-assignments.bicep
@@ -22,6 +22,9 @@ param storageAccountName string
 @description('Application Insights resource name (for Monitoring Reader RBAC)')
 param appInsightsName string = ''
 
+@description('Container Registry name (for AcrPull grant to the Foundry hosted-agent MI)')
+param containerRegistryName string = ''
+
 @description('Deploying user principal ID')
 param principalId string = ''
 
@@ -35,6 +38,7 @@ var azureAIDeveloper = '64702f94-c441-49e6-a78b-ef80e0188fee'
 var cognitiveServicesUser = 'a97b65f3-24c7-4388-baec-2e87135dc908'
 var storageBlobDataContributor = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
 var monitoringReader = '43d0d8ad-25c7-4714-9337-8ba259a9fe05'
+var acrPull = '7f951dda-4ed3-4680-a7ca-43fe172d538d'
 
 // ─── References ───
 resource cosmosDb 'Microsoft.DocumentDB/databaseAccounts@2024-02-15-preview' existing = {
@@ -59,6 +63,10 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing 
 
 resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = if (!empty(appInsightsName)) {
   name: appInsightsName
+}
+
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' existing = if (!empty(containerRegistryName)) {
+  name: containerRegistryName
 }
 
 // ─── Agent Service → Cosmos DB ───
@@ -159,6 +167,17 @@ resource agentAppInsightsRole 'Microsoft.Authorization/roleAssignments@2022-04-0
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', monitoringReader)
     principalId: agentServicePrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// ─── AI Services (Foundry hosted-agent MI) → ACR (AcrPull, so Foundry can pull the hosted-agent image) ───
+resource aiServicesAcrPullRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(containerRegistryName)) {
+  name: guid(containerRegistry.id, aiServicesPrincipalId, acrPull)
+  scope: containerRegistry
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', acrPull)
+    principalId: aiServicesPrincipalId
     principalType: 'ServicePrincipal'
   }
 }

--- a/scripts/fetch_traces.py
+++ b/scripts/fetch_traces.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Fetch trace operations from the backend (App Insights waterfall).
+
+Usage:
+    python scripts/fetch_traces.py                                 # list recent ops
+    python scripts/fetch_traces.py --use-case insurance --hours 24
+    python scripts/fetch_traces.py --conversation-id abc123
+    python scripts/fetch_traces.py --run-id 20260101T120000Z
+    python scripts/fetch_traces.py --operation-id 9fe9...           # full waterfall
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+import httpx
+
+BACKEND_URL = os.environ.get("BACKEND_URL", "http://localhost:8000").rstrip("/")
+ADMIN_TOKEN = os.environ.get("ADMIN_TOKEN")
+
+
+def _headers() -> dict[str, str]:
+    h: dict[str, str] = {}
+    if ADMIN_TOKEN:
+        h["authorization"] = f"Bearer {ADMIN_TOKEN}"
+    return h
+
+
+def list_ops(**filters: str | int | None) -> dict:
+    params = {k: v for k, v in filters.items() if v is not None}
+    url = f"{BACKEND_URL}/api/traces/operations"
+    with httpx.Client(timeout=60.0) as client:
+        r = client.get(url, params=params, headers=_headers())
+    r.raise_for_status()
+    return r.json()
+
+
+def get_op(operation_id: str, hours: int) -> dict:
+    url = f"{BACKEND_URL}/api/traces/operations/{operation_id}"
+    with httpx.Client(timeout=60.0) as client:
+        r = client.get(url, params={"lookback_hours": hours}, headers=_headers())
+    r.raise_for_status()
+    return r.json()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--use-case")
+    p.add_argument("--conversation-id")
+    p.add_argument("--run-id")
+    p.add_argument("--operation-id", help="Fetch full waterfall for this op id")
+    p.add_argument("--hours", type=int, default=24)
+    p.add_argument("--limit", type=int, default=50)
+    args = p.parse_args()
+
+    try:
+        if args.operation_id:
+            data = get_op(args.operation_id, args.hours)
+        else:
+            data = list_ops(
+                use_case=args.use_case,
+                conversation_id=args.conversation_id,
+                run_id=args.run_id,
+                hours=args.hours,
+                limit=args.limit,
+            )
+    except httpx.HTTPStatusError as e:
+        print(f"✗ HTTP {e.response.status_code}: {e.response.text[:400]}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(data, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_evals.py
+++ b/scripts/generate_evals.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Generate eval scenarios for one (or all) use-cases via the running backend.
+
+Usage:
+    # Local backend (default http://localhost:8000):
+    python scripts/generate_evals.py --use-case insurance --count 5
+
+    # Deployed backend:
+    BACKEND_URL=https://kratos-be.example.com python scripts/generate_evals.py --all
+
+    # Save generated scenarios into the repo (not just echo to stdout):
+    python scripts/generate_evals.py --use-case insurance --save
+
+Requires the backend's ``EvalService`` to be reachable. Auth: set
+ADMIN_TOKEN (passed as bearer) only if ``ADMIN_AUTH_ENABLED=true`` on the
+backend; otherwise endpoints are open.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+USE_CASES_DIR = REPO_ROOT / "use-cases"
+BACKEND_URL = os.environ.get("BACKEND_URL", "http://localhost:8000").rstrip("/")
+ADMIN_TOKEN = os.environ.get("ADMIN_TOKEN")
+
+ALL_USE_CASES = [
+    "generic",
+    "insurance",
+    "retail-banking",
+    "sales-account-review",
+    "wealth-management",
+]
+
+
+def _headers() -> dict[str, str]:
+    h = {"content-type": "application/json"}
+    if ADMIN_TOKEN:
+        h["authorization"] = f"Bearer {ADMIN_TOKEN}"
+    return h
+
+
+def generate_for(use_case: str, count: int, instructions: str) -> list[dict[str, Any]]:
+    url = f"{BACKEND_URL}/api/use-cases/{use_case}/evals/scenarios/generate"
+    payload = {"count": count, "instructions": instructions}
+    with httpx.Client(timeout=300.0) as client:
+        r = client.post(url, json=payload, headers=_headers())
+    r.raise_for_status()
+    return r.json().get("scenarios", [])
+
+
+def save_scenarios(use_case: str, scenarios: list[dict[str, Any]]) -> None:
+    target_dir = USE_CASES_DIR / use_case / "evals" / "scenarios"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for s in scenarios:
+        name = s.get("name", "").strip()
+        if not name:
+            print(f"  ! skipping scenario without 'name': {s!r}", file=sys.stderr)
+            continue
+        path = target_dir / f"{name}.json"
+        path.write_text(json.dumps(s, indent=2) + "\n", encoding="utf-8")
+        print(f"  ✔ saved {path.relative_to(REPO_ROOT)}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--use-case", help="One of: " + ", ".join(ALL_USE_CASES))
+    group.add_argument("--all", action="store_true", help="Run for every use-case")
+    parser.add_argument("--count", type=int, default=5, help="Scenarios per use-case (default 5)")
+    parser.add_argument("--instructions", default="", help="Extra LLM hints")
+    parser.add_argument("--save", action="store_true", help="Persist into use-cases/<uc>/evals/scenarios/")
+    args = parser.parse_args()
+
+    targets = ALL_USE_CASES if args.all else [args.use_case]
+    for uc in targets:
+        if uc not in ALL_USE_CASES:
+            print(f"Unknown use-case: {uc}", file=sys.stderr)
+            return 2
+        print(f"→ Generating {args.count} scenarios for '{uc}'…")
+        try:
+            scenarios = generate_for(uc, args.count, args.instructions)
+        except httpx.HTTPStatusError as e:
+            print(f"  ✗ HTTP {e.response.status_code}: {e.response.text[:400]}", file=sys.stderr)
+            return 1
+        except httpx.HTTPError as e:
+            print(f"  ✗ {type(e).__name__}: {e}", file=sys.stderr)
+            return 1
+        print(f"  Got {len(scenarios)} scenarios.")
+        if args.save:
+            save_scenarios(uc, scenarios)
+        else:
+            print(json.dumps(scenarios, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Run evals for a use-case against the running backend.
+
+Usage:
+    # Validation mode (in-process invoke + score, fast):
+    python scripts/run_evals.py --use-case insurance --mode validation
+
+    # Foundry mode (cloud eval, slower):
+    python scripts/run_evals.py --use-case insurance --mode foundry
+
+    # Run only specific scenarios:
+    python scripts/run_evals.py --use-case insurance --scenarios load-customer-profile,policy-wording-lookup
+
+Polls until the run completes and prints a summary table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from typing import Any
+
+import httpx
+
+BACKEND_URL = os.environ.get("BACKEND_URL", "http://localhost:8000").rstrip("/")
+ADMIN_TOKEN = os.environ.get("ADMIN_TOKEN")
+POLL_INTERVAL_S = 5
+POLL_TIMEOUT_S = 60 * 30
+
+
+def _headers() -> dict[str, str]:
+    h = {"content-type": "application/json"}
+    if ADMIN_TOKEN:
+        h["authorization"] = f"Bearer {ADMIN_TOKEN}"
+    return h
+
+
+def start_run(use_case: str, mode: str, scenario_names: list[str] | None) -> dict[str, Any]:
+    url = f"{BACKEND_URL}/api/use-cases/{use_case}/evals/run"
+    payload: dict[str, Any] = {"mode": mode}
+    if scenario_names:
+        payload["scenario_names"] = scenario_names
+    with httpx.Client(timeout=60.0) as client:
+        r = client.post(url, json=payload, headers=_headers())
+    r.raise_for_status()
+    return r.json()
+
+
+def get_run(use_case: str, run_id: str) -> dict[str, Any]:
+    url = f"{BACKEND_URL}/api/use-cases/{use_case}/evals/runs/{run_id}"
+    with httpx.Client(timeout=30.0) as client:
+        r = client.get(url, headers=_headers())
+    r.raise_for_status()
+    return r.json()
+
+
+def poll(use_case: str, run_id: str) -> dict[str, Any]:
+    deadline = time.time() + POLL_TIMEOUT_S
+    last_status = ""
+    while time.time() < deadline:
+        run = get_run(use_case, run_id)
+        status = run.get("status", "")
+        if status != last_status:
+            print(f"  status={status}")
+            last_status = status
+        if status in ("completed", "failed", "cancelled"):
+            return run
+        time.sleep(POLL_INTERVAL_S)
+    raise TimeoutError(f"Run {run_id} did not finish within {POLL_TIMEOUT_S}s")
+
+
+def print_summary(run: dict[str, Any]) -> None:
+    print()
+    print(f"Run:      {run.get('run_id')}")
+    print(f"Use-case: {run.get('use_case')}")
+    print(f"Mode:     {run.get('mode')}")
+    print(f"Status:   {run.get('status')}")
+
+    foundry = run.get("foundry") or {}
+    if foundry.get("report_url"):
+        print(f"Foundry:  {foundry['report_url']}")
+
+    results = run.get("results", []) or []
+    if not results:
+        print("(no per-scenario results)")
+        return
+
+    print()
+    print(f"{'scenario':<40} {'status':<10} avg")
+    print("-" * 65)
+    for r in results:
+        scores = r.get("scores") or {}
+        numeric = [v for v in scores.values() if isinstance(v, (int, float))]
+        avg = (sum(numeric) / len(numeric)) if numeric else None
+        avg_str = f"{avg:.2f}" if avg is not None else "n/a"
+        print(f"{r.get('scenario_name', ''):<40} {r.get('status', ''):<10} {avg_str}")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--use-case", required=True)
+    p.add_argument("--mode", choices=["validation", "foundry"], default="validation")
+    p.add_argument("--scenarios", help="Comma-separated scenario names. Default: all.")
+    args = p.parse_args()
+
+    scenario_names = [s.strip() for s in args.scenarios.split(",")] if args.scenarios else None
+
+    print(f"→ Starting {args.mode} run for '{args.use_case}'…")
+    try:
+        run = start_run(args.use_case, args.mode, scenario_names)
+    except httpx.HTTPStatusError as e:
+        print(f"✗ HTTP {e.response.status_code}: {e.response.text[:400]}", file=sys.stderr)
+        return 1
+
+    run_id = run.get("run_id")
+    if not run_id:
+        print(f"✗ No run_id in response: {run}", file=sys.stderr)
+        return 1
+    print(f"  run_id={run_id}")
+
+    try:
+        final = poll(args.use_case, run_id)
+    except TimeoutError as e:
+        print(f"✗ {e}", file=sys.stderr)
+        return 1
+
+    print_summary(final)
+    return 0 if final.get("status") == "completed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -67,6 +67,20 @@ class Settings(BaseSettings):
     local_data_dir: str = ".local"
     blob_storage_connection_string: str = ""  # set for Azurite / local emulators
 
+    # ── Evals ────────────────────────────────────────────────────────────
+    # Optional override for the judge model used by azure-ai-evaluation
+    # (defaults to ``gpt-4.1`` per the foundry-evals skill recommendation —
+    # azure-ai-evaluation still expects ``max_tokens`` which gpt-5.x rejects).
+    eval_model: str = "gpt-4.1"
+    # App Insights ARM resource ID for resource-scoped KQL queries used by
+    # the Traces panel. Falls back to ``application_insights_workspace_id``
+    # (workspace-scoped) when the resource ID is not set.
+    application_insights_resource_id: str = ""
+    application_insights_workspace_id: str = ""
+    # Foundry project endpoint used by the eval submitter (overrides the
+    # value already on Settings if set explicitly for evals).
+    eval_foundry_project_endpoint: str = ""
+
     @property
     def is_local_mode(self) -> bool:
         """True when the backend should run without Azure services."""

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -19,16 +19,21 @@ from app.routers import (
     agent,
     conversations,
     copilot_studio,
+    evals,
     files,
     health,
     settings,
+    traces,
     use_cases,
 )
 from app.services.apm_service import ApmError, ApmService
 from app.services.blob_skill_service import BlobSkillService
 from app.services.cosmos_service import CosmosService
+from app.services.eval_service import EvalService
+from app.services.eval_storage import EvalStorage
 from app.services.foundry_agent_proxy import FoundryAgentProxy
 from app.services.skill_registry import SkillRegistry
+from app.services.traces_service import TracesService
 
 logging.basicConfig(
     level=logging.INFO,
@@ -138,10 +143,22 @@ async def lifespan(application: FastAPI) -> AsyncGenerator[None, None]:
     application.state.foundry_proxy = foundry_proxy
     application.state.settings = settings
 
+    # Initialize Eval storage + service (per-use-case scenarios, runs, results)
+    eval_storage = EvalStorage(blob_skill_service, local_base_dir=settings.apm_use_cases_root)
+    application.state.eval_storage = eval_storage
+    eval_service = EvalService(settings, eval_storage, registries)
+    application.state.eval_service = eval_service
+
+    # Initialize Traces service (App Insights waterfall queries)
+    traces_service = TracesService(settings)
+    application.state.traces_service = traces_service
+
     logger.info("Kratos Agent Service started — environment=%s", settings.environment)
     yield
 
     # Cleanup
+    await eval_service.shutdown()
+    await traces_service.close()
     await foundry_proxy.stop()
     await blob_skill_service.close()
     await cosmos_service.close()
@@ -181,5 +198,7 @@ app.include_router(admin_mcp.router, prefix="/api/admin/mcp-servers", tags=["adm
 app.include_router(admin_apm.router, prefix="/api/admin/use-cases/{use_case}/apm", tags=["admin"])
 app.include_router(admin_analysis.router, prefix="/api/admin/analysis", tags=["admin"])
 app.include_router(use_cases.router, prefix="/api/use-cases", tags=["use-cases"])
+app.include_router(evals.router, prefix="/api/use-cases", tags=["evals"])
+app.include_router(traces.router, prefix="/api/traces", tags=["traces"])
 app.include_router(files.router, prefix="/api/files", tags=["files"])
 app.include_router(copilot_studio.router, prefix="/api/copilot-studio", tags=["copilot-studio"])

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -146,7 +146,7 @@ async def lifespan(application: FastAPI) -> AsyncGenerator[None, None]:
     # Initialize Eval storage + service (per-use-case scenarios, runs, results)
     eval_storage = EvalStorage(blob_skill_service, local_base_dir=settings.apm_use_cases_root)
     application.state.eval_storage = eval_storage
-    eval_service = EvalService(settings, eval_storage, registries)
+    eval_service = EvalService(settings, eval_storage, registries, foundry_proxy=foundry_proxy)
     application.state.eval_service = eval_service
 
     # Initialize Traces service (App Insights waterfall queries)

--- a/src/backend/app/models.py
+++ b/src/backend/app/models.py
@@ -291,3 +291,175 @@ class MCPConfigResponse(BaseModel):
 class MCPConfigUpdate(BaseModel):
     """Payload for updating the MCP servers config."""
     servers: dict
+
+
+# ─── Evals ───────────────────────────────────────────────────────────────────
+
+
+class ScenarioCategory(str, Enum):
+    """Category of evaluation scenario — mirrors the threadlight-vnext taxonomy."""
+
+    STANDARD = "standard"
+    EDGE_CASE = "edge_case"
+    ERROR_HANDLING = "error_handling"
+    BOUNDARY = "boundary"
+    COMPLIANCE = "compliance"
+
+
+class EvalScenario(BaseModel):
+    """A single evaluation scenario for a use-case."""
+
+    name: str = Field(..., description="Unique slug, used as filename (lowercase, hyphenated)")
+    category: ScenarioCategory = ScenarioCategory.STANDARD
+    description: str = Field(default="", description="What this scenario tests")
+    input_message: str = Field(..., description="The user message sent to the agent")
+    input_data: dict[str, Any] = Field(default_factory=dict, description="Optional structured context")
+    expected_behavior: str = Field(default="", description="Plain-language expected behavior")
+    expected_tool_calls: list[str] = Field(
+        default_factory=list,
+        description="Tool names the agent is expected to call (without the mcp-tools- prefix)",
+    )
+    evaluators: list[str] = Field(
+        default_factory=lambda: ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"],
+        description="Evaluator names to apply",
+    )
+
+
+class EvalScenarioList(BaseModel):
+    scenarios: list[EvalScenario]
+
+
+class GenerateScenariosRequest(BaseModel):
+    """Body for the LLM-generation endpoint."""
+    count: int = Field(default=10, ge=1, le=24, description="Number of scenarios to draft")
+    persist: bool = Field(default=False, description="When True, persist the generated scenarios to blob")
+    instructions: str = Field(
+        default="",
+        description="Optional extra guidance to inject into the generator prompt",
+        max_length=4000,
+    )
+
+
+class GenerateScenariosResponse(BaseModel):
+    scenarios: list[EvalScenario]
+    persisted: bool = False
+
+
+class EvalMode(str, Enum):
+    """Eval execution mode."""
+
+    VALIDATION = "validation"  # in-process invoke only, no Foundry evaluators
+    FOUNDRY = "foundry"        # two-phase invoke + score via Foundry evaluators
+
+
+class EvalRunStatus(str, Enum):
+    PENDING = "pending"
+    INVOKING = "invoking"
+    SCORING = "scoring"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class EvalRunRequest(BaseModel):
+    """Body to start an eval run."""
+    mode: EvalMode = EvalMode.VALIDATION
+    scenarios: list[str] = Field(
+        default_factory=list,
+        description="Subset of scenario names to run. Empty = all scenarios for the use-case.",
+    )
+
+
+class ScenarioResult(BaseModel):
+    """Per-scenario invocation + score record."""
+    scenario: str
+    query: str
+    response: str = ""
+    tool_calls: list[dict[str, Any]] = Field(default_factory=list)
+    status: str = "completed"
+    error: str = ""
+    duration_ms: int = 0
+    scores: dict[str, dict[str, Any]] = Field(default_factory=dict)
+
+
+class FoundryEvalSummary(BaseModel):
+    """Summary block from Foundry evaluators."""
+    eval_id: str = ""
+    eval_run_id: str = ""
+    run_status: str = ""
+    result_counts: dict[str, int] = Field(default_factory=dict)
+    per_testing_criteria_results: list[dict[str, Any]] = Field(default_factory=list)
+    output_items: list[dict[str, Any]] = Field(default_factory=list)
+    report_url: str = ""
+
+
+class EvalRun(BaseModel):
+    """An eval run record."""
+    run_id: str
+    use_case: str
+    mode: EvalMode
+    status: EvalRunStatus
+    scenarios: list[str] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+    started_by: str = ""
+    progress: str = ""
+    error: str = ""
+    results: list[ScenarioResult] = Field(default_factory=list)
+    foundry: FoundryEvalSummary | None = None
+
+
+class EvalRunList(BaseModel):
+    runs: list[EvalRun]
+
+
+# ─── Traces ──────────────────────────────────────────────────────────────────
+
+
+class TraceSpan(BaseModel):
+    """A single span in an operation waterfall."""
+    id: str
+    parent_id: str = ""
+    name: str
+    duration_ms: float = 0
+    offset_ms: float = 0
+    timestamp: str = ""
+    success: bool = True
+    result_code: str = ""
+    type: str = ""
+    cloud_role: str = ""
+    category: str = "other"  # llm | agent | agent_internal | tool | skill | http | platform | error | other
+    depth: int = 0
+    attributes: dict[str, str | int | float] = Field(default_factory=dict)
+
+
+class TraceLog(BaseModel):
+    timestamp: str = ""
+    message: str = ""
+    severity: int = 0
+    cloud_role: str = ""
+
+
+class TraceOperation(BaseModel):
+    """One operation (root span + its descendants)."""
+    operation_id: str
+    timestamp: str = ""
+    total_duration_ms: float = 0
+    span_count: int = 0
+    use_case: str = ""
+    conversation_id: str = ""
+    eval_run_id: str = ""
+    spans: list[TraceSpan] = Field(default_factory=list)
+    logs: list[TraceLog] = Field(default_factory=list)
+
+
+class TraceSummary(BaseModel):
+    total_operations: int = 0
+    avg_latency_ms: float = 0
+    total_tokens: int = 0
+    models_used: list[str] = Field(default_factory=list)
+    error: str = ""
+
+
+class TraceList(BaseModel):
+    operations: list[TraceOperation]
+    summary: TraceSummary

--- a/src/backend/app/routers/agent.py
+++ b/src/backend/app/routers/agent.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
+from opentelemetry import trace
 from sse_starlette.sse import EventSourceResponse
 
 from app.models import (
@@ -62,6 +63,18 @@ async def chat(body: AgentRequest, request: Request) -> EventSourceResponse:
     cosmos = request.app.state.cosmos_service
     foundry_proxy = request.app.state.foundry_proxy
 
+    # Stamp kratos attributes on the current (HTTP) span so every request is
+    # filterable by use-case, conversation, and optional eval run.
+    eval_run_id = request.headers.get("x-kratos-eval-run-id") or ""
+    request.state.eval_run_id = eval_run_id
+    _span = trace.get_current_span()
+    if body.useCase:
+        _span.set_attribute("kratos.use_case", str(body.useCase))
+    if body.conversationId:
+        _span.set_attribute("kratos.conversation_id", str(body.conversationId))
+    if eval_run_id:
+        _span.set_attribute("kratos.eval_run_id", eval_run_id)
+
     async def event_generator():  # noqa: ANN202
         start_time = time.monotonic()
         total_tool_calls = 0
@@ -100,6 +113,7 @@ async def chat(body: AgentRequest, request: Request) -> EventSourceResponse:
                 use_case=body.useCase,
                 system_prompt=system_prompt,
                 agent_session_id=agent_session_id,
+                eval_run_id=eval_run_id or None,
             ):
                 event_name = event_dict.get("event")
                 event_data = event_dict.get("data", {})

--- a/src/backend/app/routers/agent.py
+++ b/src/backend/app/routers/agent.py
@@ -7,6 +7,7 @@ import re
 import time
 import uuid
 from datetime import datetime, timezone
+from typing import Any
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
@@ -24,6 +25,7 @@ from app.models import (
 from app.services.follow_up_service import generate_follow_ups
 
 logger = logging.getLogger(__name__)
+_tracer = trace.get_tracer("kratos.agent.proxy")
 
 router = APIRouter()
 
@@ -107,6 +109,22 @@ async def chat(body: AgentRequest, request: Request) -> EventSourceResponse:
             proxy_done: dict = {}
             gateway_session_id: str | None = None
 
+            # Replay tool/usage events as OTel child spans so the traces tab
+            # can render meaningful waterfalls. The hosted Foundry agent emits
+            # its own gen_ai spans to its private AppInsights — these manual
+            # spans surface the same signal in the kratos-side trace tree.
+            common_attrs = {
+                "kratos.use_case": str(body.useCase) if body.useCase else "",
+                "kratos.conversation_id": str(body.conversationId),
+            }
+            if eval_run_id:
+                common_attrs["kratos.eval_run_id"] = eval_run_id
+            open_tool_spans: dict[str, Any] = {}
+            # When the SSE event doesn't carry a unique call_id, use a per-skill
+            # FIFO queue so started→completed pairs match by arrival order.
+            started_queue: dict[str, list[str]] = {}
+            synthetic_seq = 0
+
             async for event_dict in foundry_proxy.invoke(
                 message=body.message,
                 conversation_id=body.conversationId,
@@ -122,11 +140,82 @@ async def chat(body: AgentRequest, request: Request) -> EventSourceResponse:
                     collected_thoughts.append(event_data.get("content", ""))
                     yield {"event": "thought", "data": json.dumps(event_data)}
                 elif event_name == "tool_call":
-                    if event_data.get("status") == "completed":
+                    status = event_data.get("status")
+                    tool_name = (
+                        event_data.get("skillName")
+                        or event_data.get("skill_name")
+                        or event_data.get("name")
+                        or event_data.get("tool_name")
+                        or event_data.get("tool")
+                        or "tool"
+                    )
+                    real_call_id = (
+                        event_data.get("id")
+                        or event_data.get("call_id")
+                        or event_data.get("tool_call_id")
+                    )
+                    if status in (None, "started", "running"):
+                        if real_call_id:
+                            call_id = str(real_call_id)
+                        else:
+                            synthetic_seq += 1
+                            call_id = f"{tool_name}:{synthetic_seq}"
+                            started_queue.setdefault(tool_name, []).append(call_id)
+                        sp = _tracer.start_span(
+                            f"tool.{tool_name}",
+                            kind=trace.SpanKind.INTERNAL,
+                            attributes={
+                                **common_attrs,
+                                "gen_ai.tool.name": str(tool_name),
+                                "kratos.skill.name": str(tool_name),
+                                "gen_ai.tool.kind": "skill",
+                            },
+                        )
+                        open_tool_spans[call_id] = sp
+                    elif status in ("completed", "failed", "error"):
+                        if real_call_id:
+                            call_id = str(real_call_id)
+                        else:
+                            queue = started_queue.get(tool_name) or []
+                            call_id = queue.pop(0) if queue else f"{tool_name}:orphan"
+                        sp = open_tool_spans.pop(call_id, None)
+                        if sp is None:
+                            # tool_call arrived only on completion — synthesise a span
+                            sp = _tracer.start_span(
+                                f"tool.{tool_name}",
+                                kind=trace.SpanKind.INTERNAL,
+                                attributes={
+                                    **common_attrs,
+                                    "gen_ai.tool.name": str(tool_name),
+                                    "kratos.skill.name": str(tool_name),
+                                    "gen_ai.tool.kind": "skill",
+                                },
+                            )
+                        if status in ("failed", "error"):
+                            sp.set_attribute("error.type", str(event_data.get("error", "tool_failed")))
+                            sp.set_status(trace.Status(trace.StatusCode.ERROR))
+                        sp.end()
                         total_tool_calls += 1
                     collected_tool_calls.append(event_data)
                     yield {"event": "tool_call", "data": json.dumps(event_data)}
                 elif event_name == "usage":
+                    # Replay usage as an LLM span so traces tab shows model + tokens
+                    llm_sp = _tracer.start_span(
+                        "chat.completions",
+                        kind=trace.SpanKind.CLIENT,
+                        attributes={
+                            **common_attrs,
+                            "gen_ai.operation.name": "chat",
+                            "gen_ai.response.model": str(
+                                event_data.get("model")
+                                or event_data.get("modelName")
+                                or proxy_done.get("model", "")
+                            ),
+                            "gen_ai.usage.input_tokens": int(event_data.get("promptTokens") or 0),
+                            "gen_ai.usage.output_tokens": int(event_data.get("completionTokens") or 0),
+                        },
+                    )
+                    llm_sp.end()
                     yield {"event": "usage", "data": json.dumps(event_data)}
                 elif event_name == "content":
                     assistant_content_parts.append(event_data.get("content", ""))
@@ -143,6 +232,14 @@ async def chat(body: AgentRequest, request: Request) -> EventSourceResponse:
                     proxy_done = event_data
                 elif event_name == "_gateway_session":
                     gateway_session_id = event_data.get("agentSessionId")
+
+            # Close any tool spans that never received a completion
+            for call_id, sp in list(open_tool_spans.items()):
+                try:
+                    sp.end()
+                except Exception:
+                    pass
+            open_tool_spans.clear()
 
             # Persist gateway session ID so subsequent messages reuse the
             # same hosted agent container (preserving CopilotClient state).

--- a/src/backend/app/routers/evals.py
+++ b/src/backend/app/routers/evals.py
@@ -1,0 +1,163 @@
+"""Evals API — per-use-case scenario CRUD + run management.
+
+Endpoints:
+    GET    /api/use-cases/{use_case}/evals/scenarios
+    POST   /api/use-cases/{use_case}/evals/scenarios/generate
+    PUT    /api/use-cases/{use_case}/evals/scenarios/{name}
+    DELETE /api/use-cases/{use_case}/evals/scenarios/{name}
+    POST   /api/use-cases/{use_case}/evals/run
+    GET    /api/use-cases/{use_case}/evals/runs
+    GET    /api/use-cases/{use_case}/evals/runs/{run_id}
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from app.auth import require_authenticated_user
+from app.models import (
+    EvalRun,
+    EvalRunList,
+    EvalRunRequest,
+    EvalScenario,
+    EvalScenarioList,
+    GenerateScenariosRequest,
+    GenerateScenariosResponse,
+)
+from app.services.eval_service import EvalService
+from app.services.eval_storage import EvalStorage
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(dependencies=[Depends(require_authenticated_user)])
+
+
+def _get_storage(request: Request) -> EvalStorage:
+    storage: EvalStorage | None = getattr(request.app.state, "eval_storage", None)
+    if storage is None:
+        raise HTTPException(status_code=503, detail="Eval storage is not initialized")
+    return storage
+
+
+def _get_service(request: Request) -> EvalService:
+    svc: EvalService | None = getattr(request.app.state, "eval_service", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Eval service is not initialized")
+    return svc
+
+
+def _ensure_use_case(request: Request, use_case: str) -> None:
+    registries = getattr(request.app.state, "registries", {})
+    if use_case not in registries:
+        raise HTTPException(status_code=404, detail=f"Use-case '{use_case}' not found")
+
+
+# ── Scenarios ────────────────────────────────────────────────────────────────
+
+
+@router.get("/{use_case}/evals/scenarios", response_model=EvalScenarioList)
+async def list_scenarios(use_case: str, request: Request) -> EvalScenarioList:
+    _ensure_use_case(request, use_case)
+    storage = _get_storage(request)
+    scenarios = await storage.list_scenarios(use_case)
+    return EvalScenarioList(scenarios=scenarios)
+
+
+@router.post("/{use_case}/evals/scenarios/generate", response_model=GenerateScenariosResponse)
+async def generate_scenarios(
+    use_case: str,
+    body: GenerateScenariosRequest,
+    request: Request,
+) -> GenerateScenariosResponse:
+    _ensure_use_case(request, use_case)
+    storage = _get_storage(request)
+    service = _get_service(request)
+    try:
+        scenarios = await service.generate_scenarios(
+            use_case=use_case,
+            count=body.count,
+            instructions=body.instructions,
+        )
+    except Exception as exc:
+        logger.exception("Scenario generation failed for %s", use_case)
+        raise HTTPException(status_code=502, detail=f"Scenario generation failed: {exc}") from exc
+
+    if body.persist:
+        for s in scenarios:
+            await storage.upsert_scenario(use_case, s)
+    return GenerateScenariosResponse(scenarios=scenarios, persisted=body.persist)
+
+
+@router.put("/{use_case}/evals/scenarios/{name}", response_model=EvalScenario)
+async def upsert_scenario(
+    use_case: str,
+    name: str,
+    scenario: EvalScenario,
+    request: Request,
+) -> EvalScenario:
+    _ensure_use_case(request, use_case)
+    if scenario.name != name:
+        # Allow renaming if the path name doesn't match — prefer body name
+        # but reject obvious mismatches that suggest a client bug.
+        if not scenario.name:
+            scenario = scenario.model_copy(update={"name": name})
+    storage = _get_storage(request)
+    await storage.upsert_scenario(use_case, scenario)
+    return scenario
+
+
+@router.delete("/{use_case}/evals/scenarios/{name}")
+async def delete_scenario(use_case: str, name: str, request: Request) -> dict[str, bool]:
+    _ensure_use_case(request, use_case)
+    storage = _get_storage(request)
+    removed = await storage.delete_scenario(use_case, name)
+    if not removed:
+        raise HTTPException(status_code=404, detail=f"Scenario '{name}' not found")
+    return {"deleted": True}
+
+
+# ── Runs ─────────────────────────────────────────────────────────────────────
+
+
+@router.post("/{use_case}/evals/run", response_model=EvalRun)
+async def start_run(
+    use_case: str,
+    body: EvalRunRequest,
+    request: Request,
+    user: dict = Depends(require_authenticated_user),
+) -> EvalRun:
+    _ensure_use_case(request, use_case)
+    service = _get_service(request)
+    try:
+        run = await service.start_run(
+            use_case=use_case,
+            mode=body.mode,
+            scenario_names=body.scenarios or None,
+            started_by=user.get("userId", "anonymous"),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Failed to start eval run for %s", use_case)
+        raise HTTPException(status_code=500, detail=f"Failed to start eval run: {exc}") from exc
+    return run
+
+
+@router.get("/{use_case}/evals/runs", response_model=EvalRunList)
+async def list_runs(use_case: str, request: Request, limit: int = 50) -> EvalRunList:
+    _ensure_use_case(request, use_case)
+    service = _get_service(request)
+    runs = await service.list_runs(use_case, limit=limit)
+    return EvalRunList(runs=runs)
+
+
+@router.get("/{use_case}/evals/runs/{run_id}", response_model=EvalRun)
+async def get_run(use_case: str, run_id: str, request: Request) -> EvalRun:
+    _ensure_use_case(request, use_case)
+    service = _get_service(request)
+    run = await service.get_run(use_case, run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
+    return run

--- a/src/backend/app/routers/traces.py
+++ b/src/backend/app/routers/traces.py
@@ -1,0 +1,59 @@
+"""Traces API — App Insights waterfall queries for the Traces panel.
+
+Endpoints:
+    GET /api/traces/operations
+    GET /api/traces/operations/{operation_id}
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from app.auth import require_authenticated_user
+from app.models import TraceList, TraceOperation
+from app.services.traces_service import TracesService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(dependencies=[Depends(require_authenticated_user)])
+
+
+def _get_service(request: Request) -> TracesService:
+    svc: TracesService | None = getattr(request.app.state, "traces_service", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Traces service is not initialized")
+    return svc
+
+
+@router.get("/operations", response_model=TraceList)
+async def list_operations(
+    request: Request,
+    use_case: str | None = Query(default=None),
+    conversation_id: str | None = Query(default=None),
+    eval_run_id: str | None = Query(default=None),
+    hours: int = Query(default=24, ge=1, le=720),
+    limit: int = Query(default=50, ge=1, le=200),
+) -> TraceList:
+    service = _get_service(request)
+    return await service.fetch_operations(
+        use_case=use_case,
+        conversation_id=conversation_id,
+        eval_run_id=eval_run_id,
+        lookback_hours=hours,
+        max_operations=limit,
+    )
+
+
+@router.get("/operations/{operation_id}", response_model=TraceOperation)
+async def get_operation(
+    operation_id: str,
+    request: Request,
+    hours: int = Query(default=168, ge=1, le=2160),
+) -> TraceOperation:
+    service = _get_service(request)
+    op = await service.fetch_operation(operation_id, lookback_hours=hours)
+    if op is None:
+        raise HTTPException(status_code=404, detail=f"Operation '{operation_id}' not found")
+    return op

--- a/src/backend/app/services/blob_skill_service.py
+++ b/src/backend/app/services/blob_skill_service.py
@@ -129,7 +129,7 @@ class BlobSkillService:
         existing = set(await self.list_use_cases())
         seeded: list[str] = []
         # APM-materialised output must never leak into blob.
-        _skip_dir_parts = {"apm_modules", ".github", "__pycache__", ".pytest_cache"}
+        _skip_dir_parts = {"apm_modules", ".github", "__pycache__", ".pytest_cache", "results"}
         for uc_dir in sorted(self.local_base_dir.iterdir()):
             if not uc_dir.is_dir() or uc_dir.name in existing:
                 continue

--- a/src/backend/app/services/copilot_agent.py
+++ b/src/backend/app/services/copilot_agent.py
@@ -33,7 +33,7 @@ from opentelemetry import trace
 from app.config import Settings
 from app.models import ContentEvent, ErrorEvent, ThoughtEvent, ToolCallEvent, UsageEvent, UserInputRequestEvent
 from app.observability import operation_duration_histogram, token_usage_histogram
-from app.services.skill_tools import ALL_TOOLS
+from app.services.skill_tools import ALL_TOOLS, _ctx_conversation_id, _ctx_eval_run_id, _ctx_use_case
 
 if TYPE_CHECKING:
     from app.services.cosmos_service import CosmosService
@@ -595,8 +595,17 @@ class CopilotAgent:
         conversation_id: str,
         attachments: list[dict] | None = None,
         sdk_session_id: str | None = None,
+        use_case: str = "",
+        eval_run_id: str | None = None,
     ) -> AsyncGenerator[ThoughtEvent | ToolCallEvent | ContentEvent | ErrorEvent | UserInputRequestEvent, None]:
         """Send a message and stream SDK events as typed SSE events."""
+
+        # Propagate kratos context into tool spans via ContextVars
+        _ctx_conversation_id.set(conversation_id)
+        if use_case:
+            _ctx_use_case.set(use_case)
+        if eval_run_id:
+            _ctx_eval_run_id.set(eval_run_id)
 
         _content_recording = (
             os.environ.get("AZURE_TRACING_GEN_AI_CONTENT_RECORDING_ENABLED", "").lower() == "true"
@@ -615,12 +624,17 @@ class CopilotAgent:
             "gen_ai.agents.name": "kratos-agent",
             "gen_ai.agent.version": "0.1.0",
             "gen_ai.conversation.id": conversation_id,
+            "kratos.conversation_id": conversation_id,
             "server.address": "api.githubcopilot.com" if _local_mode else self.settings.foundry_endpoint,
         }
         with tracer.start_as_current_span(
             "invoke_agent kratos-agent",
             attributes=_invoke_span_attrs,
         ) as span:
+            if use_case:
+                span.set_attribute("kratos.use_case", str(use_case))
+            if eval_run_id:
+                span.set_attribute("kratos.eval_run_id", str(eval_run_id))
             queue: asyncio.Queue = asyncio.Queue()
             self._queues[conversation_id] = queue
             self._tool_counters[conversation_id] = 0
@@ -776,8 +790,13 @@ class CopilotAgent:
                                         "gen_ai.tool.call.id": str(tool_call_id),
                                         "gen_ai.tool.type": "function",
                                         "gen_ai.tool.call.arguments": raw_input_str[:2000],
+                                        "kratos.conversation_id": cid,
                                     },
                                 )
+                                if use_case:
+                                    tool_span.set_attribute("kratos.use_case", str(use_case))
+                                if eval_run_id:
+                                    tool_span.set_attribute("kratos.eval_run_id", str(eval_run_id))
                                 _tool_spans[tool_name] = tool_span
                                 _tool_span_stack.append((tool_name, tool_span))
                                 # Emit descriptive thought (not just "Calling tool: X")

--- a/src/backend/app/services/copilot_agent.py
+++ b/src/backend/app/services/copilot_agent.py
@@ -967,9 +967,12 @@ class CopilotAgent:
                     send_opts["attachments"] = attachments
                 await session.send(send_opts)
 
-                # Drain the queue until sentinel
+                # Drain the queue until sentinel. 300s silence threshold matches
+                # eval_service._REQUEST_TIMEOUT — gives complex multi-tool scenarios
+                # (PDF generation, long triage chains) enough headroom under gateway
+                # throttle bursts where individual tool calls can stall 60-120s.
                 while True:
-                    item = await asyncio.wait_for(queue.get(), timeout=120.0)
+                    item = await asyncio.wait_for(queue.get(), timeout=300.0)
                     if item is None:
                         break
                     yield item

--- a/src/backend/app/services/eval_service.py
+++ b/src/backend/app/services/eval_service.py
@@ -53,7 +53,9 @@ _WARMUP_ATTEMPTS = 6
 _WARMUP_BACKOFF_S = 5.0
 
 # Request timeout for the Foundry OpenAI client (seconds)
-_REQUEST_TIMEOUT = 120.0
+# Bumped to 300s — complex multi-tool scenarios (PDF report generation, multi-step
+# triage flows) routinely exceed 120s; gateway throttle bursts also push tail latency.
+_REQUEST_TIMEOUT = 300.0
 
 # Scenario count cap
 _SCENARIO_COUNT_MAX = 24

--- a/src/backend/app/services/eval_service.py
+++ b/src/backend/app/services/eval_service.py
@@ -1,0 +1,723 @@
+"""Eval service — scenario generation and eval run orchestration.
+
+Two public entry points:
+  1. ``generate_scenarios`` — LLM-assisted scenario drafting (no persistence)
+  2. ``start_run``          — kick off a background eval run (invoke ± score)
+
+Scoring (FOUNDRY mode) uses ``azure-ai-evaluation`` evaluators lazily imported
+so the module loads cleanly even when the package is not installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import openai
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+
+from app.config import Settings
+from app.models import (
+    EvalMode,
+    EvalRun,
+    EvalRunStatus,
+    EvalScenario,
+    FoundryEvalSummary,
+    ScenarioResult,
+)
+from app.services.eval_storage import EvalStorage
+from app.services.skill_registry import SkillRegistry
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+_INTERNAL_TOOLS: frozenset[str] = frozenset({"report_intent", "skill", "sql", "ask_user"})
+_MCP_PREFIX = "mcp-tools-"
+
+# Use-case → industry canon mapping (FSI covers insurance/banking/wealth)
+_FSI_USE_CASES = {"insurance", "retail-banking", "wealth-management"}
+_CANON_BASE = Path("/Users/ricchi/Repos/awesome-gbb/skills/threadlight-demo-data-factory/references")
+
+# Warmup parameters (tuned per foundry-evals skill guidance)
+_WARMUP_ATTEMPTS = 6
+_WARMUP_BACKOFF_S = 5.0
+
+# Request timeout for the Foundry OpenAI client (seconds)
+_REQUEST_TIMEOUT = 120.0
+
+# Scenario count cap
+_SCENARIO_COUNT_MAX = 24
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _load_canon(use_case: str) -> str:
+    """Return the industry realism canon text, or empty string if absent."""
+    industry = "fsi" if use_case in _FSI_USE_CASES else None
+    if industry:
+        canon_path = _CANON_BASE / f"{industry}.md"
+        if canon_path.is_file():
+            try:
+                return canon_path.read_text(encoding="utf-8")
+            except Exception as exc:
+                logger.warning("Could not read canon %s: %s", canon_path, exc)
+    return ""
+
+
+def _build_generator_system_prompt(
+    use_case: str,
+    registry: SkillRegistry,
+    count: int,
+    instructions: str,
+) -> str:
+    """Build the system prompt for the LLM scenario generator."""
+    skill_bullets = "\n".join(
+        f"- **{s.name}** (enabled={s.enabled}): {s.description}"
+        for s in registry.skills.values()
+    )
+
+    canon = _load_canon(use_case)
+    canon_section = f"\n\n## Industry Realism Canon\n\n{canon}" if canon else ""
+
+    extra = f"\n\n## Extra Instructions\n\n{instructions}" if instructions.strip() else ""
+
+    schema_hint = json.dumps(
+        {
+            "scenarios": [
+                {
+                    "name": "lowercase-hyphenated-slug",
+                    "category": "standard | edge_case | error_handling | boundary | compliance",
+                    "description": "What this scenario tests",
+                    "input_message": "The user message sent to the agent",
+                    "input_data": {},
+                    "expected_behavior": "Plain-language expected behavior",
+                    "expected_tool_calls": ["tool_name_without_mcp_prefix"],
+                    "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"],
+                }
+            ]
+        },
+        indent=2,
+    )
+
+    return f"""You are an expert QA engineer generating evaluation scenarios for an AI agent.
+
+## Agent System Prompt
+
+{registry.system_prompt or "(not available)"}
+
+## Available Skills
+
+{skill_bullets or "(none registered)"}
+{canon_section}{extra}
+
+## Task
+
+Generate exactly {count} distinct evaluation scenarios that cover happy-path,
+edge-case, error-handling, boundary, and compliance categories.  Make the
+scenarios realistic and grounded in the domain.
+
+Respond with a single JSON object matching this exact schema — no prose,
+no markdown fencing, just the JSON:
+
+{schema_hint}
+
+Rules:
+- `name` must be a unique lowercase-hyphenated slug (max 80 chars).
+- `category` must be one of: standard, edge_case, error_handling, boundary, compliance.
+- `input_message` must be a natural user message (1-3 sentences).
+- `expected_tool_calls` must NOT include the `mcp-tools-` prefix.
+- Include all five evaluator names in `evaluators`.
+- Vary the categories; do not produce all `standard` scenarios.
+"""
+
+
+def _build_foundry_oai_client(settings: Settings) -> Any:
+    """Return an AIProjectClient-derived OpenAI client bound to the hosted agent."""
+    from azure.ai.projects import AIProjectClient
+
+    endpoint = settings.eval_foundry_project_endpoint or settings.foundry_project_endpoint
+    project = AIProjectClient(
+        endpoint=endpoint,
+        credential=DefaultAzureCredential(),
+        allow_preview=True,
+    )
+    return project.get_openai_client(agent_name=settings.foundry_agent_name)
+
+
+def _build_model_config(settings: Settings) -> dict[str, Any]:
+    """Return the model config dict for azure-ai-evaluation evaluators."""
+    azure_endpoint = settings.foundry_endpoint.rstrip("/")
+    model = settings.eval_model or "gpt-4.1"
+    api_key = os.environ.get("FOUNDRY_API_KEY", "").strip()
+    config: dict[str, Any] = {
+        "azure_endpoint": azure_endpoint,
+        "azure_deployment": model,
+    }
+    if api_key:
+        config["api_key"] = api_key
+    else:
+        config["credential"] = DefaultAzureCredential()
+    return config
+
+
+def _apply_validate_model_config_patch() -> None:
+    """Patch azure-ai-evaluation's validate_model_config for Python 3.13 compat.
+
+    Python 3.13 changed isinstance(v, typing.Any) to raise TypeError; this
+    breaks the credential-field check inside azure-ai-evaluation.  The patch
+    short-circuits when the config already has ``azure_endpoint``.
+    """
+    if sys.version_info < (3, 13):
+        return
+    try:
+        import azure.ai.evaluation._common.utils as _eval_utils
+        import azure.ai.evaluation._evaluators._common._base_prompty_eval as _bpe
+
+        _orig = _eval_utils.validate_model_config
+
+        def _patched(config: Any) -> Any:
+            if isinstance(config, dict) and "azure_endpoint" in config:
+                return config
+            return _orig(config)
+
+        _eval_utils.validate_model_config = _patched
+        _bpe.validate_model_config = _patched
+    except Exception:
+        pass  # graceful degradation if internals change
+
+
+def _extract_response_text(response: Any) -> str:
+    """Extract the assistant text from an OpenAI Responses API response."""
+    text: str = getattr(response, "output_text", "") or ""
+    if not text and hasattr(response, "output"):
+        for item in response.output:
+            if getattr(item, "type", "") == "message":
+                for content in getattr(item, "content", []):
+                    text += getattr(content, "text", "")
+    return text
+
+
+def _extract_tool_calls(response: Any) -> list[dict[str, Any]]:
+    """Extract tool calls from an OpenAI Responses API response."""
+    calls: list[dict[str, Any]] = []
+    if not hasattr(response, "output"):
+        return calls
+    for item in response.output:
+        if getattr(item, "type", "") == "function_call":
+            raw_args = getattr(item, "arguments", "{}")
+            try:
+                args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+            except Exception:
+                args = {}
+            result_text = ""
+            calls.append(
+                {
+                    "name": getattr(item, "name", ""),
+                    "arguments": args,
+                    "result": result_text,
+                }
+            )
+        elif getattr(item, "type", "") == "function_call_output":
+            # Pair results back to the most recent call with matching call_id
+            call_id = getattr(item, "call_id", "")
+            output_val = getattr(item, "output", "")
+            for call in reversed(calls):
+                if call.get("_call_id") == call_id:
+                    call["result"] = output_val
+                    break
+    # Strip internal _call_id bookkeeping
+    for call in calls:
+        call.pop("_call_id", None)
+    return calls
+
+
+def _filter_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Remove internal GHCP SDK tools and normalise MCP prefix."""
+    filtered: list[dict[str, Any]] = []
+    for tc in tool_calls:
+        name = tc.get("name", "")
+        if name in _INTERNAL_TOOLS:
+            continue
+        if name and not name.startswith(_MCP_PREFIX):
+            tc = {**tc, "name": _MCP_PREFIX + name}
+        filtered.append(tc)
+    return filtered
+
+
+def _build_tool_definitions(expected_tool_calls: list[str]) -> list[dict[str, Any]]:
+    """Build the tool_definitions list for evaluators from expected tool names."""
+    filtered = [t for t in expected_tool_calls if t not in _INTERNAL_TOOLS]
+    return [
+        {"name": t if t.startswith(_MCP_PREFIX) else _MCP_PREFIX + t}
+        for t in filtered
+    ]
+
+
+# ── EvalService ───────────────────────────────────────────────────────────────
+
+
+class EvalService:
+    """Orchestrates eval scenario generation and run execution."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        storage: EvalStorage,
+        registries: dict[str, SkillRegistry],
+    ) -> None:
+        self._settings = settings
+        self._storage = storage
+        self._registries = registries
+        self._tasks: dict[tuple[str, str], asyncio.Task[None]] = {}
+
+    # ── Public API ────────────────────────────────────────────────────────
+
+    async def generate_scenarios(
+        self,
+        use_case: str,
+        count: int,
+        instructions: str = "",
+    ) -> list[EvalScenario]:
+        """Generate ``count`` evaluation scenarios for ``use_case`` via LLM."""
+        count = min(count, _SCENARIO_COUNT_MAX)
+        registry = self._registries.get(use_case) or SkillRegistry(use_case=use_case)
+        system_prompt = _build_generator_system_prompt(use_case, registry, count, instructions)
+
+        azure_endpoint = self._settings.foundry_endpoint.rstrip("/")
+        model = self._settings.foundry_model_deployment or self._settings.eval_model or "gpt-4.1"
+        api_key = os.environ.get("FOUNDRY_API_KEY", "").strip()
+
+        if api_key:
+            oai_client = openai.AzureOpenAI(
+                azure_endpoint=azure_endpoint,
+                api_key=api_key,
+                api_version="2024-12-01-preview",
+            )
+        else:
+            token_provider = get_bearer_token_provider(
+                DefaultAzureCredential(),
+                "https://cognitiveservices.azure.com/.default",
+            )
+            oai_client = openai.AzureOpenAI(
+                azure_endpoint=azure_endpoint,
+                azure_ad_token_provider=token_provider,
+                api_version="2024-12-01-preview",
+            )
+
+        logger.info("Generating %d scenarios for use-case '%s'", count, use_case)
+        try:
+            completion = oai_client.chat.completions.create(
+                model=model,
+                messages=[{"role": "system", "content": system_prompt}],
+                response_format={"type": "json_object"},
+                temperature=0.7,
+            )
+        except Exception as exc:
+            logger.exception("Scenario generation LLM call failed for '%s'", use_case)
+            raise RuntimeError(f"Scenario generation failed: {exc}") from exc
+
+        raw = completion.choices[0].message.content or ""
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.error("Generator returned non-JSON: %s", raw[:200])
+            raise RuntimeError(f"LLM did not return valid JSON: {exc}") from exc
+
+        raw_scenarios = parsed.get("scenarios", [])
+        scenarios: list[EvalScenario] = []
+        for item in raw_scenarios:
+            try:
+                scenarios.append(EvalScenario.model_validate(item))
+            except Exception as exc:
+                logger.warning("Skipping malformed scenario item: %s — %s", item, exc)
+
+        if not scenarios:
+            raise RuntimeError("LLM generated zero valid scenarios — check the model output.")
+
+        logger.info("Generated %d scenarios for '%s'", len(scenarios), use_case)
+        return scenarios
+
+    async def start_run(
+        self,
+        use_case: str,
+        mode: EvalMode,
+        scenario_names: list[str] | None,
+        started_by: str = "",
+    ) -> EvalRun:
+        """Create an EvalRun record, persist it, and kick off the background task."""
+        run_id = uuid.uuid4().hex
+
+        # Resolve scenario list
+        if scenario_names:
+            scenarios = scenario_names
+        else:
+            all_scenarios = await self._storage.list_scenarios(use_case)
+            scenarios = [s.name for s in all_scenarios]
+
+        now = _now()
+        run = EvalRun(
+            run_id=run_id,
+            use_case=use_case,
+            mode=mode,
+            status=EvalRunStatus.PENDING,
+            scenarios=scenarios,
+            created_at=now,
+            updated_at=now,
+            started_by=started_by,
+        )
+        await self._storage.save_run(run)
+
+        task = asyncio.create_task(
+            self._execute_run(run),
+            name=f"eval-{use_case}-{run_id}",
+        )
+        self._tasks[(use_case, run_id)] = task
+        task.add_done_callback(lambda t: self._tasks.pop((use_case, run_id), None))
+
+        logger.info("Started eval run %s for '%s' (mode=%s, %d scenarios)", run_id, use_case, mode, len(scenarios))
+        return run
+
+    async def get_run(self, use_case: str, run_id: str) -> EvalRun | None:
+        return await self._storage.load_run(use_case, run_id)
+
+    async def list_runs(self, use_case: str, limit: int = 50) -> list[EvalRun]:
+        return await self._storage.list_runs(use_case, limit)
+
+    async def shutdown(self) -> None:
+        """Cancel all in-flight eval tasks gracefully."""
+        tasks = list(self._tasks.values())
+        if not tasks:
+            return
+        logger.info("Cancelling %d in-flight eval tasks", len(tasks))
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        self._tasks.clear()
+
+    # ── Background execution ──────────────────────────────────────────────
+
+    async def _execute_run(self, run: EvalRun) -> None:
+        """Full eval run: warmup → invoke → (score) → report."""
+        run_id = run.run_id
+
+        try:
+            await self._do_execute_run(run)
+        except asyncio.CancelledError:
+            logger.info("Eval run %s cancelled", run_id)
+            run.status = EvalRunStatus.FAILED
+            run.error = "Cancelled"
+            await self._storage.save_run(run)
+        except Exception as exc:
+            logger.exception("Eval run %s failed", run_id)
+            run.status = EvalRunStatus.FAILED
+            run.error = str(exc)
+            await self._storage.save_run(run)
+
+    async def _do_execute_run(self, run: EvalRun) -> None:
+        use_case = run.use_case
+        run_id = run.run_id
+        settings = self._settings
+
+        # ── Phase 0: resolve scenarios ────────────────────────────────────
+        all_stored = await self._storage.list_scenarios(use_case)
+        stored_map: dict[str, EvalScenario] = {s.name: s for s in all_stored}
+        scenarios_to_run: list[EvalScenario] = []
+        for name in run.scenarios:
+            sc = stored_map.get(name)
+            if sc is None:
+                logger.warning("Scenario '%s' not found in storage — skipping", name)
+                continue
+            scenarios_to_run.append(sc)
+
+        if not scenarios_to_run:
+            raise RuntimeError("No valid scenarios found for this run.")
+
+        # ── Phase 1: INVOKING ─────────────────────────────────────────────
+        run.status = EvalRunStatus.INVOKING
+        await self._storage.save_run(run)
+
+        # Build Foundry OpenAI client
+        oai = _build_foundry_oai_client(settings)
+
+        # Warmup loop — handles scale-from-zero hosted agents
+        logger.info("[eval %s] warmup start (max %d attempts)", run_id, _WARMUP_ATTEMPTS)
+        backoff = _WARMUP_BACKOFF_S
+        for attempt in range(1, _WARMUP_ATTEMPTS + 1):
+            try:
+                r = await asyncio.get_event_loop().run_in_executor(
+                    None,
+                    lambda: oai.responses.create(input="ping", stream=False),
+                )
+                status = getattr(r, "status", "unknown")
+                logger.info("[eval %s] warmup attempt=%d status=%s", run_id, attempt, status)
+                if status == "completed":
+                    logger.info("[eval %s] warmup READY", run_id)
+                    break
+            except Exception as exc:
+                logger.warning("[eval %s] warmup attempt=%d exc: %s", run_id, attempt, str(exc)[:120])
+            if attempt < _WARMUP_ATTEMPTS:
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 60.0)
+        else:
+            raise RuntimeError(
+                f"Hosted agent failed to warm up after {_WARMUP_ATTEMPTS} attempts."
+            )
+
+        # Sequential invocation
+        total = len(scenarios_to_run)
+        for idx, scenario in enumerate(scenarios_to_run):
+            t_start = time.monotonic()
+            try:
+                response = await asyncio.get_event_loop().run_in_executor(
+                    None,
+                    lambda sc=scenario: oai.responses.create(
+                        input=sc.input_message,
+                        stream=False,
+                        extra_headers={
+                            "x-kratos-eval-run-id": run_id,
+                            "x-kratos-use-case": use_case,
+                        },
+                        timeout=_REQUEST_TIMEOUT,
+                    ),
+                )
+                resp_text = _extract_response_text(response)
+                # Retry once on empty response
+                if not resp_text:
+                    await asyncio.sleep(3)
+                    response = await asyncio.get_event_loop().run_in_executor(
+                        None,
+                        lambda sc=scenario: oai.responses.create(
+                            input=sc.input_message,
+                            stream=False,
+                            extra_headers={
+                                "x-kratos-eval-run-id": run_id,
+                                "x-kratos-use-case": use_case,
+                            },
+                            timeout=_REQUEST_TIMEOUT,
+                        ),
+                    )
+                    resp_text = _extract_response_text(response)
+
+                raw_tool_calls = _extract_tool_calls(response)
+                duration_ms = int((time.monotonic() - t_start) * 1000)
+
+                result = ScenarioResult(
+                    scenario=scenario.name,
+                    query=scenario.input_message,
+                    response=resp_text,
+                    tool_calls=raw_tool_calls,
+                    status="completed",
+                    duration_ms=duration_ms,
+                )
+            except Exception as exc:
+                duration_ms = int((time.monotonic() - t_start) * 1000)
+                logger.warning("[eval %s] scenario '%s' failed: %s", run_id, scenario.name, exc)
+                result = ScenarioResult(
+                    scenario=scenario.name,
+                    query=scenario.input_message,
+                    status="error",
+                    error=str(exc),
+                    duration_ms=duration_ms,
+                )
+
+            run.results.append(result)
+            run.progress = f"{idx + 1}/{total}"
+
+            await self._storage.append_jsonl(
+                use_case,
+                run_id,
+                {
+                    "scenario": result.scenario,
+                    "query": result.query,
+                    "response": result.response,
+                    "tool_calls": result.tool_calls,
+                    "status": result.status,
+                    "error": result.error,
+                    "duration_ms": result.duration_ms,
+                },
+            )
+
+            # Persist run meta periodically (every 5 scenarios or at end)
+            if (idx + 1) % 5 == 0 or (idx + 1) == total:
+                await self._storage.save_run(run)
+
+            # Pace invocations per foundry-evals guidance
+            if idx < total - 1:
+                await asyncio.sleep(5)
+
+        # ── Phase 2: SCORING (FOUNDRY mode only) ─────────────────────────
+        if run.mode == EvalMode.FOUNDRY:
+            await self._score_run(run, scenarios_to_run, use_case, run_id)
+
+        # ── Phase 3: Write report ─────────────────────────────────────────
+        report = self._build_report(run, use_case)
+        await self._storage.write_report(use_case, run_id, report)
+
+        run.status = EvalRunStatus.COMPLETED
+        run.progress = f"{total}/{total}"
+        await self._storage.save_run(run)
+        logger.info("[eval %s] COMPLETED (%d scenarios)", run_id, total)
+
+    async def _score_run(
+        self,
+        run: EvalRun,
+        scenarios: list[EvalScenario],
+        use_case: str,
+        run_id: str,
+    ) -> None:
+        """Score invocation results with azure-ai-evaluation evaluators."""
+        run.status = EvalRunStatus.SCORING
+        await self._storage.save_run(run)
+        logger.info("[eval %s] scoring %d results", run_id, len(run.results))
+
+        # Lazy import — azure-ai-evaluation may not be installed
+        _apply_validate_model_config_patch()
+        try:
+            from azure.ai.evaluation import (  # noqa: PLC0415
+                CoherenceEvaluator,
+                IntentResolutionEvaluator,
+                RelevanceEvaluator,
+                TaskAdherenceEvaluator,
+                ToolCallAccuracyEvaluator,
+            )
+        except ImportError as exc:
+            logger.error("[eval %s] azure-ai-evaluation not installed: %s — skipping scoring", run_id, exc)
+            return
+
+        model_config = _build_model_config(self._settings)
+        evaluators = {
+            "TaskAdherence": TaskAdherenceEvaluator(model_config=model_config),
+            "IntentResolution": IntentResolutionEvaluator(model_config=model_config),
+            "Coherence": CoherenceEvaluator(model_config=model_config),
+            "Relevance": RelevanceEvaluator(model_config=model_config),
+            "ToolCallAccuracy": ToolCallAccuracyEvaluator(model_config=model_config),
+        }
+
+        scenario_map: dict[str, EvalScenario] = {s.name: s for s in scenarios}
+        criteria_totals: dict[str, dict[str, int]] = {}
+
+        for result in run.results:
+            if result.status == "error":
+                continue
+
+            sc = scenario_map.get(result.scenario)
+            expected_behavior = sc.expected_behavior if sc else ""
+            expected_tools = sc.expected_tool_calls if sc else []
+
+            eval_query = (
+                f"{result.query}\n\nExpected: {expected_behavior}"
+                if expected_behavior
+                else result.query
+            )
+
+            filtered_tool_calls = _filter_tool_calls(result.tool_calls)
+            tool_defs = _build_tool_definitions(expected_tools)
+
+            scores: dict[str, dict[str, Any]] = {}
+            for eval_name, evaluator in evaluators.items():
+                try:
+                    kwargs: dict[str, Any] = {
+                        "query": eval_query,
+                        "response": result.response,
+                    }
+                    if eval_name == "ToolCallAccuracy" and filtered_tool_calls:
+                        kwargs["tool_calls"] = filtered_tool_calls
+                        kwargs["tool_definitions"] = tool_defs
+                    # Run synchronous evaluator in executor to avoid blocking event loop
+                    score_result = await asyncio.get_event_loop().run_in_executor(
+                        None, lambda ev=evaluator, kw=kwargs: ev(**kw)
+                    )
+                    scores[eval_name] = score_result if isinstance(score_result, dict) else {"score": score_result}
+                except Exception as exc:
+                    logger.warning(
+                        "[eval %s] evaluator %s failed for '%s': %s",
+                        run_id, eval_name, result.scenario, exc,
+                    )
+                    scores[eval_name] = {"error": str(exc)}
+
+            result.scores = scores
+
+            # Accumulate per-criterion pass/fail
+            for criterion, sd in scores.items():
+                if criterion not in criteria_totals:
+                    criteria_totals[criterion] = {"passed": 0, "failed": 0}
+                passed = sd.get("passed", False)
+                if not passed:
+                    # Treat numeric score >= 3 as pass (5-point scale)
+                    score_val = next((v for v in sd.values() if isinstance(v, (int, float))), None)
+                    passed = bool(score_val is not None and score_val >= 3)
+                if passed:
+                    criteria_totals[criterion]["passed"] += 1
+                else:
+                    criteria_totals[criterion]["failed"] += 1
+
+        # Aggregate: scenario "passed" if ALL criteria passed
+        passed_count = 0
+        failed_count = 0
+        for result in run.results:
+            if result.status == "error":
+                failed_count += 1
+                continue
+            all_passed = all(
+                sd.get("passed", False)
+                or (
+                    next((v for v in sd.values() if isinstance(v, (int, float))), None) is not None
+                    and next((v for v in sd.values() if isinstance(v, (int, float))), 0) >= 3
+                )
+                for sd in result.scores.values()
+                if "error" not in sd
+            )
+            if all_passed and result.scores:
+                passed_count += 1
+            else:
+                failed_count += 1
+
+        per_criteria: list[dict[str, Any]] = [
+            {"criterion": k, **v} for k, v in criteria_totals.items()
+        ]
+        run.foundry = FoundryEvalSummary(
+            eval_id="",
+            eval_run_id="",
+            run_status="completed",
+            result_counts={"passed": passed_count, "failed": failed_count},
+            per_testing_criteria_results=per_criteria,
+            output_items=[],
+            report_url="",
+        )
+        await self._storage.save_run(run)
+
+    def _build_report(self, run: EvalRun, use_case: str) -> dict[str, Any]:
+        """Build the eval_report.json dict."""
+        return {
+            "run_id": run.run_id,
+            "use_case": use_case,
+            "mode": run.mode,
+            "status": run.status,
+            "created_at": run.created_at.isoformat(),
+            "total_scenarios": len(run.results),
+            "foundry_summary": run.foundry.model_dump() if run.foundry else None,
+            "scenarios": [
+                {
+                    "scenario": r.scenario,
+                    "status": r.status,
+                    "duration_ms": r.duration_ms,
+                    "scores": r.scores,
+                    "error": r.error,
+                }
+                for r in run.results
+            ],
+        }

--- a/src/backend/app/services/eval_service.py
+++ b/src/backend/app/services/eval_service.py
@@ -34,6 +34,7 @@ from app.models import (
     ScenarioResult,
 )
 from app.services.eval_storage import EvalStorage
+from app.services.foundry_agent_proxy import FoundryAgentProxy
 from app.services.skill_registry import SkillRegistry
 
 logger = logging.getLogger(__name__)
@@ -278,11 +279,63 @@ class EvalService:
         settings: Settings,
         storage: EvalStorage,
         registries: dict[str, SkillRegistry],
+        foundry_proxy: FoundryAgentProxy | None = None,
     ) -> None:
         self._settings = settings
         self._storage = storage
         self._registries = registries
+        self._foundry_proxy = foundry_proxy
         self._tasks: dict[tuple[str, str], asyncio.Task[None]] = {}
+
+    # ── Hosted-agent invocation helper (uses Invocations protocol via FoundryAgentProxy) ──
+
+    async def _invoke_hosted_agent(
+        self,
+        message: str,
+        conversation_id: str,
+        use_case: str,
+        run_id: str | None = None,
+        timeout: float = _REQUEST_TIMEOUT,
+    ) -> tuple[str, list[dict[str, Any]], str | None]:
+        """Invoke the hosted agent once and aggregate the SSE stream.
+
+        Returns ``(response_text, tool_calls, error_message)``. ``error_message``
+        is non-empty when the agent stream emitted an error event.
+        """
+        if self._foundry_proxy is None:
+            raise RuntimeError(
+                "EvalService: foundry_proxy is not configured — cannot invoke hosted agent."
+            )
+
+        chunks: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+        error_msg: str | None = None
+
+        async def _drain() -> None:
+            nonlocal error_msg
+            async for ev in self._foundry_proxy.invoke(
+                message=message,
+                conversation_id=conversation_id,
+                use_case=use_case,
+                eval_run_id=run_id,
+            ):
+                etype = ev.get("event") or ev.get("type") or ""
+                data = ev.get("data") or {}
+                if etype == "content":
+                    txt = data.get("content") or data.get("text") or ""
+                    if txt:
+                        chunks.append(str(txt))
+                elif etype == "tool_call":
+                    tool_calls.append(data if isinstance(data, dict) else {"raw": str(data)})
+                elif etype == "error":
+                    error_msg = str(data.get("message") or data)
+
+        try:
+            await asyncio.wait_for(_drain(), timeout=timeout)
+        except TimeoutError:
+            error_msg = error_msg or f"Hosted agent invocation timed out after {timeout}s"
+
+        return "".join(chunks), tool_calls, error_msg
 
     # ── Public API ────────────────────────────────────────────────────────
 
@@ -450,25 +503,36 @@ class EvalService:
         run.status = EvalRunStatus.INVOKING
         await self._storage.save_run(run)
 
-        # Build Foundry OpenAI client
-        oai = _build_foundry_oai_client(settings)
+        # Build Foundry OpenAI client (used later for scoring evaluators in FOUNDRY mode)
+        oai = _build_foundry_oai_client(settings) if run.mode == EvalMode.FOUNDRY else None
 
-        # Warmup loop — handles scale-from-zero hosted agents
+        # Warmup loop — handles scale-from-zero hosted agents (uses Invocations protocol)
         logger.info("[eval %s] warmup start (max %d attempts)", run_id, _WARMUP_ATTEMPTS)
         backoff = _WARMUP_BACKOFF_S
         for attempt in range(1, _WARMUP_ATTEMPTS + 1):
             try:
-                r = await asyncio.get_event_loop().run_in_executor(
-                    None,
-                    lambda: oai.responses.create(input="ping", stream=False),
+                wtext, _, werr = await self._invoke_hosted_agent(
+                    message="ping",
+                    conversation_id=f"warmup-{run_id}-{attempt}",
+                    use_case=use_case,
+                    run_id=run_id,
+                    timeout=60.0,
                 )
-                status = getattr(r, "status", "unknown")
-                logger.info("[eval %s] warmup attempt=%d status=%s", run_id, attempt, status)
-                if status == "completed":
-                    logger.info("[eval %s] warmup READY", run_id)
+                if werr:
+                    logger.warning(
+                        "[eval %s] warmup attempt=%d error: %s", run_id, attempt, werr[:160]
+                    )
+                elif wtext:
+                    logger.info(
+                        "[eval %s] warmup READY (chars=%d)", run_id, len(wtext)
+                    )
                     break
+                else:
+                    logger.warning(
+                        "[eval %s] warmup attempt=%d empty response", run_id, attempt
+                    )
             except Exception as exc:
-                logger.warning("[eval %s] warmup attempt=%d exc: %s", run_id, attempt, str(exc)[:120])
+                logger.warning("[eval %s] warmup attempt=%d exc: %s", run_id, attempt, str(exc)[:160])
             if attempt < _WARMUP_ATTEMPTS:
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 60.0)
@@ -482,47 +546,42 @@ class EvalService:
         for idx, scenario in enumerate(scenarios_to_run):
             t_start = time.monotonic()
             try:
-                response = await asyncio.get_event_loop().run_in_executor(
-                    None,
-                    lambda sc=scenario: oai.responses.create(
-                        input=sc.input_message,
-                        stream=False,
-                        extra_headers={
-                            "x-kratos-eval-run-id": run_id,
-                            "x-kratos-use-case": use_case,
-                        },
-                        timeout=_REQUEST_TIMEOUT,
-                    ),
+                resp_text, raw_tool_calls, err = await self._invoke_hosted_agent(
+                    message=scenario.input_message,
+                    conversation_id=f"eval-{run_id}-{scenario.name}",
+                    use_case=use_case,
+                    run_id=run_id,
+                    timeout=_REQUEST_TIMEOUT,
                 )
-                resp_text = _extract_response_text(response)
-                # Retry once on empty response
-                if not resp_text:
+                # Retry once on empty response (and no explicit error)
+                if not resp_text and not err:
                     await asyncio.sleep(3)
-                    response = await asyncio.get_event_loop().run_in_executor(
-                        None,
-                        lambda sc=scenario: oai.responses.create(
-                            input=sc.input_message,
-                            stream=False,
-                            extra_headers={
-                                "x-kratos-eval-run-id": run_id,
-                                "x-kratos-use-case": use_case,
-                            },
-                            timeout=_REQUEST_TIMEOUT,
-                        ),
+                    resp_text, raw_tool_calls, err = await self._invoke_hosted_agent(
+                        message=scenario.input_message,
+                        conversation_id=f"eval-{run_id}-{scenario.name}-retry",
+                        use_case=use_case,
+                        run_id=run_id,
+                        timeout=_REQUEST_TIMEOUT,
                     )
-                    resp_text = _extract_response_text(response)
-
-                raw_tool_calls = _extract_tool_calls(response)
                 duration_ms = int((time.monotonic() - t_start) * 1000)
 
-                result = ScenarioResult(
-                    scenario=scenario.name,
-                    query=scenario.input_message,
-                    response=resp_text,
-                    tool_calls=raw_tool_calls,
-                    status="completed",
-                    duration_ms=duration_ms,
-                )
+                if err and not resp_text:
+                    result = ScenarioResult(
+                        scenario=scenario.name,
+                        query=scenario.input_message,
+                        status="error",
+                        error=err,
+                        duration_ms=duration_ms,
+                    )
+                else:
+                    result = ScenarioResult(
+                        scenario=scenario.name,
+                        query=scenario.input_message,
+                        response=resp_text,
+                        tool_calls=raw_tool_calls,
+                        status="completed",
+                        duration_ms=duration_ms,
+                    )
             except Exception as exc:
                 duration_ms = int((time.monotonic() - t_start) * 1000)
                 logger.warning("[eval %s] scenario '%s' failed: %s", run_id, scenario.name, exc)

--- a/src/backend/app/services/eval_service.py
+++ b/src/backend/app/services/eval_service.py
@@ -162,11 +162,18 @@ def _build_foundry_oai_client(settings: Settings) -> Any:
 def _build_model_config(settings: Settings) -> dict[str, Any]:
     """Return the model config dict for azure-ai-evaluation evaluators."""
     azure_endpoint = settings.foundry_endpoint.rstrip("/")
-    model = settings.eval_model or "gpt-4.1"
+    # Prefer the actual deployment name (e.g. ``gpt-54``) — ``eval_model``'s
+    # default of ``gpt-4.1`` is only used if the runtime model isn't set.
+    model = (
+        settings.foundry_model_deployment
+        or settings.eval_model
+        or "gpt-4.1"
+    )
     api_key = os.environ.get("FOUNDRY_API_KEY", "").strip()
     config: dict[str, Any] = {
         "azure_endpoint": azure_endpoint,
         "azure_deployment": model,
+        "api_version": "2024-12-01-preview",
     }
     if api_key:
         config["api_key"] = api_key
@@ -176,14 +183,19 @@ def _build_model_config(settings: Settings) -> dict[str, Any]:
 
 
 def _apply_validate_model_config_patch() -> None:
-    """Patch azure-ai-evaluation's validate_model_config for Python 3.13 compat.
+    """Patch azure-ai-evaluation's validate_model_config.
 
-    Python 3.13 changed isinstance(v, typing.Any) to raise TypeError; this
-    breaks the credential-field check inside azure-ai-evaluation.  The patch
-    short-circuits when the config already has ``azure_endpoint``.
+    Two reasons this must run on ALL Python versions:
+
+    1. Python 3.13 changed ``isinstance(v, typing.Any)`` to raise TypeError;
+       this breaks the credential-field check inside azure-ai-evaluation.
+    2. azure-ai-evaluation's TypedDict for AzureOpenAIModelConfiguration does
+       NOT accept ``credential`` (only ``api_key`` / ``api_version``), so a
+       managed-identity-flavored dict fails strict validation on 3.11 too.
+
+    The patch short-circuits validation when the config already has
+    ``azure_endpoint`` — the only field we actually need to be well-formed.
     """
-    if sys.version_info < (3, 13):
-        return
     try:
         import azure.ai.evaluation._common.utils as _eval_utils
         import azure.ai.evaluation._evaluators._common._base_prompty_eval as _bpe
@@ -260,12 +272,60 @@ def _filter_tool_calls(tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]
 
 
 def _build_tool_definitions(expected_tool_calls: list[str]) -> list[dict[str, Any]]:
-    """Build the tool_definitions list for evaluators from expected tool names."""
+    """Build the tool_definitions list for evaluators from expected tool names.
+
+    ToolCallAccuracyEvaluator requires each definition to carry a ``parameters``
+    field (JSON Schema shape). We don't know the real schema of expected tools,
+    so emit an empty-object schema which matches the evaluator's contract while
+    staying generic.
+    """
     filtered = [t for t in expected_tool_calls if t not in _INTERNAL_TOOLS]
     return [
-        {"name": t if t.startswith(_MCP_PREFIX) else _MCP_PREFIX + t}
+        {
+            "name": t if t.startswith(_MCP_PREFIX) else _MCP_PREFIX + t,
+            "description": f"Skill: {t}",
+            "parameters": {"type": "object", "properties": {}},
+        }
         for t in filtered
     ]
+
+
+def _apply_openai_max_tokens_patch() -> None:
+    """Translate ``max_tokens`` → ``max_completion_tokens`` on OpenAI calls.
+
+    gpt-5.x / o1-* models reject ``max_tokens`` and require the new
+    ``max_completion_tokens`` parameter. azure-ai-evaluation's prompty
+    templates still hardcode ``max_tokens``, so we monkey-patch the OpenAI
+    chat-completions ``create`` method to rewrite the parameter at call time.
+    Idempotent.
+    """
+    try:
+        from openai.resources.chat import completions as _cc  # noqa: PLC0415
+
+        for cls_name in ("Completions", "AsyncCompletions"):
+            cls = getattr(_cc, cls_name, None)
+            if cls is None:
+                continue
+            orig = cls.create
+            if getattr(orig, "_kratos_max_tokens_patched", False):
+                continue
+
+            if cls_name == "AsyncCompletions":
+                async def _patched_async(self, *args, _orig=orig, **kwargs):  # type: ignore[no-untyped-def]
+                    if "max_tokens" in kwargs and "max_completion_tokens" not in kwargs:
+                        kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
+                    return await _orig(self, *args, **kwargs)
+                _patched_async._kratos_max_tokens_patched = True  # type: ignore[attr-defined]
+                cls.create = _patched_async  # type: ignore[assignment]
+            else:
+                def _patched_sync(self, *args, _orig=orig, **kwargs):  # type: ignore[no-untyped-def]
+                    if "max_tokens" in kwargs and "max_completion_tokens" not in kwargs:
+                        kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
+                    return _orig(self, *args, **kwargs)
+                _patched_sync._kratos_max_tokens_patched = True  # type: ignore[attr-defined]
+                cls.create = _patched_sync  # type: ignore[assignment]
+    except Exception:
+        pass
 
 
 # ── EvalService ───────────────────────────────────────────────────────────────
@@ -618,9 +678,17 @@ class EvalService:
             if idx < total - 1:
                 await asyncio.sleep(5)
 
-        # ── Phase 2: SCORING (FOUNDRY mode only) ─────────────────────────
-        if run.mode == EvalMode.FOUNDRY:
+        # ── Phase 2: SCORING (both validation + foundry modes) ──────────
+        # The mode label is purely a pacing/strictness hint — both flows
+        # benefit from per-evaluator scores. Without this, results[].scores
+        # is empty and the eval panel can't render per-evaluator bars.
+        # Scoring is best-effort enrichment; never let a scoring failure
+        # mark the whole run as failed when invocations succeeded.
+        try:
             await self._score_run(run, scenarios_to_run, use_case, run_id)
+        except Exception as exc:
+            logger.exception("[eval %s] scoring failed (invocations OK)", run_id)
+            run.error = f"Scoring failed: {exc}"
 
         # ── Phase 3: Write report ─────────────────────────────────────────
         report = self._build_report(run, use_case)
@@ -645,6 +713,7 @@ class EvalService:
 
         # Lazy import — azure-ai-evaluation may not be installed
         _apply_validate_model_config_patch()
+        _apply_openai_max_tokens_patch()
         try:
             from azure.ai.evaluation import (  # noqa: PLC0415
                 CoherenceEvaluator,
@@ -658,13 +727,24 @@ class EvalService:
             return
 
         model_config = _build_model_config(self._settings)
-        evaluators = {
-            "TaskAdherence": TaskAdherenceEvaluator(model_config=model_config),
-            "IntentResolution": IntentResolutionEvaluator(model_config=model_config),
-            "Coherence": CoherenceEvaluator(model_config=model_config),
-            "Relevance": RelevanceEvaluator(model_config=model_config),
-            "ToolCallAccuracy": ToolCallAccuracyEvaluator(model_config=model_config),
+        # Lazy per-evaluator instantiation — if one evaluator class fails to
+        # construct (e.g. version-specific validation), the rest still run.
+        evaluator_classes = {
+            "TaskAdherence": TaskAdherenceEvaluator,
+            "IntentResolution": IntentResolutionEvaluator,
+            "Coherence": CoherenceEvaluator,
+            "Relevance": RelevanceEvaluator,
+            "ToolCallAccuracy": ToolCallAccuracyEvaluator,
         }
+        evaluators: dict[str, Any] = {}
+        for name, cls in evaluator_classes.items():
+            try:
+                evaluators[name] = cls(model_config=model_config)
+            except Exception as exc:
+                logger.warning("[eval %s] evaluator %s init failed: %s", run_id, name, exc)
+        if not evaluators:
+            logger.error("[eval %s] no evaluators could be instantiated", run_id)
+            return
 
         scenario_map: dict[str, EvalScenario] = {s.name: s for s in scenarios}
         criteria_totals: dict[str, dict[str, int]] = {}

--- a/src/backend/app/services/eval_storage.py
+++ b/src/backend/app/services/eval_storage.py
@@ -1,0 +1,279 @@
+"""Eval storage — scenarios, runs, results in blob (with local fallback).
+
+Layout (in the ``skills`` container, alongside existing use-case content):
+
+    use-cases/{use_case}/evals/eval_config.json
+    use-cases/{use_case}/evals/scenarios/{name}.json
+    use-cases/{use_case}/evals/runs/{run_id}/_meta.json
+    use-cases/{use_case}/evals/runs/{run_id}/run_results.jsonl
+    use-cases/{use_case}/evals/runs/{run_id}/eval_report.json
+
+A repository-local fallback under ``use-cases/{use_case}/evals/`` is used when
+blob storage is not configured (local-mode dev without Azurite). Scenarios
+checked into Git seed the blob via the existing ``seed_from_local`` flow in
+``BlobSkillService`` because they live under the same ``use-cases/`` tree.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from app.models import EvalRun, EvalScenario
+from app.services.blob_skill_service import BlobSkillService
+
+logger = logging.getLogger(__name__)
+
+_USE_CASES_PREFIX = "use-cases/"
+_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,80}$")
+
+
+def _evals_root(use_case: str) -> str:
+    return f"{_USE_CASES_PREFIX}{use_case}/evals"
+
+
+def _scenarios_prefix(use_case: str) -> str:
+    return f"{_evals_root(use_case)}/scenarios/"
+
+
+def _runs_prefix(use_case: str) -> str:
+    return f"{_evals_root(use_case)}/runs/"
+
+
+def _validate_name(name: str) -> str:
+    if not _NAME_PATTERN.match(name):
+        raise ValueError(
+            f"Invalid scenario name '{name}'. Must match {_NAME_PATTERN.pattern}"
+        )
+    return name
+
+
+class EvalStorage:
+    """Read/write scenarios and runs to blob, falling back to the local repo."""
+
+    def __init__(self, blob: BlobSkillService, local_base_dir: str | Path = "use-cases") -> None:
+        self._blob = blob
+        self._local_base = Path(local_base_dir)
+
+    # ── Local helpers ────────────────────────────────────────────────────
+
+    def _local_dir(self, use_case: str) -> Path:
+        return self._local_base / use_case / "evals"
+
+    def _local_scenarios_dir(self, use_case: str) -> Path:
+        return self._local_dir(use_case) / "scenarios"
+
+    def _local_runs_dir(self, use_case: str) -> Path:
+        return self._local_dir(use_case) / "results" / "runs"
+
+    # ── Scenarios ────────────────────────────────────────────────────────
+
+    async def list_scenarios(self, use_case: str) -> list[EvalScenario]:
+        """Return all scenarios for a use-case.
+
+        Source priority:
+          1. blob (if available)
+          2. local filesystem (always merged in for repo-shipped scenarios)
+        """
+        seen: dict[str, EvalScenario] = {}
+
+        # 1) local first — these ship with the repo
+        local_dir = self._local_scenarios_dir(use_case)
+        if local_dir.is_dir():
+            for p in sorted(local_dir.glob("*.json")):
+                try:
+                    seen[p.stem] = EvalScenario.model_validate_json(p.read_text(encoding="utf-8"))
+                except Exception as exc:
+                    logger.warning("Failed to load local scenario %s: %s", p, exc)
+
+        # 2) blob overrides — UI-edited scenarios win
+        if self._blob.is_available:
+            prefix = _scenarios_prefix(use_case)
+            try:
+                client = self._blob._container_client  # noqa: SLF001 — internal access by design
+                if client is not None:
+                    async for blob in client.list_blobs(name_starts_with=prefix):
+                        if not blob.name.endswith(".json"):
+                            continue
+                        raw = await self._blob.download_blob(blob.name)
+                        if not raw:
+                            continue
+                        try:
+                            scenario = EvalScenario.model_validate_json(raw.decode("utf-8"))
+                            seen[scenario.name] = scenario
+                        except Exception as exc:
+                            logger.warning("Failed to load blob scenario %s: %s", blob.name, exc)
+            except Exception:
+                logger.exception("Failed to list blob scenarios for %s", use_case)
+
+        return sorted(seen.values(), key=lambda s: s.name)
+
+    async def get_scenario(self, use_case: str, name: str) -> EvalScenario | None:
+        _validate_name(name)
+        # blob first (latest edits), then local fallback
+        if self._blob.is_available:
+            raw = await self._blob.download_blob(f"{_scenarios_prefix(use_case)}{name}.json")
+            if raw:
+                try:
+                    return EvalScenario.model_validate_json(raw.decode("utf-8"))
+                except Exception as exc:
+                    logger.warning("Bad scenario in blob %s: %s", name, exc)
+
+        local_path = self._local_scenarios_dir(use_case) / f"{name}.json"
+        if local_path.is_file():
+            try:
+                return EvalScenario.model_validate_json(local_path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                logger.warning("Bad scenario in repo %s: %s", local_path, exc)
+        return None
+
+    async def upsert_scenario(self, use_case: str, scenario: EvalScenario) -> None:
+        _validate_name(scenario.name)
+        payload = scenario.model_dump_json(indent=2).encode("utf-8")
+        if self._blob.is_available:
+            await self._blob.upload_file(
+                f"{_scenarios_prefix(use_case)}{scenario.name}.json", payload
+            )
+        # Always mirror to local filesystem so devs see the file in their tree
+        local_dir = self._local_scenarios_dir(use_case)
+        local_dir.mkdir(parents=True, exist_ok=True)
+        (local_dir / f"{scenario.name}.json").write_bytes(payload)
+
+    async def delete_scenario(self, use_case: str, name: str) -> bool:
+        _validate_name(name)
+        removed = False
+        if self._blob.is_available and self._blob._container_client is not None:  # noqa: SLF001
+            try:
+                client = self._blob._container_client.get_blob_client(  # noqa: SLF001
+                    f"{_scenarios_prefix(use_case)}{name}.json"
+                )
+                await client.delete_blob()
+                removed = True
+            except Exception:
+                # already gone or never existed
+                pass
+        local_path = self._local_scenarios_dir(use_case) / f"{name}.json"
+        if local_path.is_file():
+            local_path.unlink()
+            removed = True
+        return removed
+
+    # ── Eval config ──────────────────────────────────────────────────────
+
+    async def get_eval_config(self, use_case: str) -> dict[str, Any]:
+        # Blob takes precedence, then local file, then default
+        for source in ("blob", "local"):
+            if source == "blob" and self._blob.is_available:
+                raw = await self._blob.download_blob(f"{_evals_root(use_case)}/eval_config.json")
+                if raw:
+                    try:
+                        return json.loads(raw.decode("utf-8"))
+                    except Exception:
+                        continue
+            if source == "local":
+                local = self._local_dir(use_case) / "eval_config.json"
+                if local.is_file():
+                    try:
+                        return json.loads(local.read_text(encoding="utf-8"))
+                    except Exception:
+                        continue
+        return {
+            "evaluation": {
+                "evaluators": [
+                    "Relevance",
+                    "Coherence",
+                    "TaskAdherence",
+                    "IntentResolution",
+                    "ToolCallAccuracy",
+                ],
+                "judge_model_env": "EVAL_MODEL",
+                "judge_model_default": "gpt-4.1",
+            }
+        }
+
+    # ── Runs ─────────────────────────────────────────────────────────────
+
+    async def save_run(self, run: EvalRun) -> None:
+        run.updated_at = datetime.now(timezone.utc)
+        payload = run.model_dump_json(indent=2).encode("utf-8")
+        if self._blob.is_available:
+            await self._blob.upload_file(
+                f"{_runs_prefix(run.use_case)}{run.run_id}/_meta.json", payload
+            )
+        local_dir = self._local_runs_dir(run.use_case) / run.run_id
+        local_dir.mkdir(parents=True, exist_ok=True)
+        (local_dir / "_meta.json").write_bytes(payload)
+
+    async def load_run(self, use_case: str, run_id: str) -> EvalRun | None:
+        if self._blob.is_available:
+            raw = await self._blob.download_blob(
+                f"{_runs_prefix(use_case)}{run_id}/_meta.json"
+            )
+            if raw:
+                try:
+                    return EvalRun.model_validate_json(raw.decode("utf-8"))
+                except Exception as exc:
+                    logger.warning("Bad run meta blob %s: %s", run_id, exc)
+
+        local = self._local_runs_dir(use_case) / run_id / "_meta.json"
+        if local.is_file():
+            try:
+                return EvalRun.model_validate_json(local.read_text(encoding="utf-8"))
+            except Exception as exc:
+                logger.warning("Bad run meta locally %s: %s", local, exc)
+        return None
+
+    async def list_runs(self, use_case: str, limit: int = 50) -> list[EvalRun]:
+        ids: set[str] = set()
+        if self._blob.is_available and self._blob._container_client is not None:  # noqa: SLF001
+            prefix = _runs_prefix(use_case)
+            try:
+                async for blob in self._blob._container_client.list_blobs(name_starts_with=prefix):  # noqa: SLF001
+                    rel = blob.name.removeprefix(prefix)
+                    parts = rel.split("/", 1)
+                    if parts and parts[0]:
+                        ids.add(parts[0])
+            except Exception:
+                logger.exception("Failed to list runs for %s", use_case)
+
+        local_runs_dir = self._local_runs_dir(use_case)
+        if local_runs_dir.is_dir():
+            for child in local_runs_dir.iterdir():
+                if child.is_dir() and (child / "_meta.json").is_file():
+                    ids.add(child.name)
+
+        runs: list[EvalRun] = []
+        for run_id in ids:
+            run = await self.load_run(use_case, run_id)
+            if run is not None:
+                runs.append(run)
+        runs.sort(key=lambda r: r.created_at, reverse=True)
+        return runs[:limit]
+
+    async def append_jsonl(self, use_case: str, run_id: str, record: dict[str, Any]) -> None:
+        line = json.dumps(record, default=str) + "\n"
+        local_dir = self._local_runs_dir(use_case) / run_id
+        local_dir.mkdir(parents=True, exist_ok=True)
+        local_path = local_dir / "run_results.jsonl"
+        with local_path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+        if self._blob.is_available:
+            # Blob append: re-upload the whole file (small per-run, no contention)
+            content = local_path.read_bytes()
+            await self._blob.upload_file(
+                f"{_runs_prefix(use_case)}{run_id}/run_results.jsonl", content
+            )
+
+    async def write_report(self, use_case: str, run_id: str, report: dict[str, Any]) -> None:
+        payload = json.dumps(report, indent=2, default=str).encode("utf-8")
+        if self._blob.is_available:
+            await self._blob.upload_file(
+                f"{_runs_prefix(use_case)}{run_id}/eval_report.json", payload
+            )
+        local_dir = self._local_runs_dir(use_case) / run_id
+        local_dir.mkdir(parents=True, exist_ok=True)
+        (local_dir / "eval_report.json").write_bytes(payload)

--- a/src/backend/app/services/foundry_agent_proxy.py
+++ b/src/backend/app/services/foundry_agent_proxy.py
@@ -68,6 +68,7 @@ class FoundryAgentProxy:
         use_case: str = "generic",
         system_prompt: str | None = None,
         agent_session_id: str | None = None,
+        eval_run_id: str | None = None,
     ) -> AsyncGenerator[dict, None]:
         """Invoke the hosted agent and yield event dicts.
 
@@ -100,7 +101,11 @@ class FoundryAgentProxy:
             "Content-Type": "application/json",
             "Accept": "text/event-stream",
             "Foundry-Features": "HostedAgents=V1Preview",
+            "x-kratos-use-case": str(use_case) if use_case else "",
+            "x-kratos-conversation-id": str(conversation_id) if conversation_id else "",
         }
+        if eval_run_id:
+            headers["x-kratos-eval-run-id"] = str(eval_run_id)
         if token:
             headers["Authorization"] = f"Bearer {token}"
         payload = {

--- a/src/backend/app/services/skill_tools.py
+++ b/src/backend/app/services/skill_tools.py
@@ -9,6 +9,7 @@ import logging
 import os
 import subprocess
 import time
+from contextvars import ContextVar
 from pathlib import Path
 
 import httpx
@@ -21,6 +22,26 @@ from opentelemetry import trace
 from pydantic import BaseModel, Field
 
 tracer = trace.get_tracer(__name__)
+
+# ─── Kratos context vars — set by copilot_agent.run() so tool spans carry the ─
+# ─── same kratos attributes as the parent invoke_agent span.               ─────
+
+_ctx_use_case: ContextVar[str] = ContextVar("kratos_use_case", default="")
+_ctx_conversation_id: ContextVar[str] = ContextVar("kratos_conversation_id", default="")
+_ctx_eval_run_id: ContextVar[str] = ContextVar("kratos_eval_run_id", default="")
+
+
+def _set_kratos_attrs(span: trace.Span) -> None:
+    """Stamp kratos.* attributes on *span* from the active context vars."""
+    use_case = _ctx_use_case.get()
+    if use_case:
+        span.set_attribute("kratos.use_case", use_case)
+    conv_id = _ctx_conversation_id.get()
+    if conv_id:
+        span.set_attribute("kratos.conversation_id", conv_id)
+    eval_run_id = _ctx_eval_run_id.get()
+    if eval_run_id:
+        span.set_attribute("kratos.eval_run_id", eval_run_id)
 
 # ─── Shared singletons — avoid recreating expensive objects on every tool call ─
 
@@ -52,7 +73,8 @@ class WebSearchParams(BaseModel):
 @define_tool(description="Real-time internet search for current information and market data")
 async def web_search(params: WebSearchParams) -> dict:
     """Search the internet using Foundry web_search_preview tool."""
-    with tracer.start_as_current_span("skill.web_search"):
+    with tracer.start_as_current_span("skill.web_search") as span:
+        _set_kratos_attrs(span)
         t0 = time.monotonic()
         query = params.query
         logger.info("web_search called: query=%r", query)
@@ -135,7 +157,8 @@ class RAGSearchParams(BaseModel):
 @define_tool(description="Azure AI Search knowledge base for grounded answers from internal documents")
 async def rag_search(params: RAGSearchParams) -> dict:
     """Search the Azure AI Search knowledge base."""
-    with tracer.start_as_current_span("skill.rag_search"):
+    with tracer.start_as_current_span("skill.rag_search") as span:
+        _set_kratos_attrs(span)
         ai_search_endpoint = os.environ.get("AZURE_AI_SEARCH_ENDPOINT", "")
         if not ai_search_endpoint:
             return {"error": "AZURE_AI_SEARCH_ENDPOINT not configured"}
@@ -177,7 +200,8 @@ class CodeInterpreterParams(BaseModel):
 @define_tool(description="Sandboxed Python execution for computation, data analysis, and code generation")
 async def code_interpreter(params: CodeInterpreterParams) -> dict:
     """Execute Python code in a sandboxed subprocess."""
-    with tracer.start_as_current_span("skill.code_interpreter"):
+    with tracer.start_as_current_span("skill.code_interpreter") as span:
+        _set_kratos_attrs(span)
         try:
             result = subprocess.run(
                 ["python", "-c", params.code],
@@ -209,7 +233,8 @@ class FoundryAgentParams(BaseModel):
 @define_tool(description="Delegate complex or specialized tasks to Microsoft Foundry sub-agents")
 async def foundry_agent(params: FoundryAgentParams) -> dict:
     """Delegate a task to a Microsoft Foundry specialized sub-agent."""
-    with tracer.start_as_current_span("skill.foundry_agent"):
+    with tracer.start_as_current_span("skill.foundry_agent") as span:
+        _set_kratos_attrs(span)
         foundry_endpoint = os.environ.get("FOUNDRY_ENDPOINT", "")
         if not foundry_endpoint:
             return {"error": "FOUNDRY_ENDPOINT not configured"}
@@ -341,7 +366,8 @@ class CRMParams(BaseModel):
 @define_tool(description="Search and retrieve wealth-management or insurance customer profiles and holdings from the CRM system")
 async def crm(params: CRMParams) -> dict:
     """CRM lookup for wealth-management clients or insurance customers."""
-    with tracer.start_as_current_span("skill.crm"):
+    with tracer.start_as_current_span("skill.crm") as span:
+        _set_kratos_attrs(span)
         domain = params.domain.strip().lower()
         action = params.action.strip().lower()
         query = params.query.strip()

--- a/src/backend/app/services/traces_service.py
+++ b/src/backend/app/services/traces_service.py
@@ -1,0 +1,513 @@
+"""Traces service — queries App Insights for agent operation waterfalls.
+
+Queries ``dependencies``, ``requests``, and ``traces`` tables via
+``LogsQueryClient``.  Spans are classified, depth-computed, and returned
+as Pydantic models matching ``app.models.TraceList / TraceOperation``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import timedelta
+from typing import Any
+
+from azure.identity import DefaultAzureCredential
+from azure.monitor.query import LogsQueryClient, LogsQueryStatus
+
+from app.config import Settings
+from app.models import TraceList, TraceLog, TraceOperation, TraceSpan, TraceSummary
+
+logger = logging.getLogger(__name__)
+
+
+class TracesService:
+    def __init__(self, settings: Settings) -> None:
+        self._resource_id = (settings.application_insights_resource_id or "").strip()
+        self._workspace_id = (settings.application_insights_workspace_id or "").strip()
+        self._credential = DefaultAzureCredential()
+        self._client = LogsQueryClient(self._credential)
+
+    # ─── Public API ──────────────────────────────────────────────────────────
+
+    async def fetch_operations(
+        self,
+        *,
+        use_case: str | None = None,
+        conversation_id: str | None = None,
+        eval_run_id: str | None = None,
+        lookback_hours: int = 24,
+        max_operations: int = 50,
+    ) -> TraceList:
+        """Return up to ``max_operations`` most-recent operations matching the filter."""
+        resource = self._resource_id or self._workspace_id
+        if not resource:
+            return TraceList(
+                operations=[],
+                summary=TraceSummary(error="No App Insights resource configured"),
+            )
+
+        # Build the WHERE clause for the narrow op-id query
+        filter_parts: list[str] = []
+        if use_case:
+            filter_parts.append(f"tostring(customDimensions['kratos.use_case']) == '{use_case}'")
+        if conversation_id:
+            filter_parts.append(
+                f"tostring(customDimensions['kratos.conversation_id']) == '{conversation_id}'"
+            )
+        if eval_run_id:
+            filter_parts.append(
+                f"tostring(customDimensions['kratos.eval_run_id']) == '{eval_run_id}'"
+            )
+
+        if filter_parts:
+            narrow_filter = " and ".join(filter_parts)
+        else:
+            # No filter — find recent "interesting" operations (agent / LLM spans)
+            narrow_filter = (
+                "cloud_RoleName == 'agent_framework'"
+                " or cloud_RoleName startswith 'AgentService-'"
+                " or cloud_RoleName == 'responsesapi'"
+                " or isnotempty(tostring(customDimensions['kratos.use_case']))"
+            )
+
+        span_kql = _build_span_kql(narrow_filter, lookback_hours, max_operations)
+        log_kql = _build_log_kql(narrow_filter, lookback_hours, max_operations)
+
+        try:
+            span_resp, log_resp = await asyncio.gather(
+                asyncio.to_thread(self._run_query, resource, span_kql, lookback_hours),
+                asyncio.to_thread(self._run_query, resource, log_kql, lookback_hours),
+            )
+        except Exception as exc:
+            logger.exception("Failed to query App Insights traces")
+            return TraceList(
+                operations=[],
+                summary=TraceSummary(error=str(exc)),
+            )
+
+        spans_tables = _extract_tables(span_resp)
+        log_tables = _extract_tables(log_resp)
+
+        log_map = _parse_logs(log_tables)
+        operations = _parse_spans(spans_tables, log_map, max_operations)
+        summary = _build_summary(operations)
+        return TraceList(operations=operations, summary=summary)
+
+    async def fetch_operation(
+        self,
+        operation_id: str,
+        *,
+        lookback_hours: int = 168,
+    ) -> TraceOperation | None:
+        """Return a single operation by ID with its full span list."""
+        resource = self._resource_id or self._workspace_id
+        if not resource:
+            return None
+
+        safe_id = operation_id.replace("'", "\\'")
+        narrow_filter = f"operation_Id == '{safe_id}'"
+        span_kql = _build_span_kql(narrow_filter, lookback_hours, max_ops=1)
+        log_kql = _build_log_kql(narrow_filter, lookback_hours, max_ops=1)
+
+        try:
+            span_resp, log_resp = await asyncio.gather(
+                asyncio.to_thread(self._run_query, resource, span_kql, lookback_hours),
+                asyncio.to_thread(self._run_query, resource, log_kql, lookback_hours),
+            )
+        except Exception:
+            logger.exception("Failed to fetch operation %s", operation_id)
+            return None
+
+        spans_tables = _extract_tables(span_resp)
+        log_tables = _extract_tables(log_resp)
+
+        log_map = _parse_logs(log_tables)
+        operations = _parse_spans(spans_tables, log_map, max_ops=1)
+        return operations[0] if operations else None
+
+    async def close(self) -> None:
+        """Release SDK resources."""
+        try:
+            self._client.close()
+        except Exception:
+            pass
+
+    # ─── Internal ────────────────────────────────────────────────────────────
+
+    def _run_query(self, resource: str, kql: str, hours: int) -> Any:
+        """Execute a KQL query synchronously (called via asyncio.to_thread)."""
+        ts = timedelta(hours=hours)
+        if resource.startswith("/"):
+            try:
+                return self._client.query_resource(resource_id=resource, query=kql, timespan=ts)
+            except TypeError:
+                return self._client.query_resource(resource_uri=resource, query=kql, timespan=ts)
+        return self._client.query_workspace(workspace_id=resource, query=kql, timespan=ts)
+
+
+# ─── KQL builders ────────────────────────────────────────────────────────────
+
+
+def _build_span_kql(narrow_filter: str, lookback_hours: int, max_ops: int) -> str:
+    return f"""
+let matching_ops =
+    union dependencies, requests
+    | where timestamp > ago({lookback_hours}h)
+    | where {narrow_filter}
+    | distinct operation_Id
+    | take {max_ops * 4};
+union dependencies, requests
+| where timestamp > ago({lookback_hours}h)
+| where operation_Id in (matching_ops)
+| summarize arg_max(timestamp, *) by id
+| project
+    timestamp,
+    id,
+    operation_Id,
+    parentId = operation_ParentId,
+    name,
+    duration,
+    success,
+    resultCode,
+    spanType = itemType,
+    cloud_RoleName,
+    dep_type = case(itemType == 'dependency', type, ''),
+    dep_target = case(itemType == 'dependency', tostring(target), ''),
+    model = tostring(customDimensions['gen_ai.response.model']),
+    op_name = tostring(customDimensions['gen_ai.operation.name']),
+    input_tokens = toint(customDimensions['gen_ai.usage.input_tokens']),
+    output_tokens = toint(customDimensions['gen_ai.usage.output_tokens']),
+    tool_name = tostring(customDimensions['gen_ai.tool.name']),
+    tool_kind = tostring(customDimensions['gen_ai.tool.kind']),
+    error_type = tostring(customDimensions['error.type']),
+    kratos_use_case = tostring(customDimensions['kratos.use_case']),
+    kratos_conversation_id = tostring(customDimensions['kratos.conversation_id']),
+    kratos_eval_run_id = tostring(customDimensions['kratos.eval_run_id']),
+    kratos_skill_name = tostring(customDimensions['kratos.skill.name'])
+| order by timestamp asc
+"""
+
+
+def _build_log_kql(narrow_filter: str, lookback_hours: int, max_ops: int) -> str:
+    return f"""
+let matching_ops =
+    union dependencies, requests
+    | where timestamp > ago({lookback_hours}h)
+    | where {narrow_filter}
+    | distinct operation_Id
+    | take {max_ops * 4};
+traces
+| where timestamp > ago({lookback_hours}h)
+| where operation_Id in (matching_ops)
+| where not(message has "Credential.get_token" and message has "succeeded")
+    and message !has "acquired a token"
+| project
+    timestamp,
+    operation_Id,
+    message = substring(message, 0, 2000),
+    severityLevel,
+    cloud_RoleName
+| order by timestamp asc
+"""
+
+
+# ─── Query result helpers ─────────────────────────────────────────────────────
+
+
+def _extract_tables(resp: Any) -> list:
+    """Extract table list from a LogsQueryResult, tolerating partial data."""
+    if resp is None:
+        return []
+    if getattr(resp, "status", None) == LogsQueryStatus.SUCCESS:
+        return resp.tables or []
+    if hasattr(resp, "partial_data") and resp.partial_data:
+        return resp.partial_data
+    return []
+
+
+# ─── Parsers ─────────────────────────────────────────────────────────────────
+
+
+def _parse_logs(tables: list) -> dict[str, list[TraceLog]]:
+    """Return log entries from the traces table, grouped by operation_Id."""
+    log_map: dict[str, list[TraceLog]] = {}
+    if not tables:
+        return log_map
+    table = tables[0]
+    columns = [c if isinstance(c, str) else c.name for c in table.columns]
+    for row in table.rows:
+        d = dict(zip(columns, row))
+        op_id = d.get("operation_Id", "")
+        msg = str(d.get("message", ""))
+        if not op_id or not msg:
+            continue
+        log_map.setdefault(op_id, []).append(
+            TraceLog(
+                timestamp=str(d.get("timestamp", "")),
+                message=msg,
+                severity=int(d.get("severityLevel") or 1),
+                cloud_role=str(d.get("cloud_RoleName") or ""),
+            )
+        )
+    return log_map
+
+
+def _parse_spans(
+    tables: list,
+    log_map: dict[str, list[TraceLog]],
+    max_ops: int,
+) -> list[TraceOperation]:
+    """Parse span rows into ``TraceOperation`` objects."""
+    if not tables:
+        return []
+
+    table = tables[0]
+    columns = [c if isinstance(c, str) else c.name for c in table.columns]
+
+    # Group raw rows by operation_Id
+    ops_raw: dict[str, list[dict[str, Any]]] = {}
+    for row in table.rows:
+        d = dict(zip(columns, row))
+        op_id = str(d.get("operation_Id") or "")
+        if not op_id:
+            continue
+        ops_raw.setdefault(op_id, []).append(d)
+
+    operations: list[TraceOperation] = []
+    for op_id, raw_spans in ops_raw.items():
+        raw_spans.sort(key=lambda x: str(x.get("timestamp") or ""))
+
+        timestamps_ms = [_ts_to_ms(str(s.get("timestamp") or "")) for s in raw_spans]
+        valid_ts = [t for t in timestamps_ms if t is not None]
+        op_start_ms = min(valid_ts) if valid_ts else 0.0
+
+        spans: list[TraceSpan] = []
+        for i, s in enumerate(raw_spans):
+            dur = s.get("duration") or 0
+            try:
+                dur = float(dur)
+            except (ValueError, TypeError):
+                dur = 0.0
+
+            ts_ms = timestamps_ms[i]
+            offset_ms = round(ts_ms - op_start_ms, 1) if ts_ms is not None and op_start_ms else 0.0
+            raw_dict = dict(s)  # pass to classifier
+            category = _classify_span(raw_dict)
+
+            attributes: dict[str, str | int | float] = {}
+            if s.get("model"):
+                attributes["gen_ai.response.model"] = str(s["model"])
+            if s.get("op_name"):
+                attributes["gen_ai.operation.name"] = str(s["op_name"])
+            if s.get("input_tokens") is not None:
+                try:
+                    attributes["gen_ai.usage.input_tokens"] = int(s["input_tokens"])
+                except (ValueError, TypeError):
+                    pass
+            if s.get("output_tokens") is not None:
+                try:
+                    attributes["gen_ai.usage.output_tokens"] = int(s["output_tokens"])
+                except (ValueError, TypeError):
+                    pass
+            if s.get("tool_name"):
+                attributes["gen_ai.tool.name"] = str(s["tool_name"])
+            if s.get("error_type"):
+                attributes["error.type"] = str(s["error_type"])
+            if s.get("dep_target"):
+                attributes["http.target"] = str(s["dep_target"])
+            if s.get("kratos_use_case"):
+                attributes["kratos.use_case"] = str(s["kratos_use_case"])
+            if s.get("kratos_conversation_id"):
+                attributes["kratos.conversation_id"] = str(s["kratos_conversation_id"])
+            if s.get("kratos_eval_run_id"):
+                attributes["kratos.eval_run_id"] = str(s["kratos_eval_run_id"])
+            if s.get("kratos_skill_name"):
+                attributes["kratos.skill.name"] = str(s["kratos_skill_name"])
+
+            success_raw = s.get("success", True)
+            success = bool(success_raw) if success_raw is not None else True
+
+            spans.append(
+                TraceSpan(
+                    id=str(s.get("id") or ""),
+                    parent_id=str(s.get("parentId") or ""),
+                    name=str(s.get("name") or ""),
+                    duration_ms=round(dur, 1),
+                    offset_ms=max(0.0, offset_ms),
+                    timestamp=str(s.get("timestamp") or ""),
+                    success=success,
+                    result_code=str(s.get("resultCode") or ""),
+                    type=str(s.get("spanType") or ""),
+                    cloud_role=str(s.get("cloud_RoleName") or ""),
+                    category=category,
+                    attributes=attributes,
+                )
+            )
+
+        _compute_depths(spans)
+
+        # Total wall-clock: last span's end relative to op start
+        total_dur = max(
+            (s.offset_ms + s.duration_ms for s in spans),
+            default=0.0,
+        )
+
+        # Skip operations with only stray HTTP / platform / other spans
+        categories = {s.category for s in spans}
+        if categories <= {"http", "other", "platform"}:
+            continue
+
+        # Collect kratos metadata from the first span that has it
+        use_case = ""
+        conversation_id = ""
+        eval_run_id = ""
+        for s in raw_spans:
+            if not use_case and s.get("kratos_use_case"):
+                use_case = str(s["kratos_use_case"])
+            if not conversation_id and s.get("kratos_conversation_id"):
+                conversation_id = str(s["kratos_conversation_id"])
+            if not eval_run_id and s.get("kratos_eval_run_id"):
+                eval_run_id = str(s["kratos_eval_run_id"])
+
+        op_ts = str(raw_spans[0].get("timestamp") or "") if raw_spans else ""
+        logs = log_map.get(op_id, [])[:30]
+
+        operations.append(
+            TraceOperation(
+                operation_id=op_id,
+                timestamp=op_ts,
+                total_duration_ms=round(total_dur, 1),
+                span_count=len(spans),
+                use_case=use_case,
+                conversation_id=conversation_id,
+                eval_run_id=eval_run_id,
+                spans=spans,
+                logs=logs,
+            )
+        )
+
+    operations.sort(key=lambda o: o.timestamp, reverse=True)
+    return operations[:max_ops]
+
+
+# ─── Span helpers ─────────────────────────────────────────────────────────────
+
+
+def _classify_span(s: dict[str, Any]) -> str:
+    """Classify a raw span dict into a display category."""
+    name = str(s.get("name") or "").lower()
+    op_name = str(s.get("op_name") or "")
+    model = str(s.get("model") or "")
+    tool_name = str(s.get("tool_name") or "")
+    tool_kind = str(s.get("tool_kind") or "")
+    role = str(s.get("cloud_RoleName") or "").lower()
+    span_type = str(s.get("spanType") or "").lower()
+    dep_type = str(s.get("dep_type") or "").lower()
+    skill_name = str(s.get("kratos_skill_name") or "")
+    success_raw = s.get("success", True)
+
+    # LLM spans first — gen_ai operation or chat name
+    if op_name or model or name.startswith("chat ") or "responses.create" in name:
+        return "llm"
+
+    # Agent root invocation
+    if role == "agent_framework":
+        return "agent"
+
+    # Internal agent spans
+    if name.startswith("agent.") or name.startswith("agent_internal."):
+        return "agent_internal"
+
+    # Tool spans
+    if tool_name or tool_kind == "tool":
+        return "tool"
+
+    # Skill spans (kratos-specific)
+    if skill_name or name.startswith("skill.") or tool_kind == "skill":
+        return "skill"
+
+    # HTTP spans
+    if span_type == "request" or name.startswith("http ") or dep_type in ("http", "https"):
+        return "http"
+
+    # Platform spans (Foundry / Azure AI Services infrastructure)
+    if role == "responsesapi" or role.startswith("agentservice-"):
+        return "platform"
+
+    # Error spans
+    if success_raw is False:
+        return "error"
+
+    return "other"
+
+
+def _compute_depths(spans: list[TraceSpan]) -> None:
+    """Assign ``depth`` to each span by walking the parent-child tree in-place."""
+    id_set = {s.id for s in spans}
+    id_to_parent = {s.id: s.parent_id for s in spans}
+    depth_cache: dict[str, int] = {}
+
+    def _depth(sid: str) -> int:
+        if sid in depth_cache:
+            return depth_cache[sid]
+        pid = id_to_parent.get(sid, "")
+        if not pid or pid not in id_set:
+            depth_cache[sid] = 0
+            return 0
+        d = _depth(pid) + 1
+        depth_cache[sid] = d
+        return d
+
+    for s in spans:
+        s.depth = _depth(s.id)
+
+
+def _build_summary(operations: list[TraceOperation]) -> TraceSummary:
+    """Aggregate token counts, latency, and model usage across operations."""
+    if not operations:
+        return TraceSummary()
+
+    total_tokens = 0
+    models: set[str] = set()
+    latencies: list[float] = []
+
+    for op in operations:
+        latencies.append(op.total_duration_ms)
+        for span in op.spans:
+            attrs = span.attributes
+            inp = int(attrs.get("gen_ai.usage.input_tokens") or 0)
+            out = int(attrs.get("gen_ai.usage.output_tokens") or 0)
+            total_tokens += inp + out
+            model = str(attrs.get("gen_ai.response.model") or "")
+            if model:
+                models.add(model)
+
+    avg = round(sum(latencies) / len(latencies), 1) if latencies else 0.0
+    return TraceSummary(
+        total_operations=len(operations),
+        avg_latency_ms=avg,
+        total_tokens=total_tokens,
+        models_used=sorted(models),
+    )
+
+
+# ─── Timestamp helper ─────────────────────────────────────────────────────────
+
+
+def _ts_to_ms(ts_str: str) -> float | None:
+    """Parse an ISO timestamp string to epoch milliseconds, or None on failure."""
+    from datetime import datetime, timezone
+
+    if not ts_str:
+        return None
+    try:
+        s = ts_str.rstrip("Z")
+        if "+" not in s and "-" not in s[10:]:
+            s += "+00:00"
+        dt = datetime.fromisoformat(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp() * 1000
+    except (ValueError, TypeError):
+        return None

--- a/src/backend/app/services/traces_service.py
+++ b/src/backend/app/services/traces_service.py
@@ -88,6 +88,14 @@ class TracesService:
 
         spans_tables = _extract_tables(span_resp)
         log_tables = _extract_tables(log_resp)
+        logger.info(
+            "traces query: filter=%r span_tables=%d span_rows=%d log_tables=%d log_rows=%d",
+            narrow_filter[:120],
+            len(spans_tables),
+            sum(len(getattr(t, "rows", []) or []) for t in spans_tables),
+            len(log_tables),
+            sum(len(getattr(t, "rows", []) or []) for t in log_tables),
+        )
 
         log_map = _parse_logs(log_tables)
         operations = _parse_spans(spans_tables, log_map, max_operations)
@@ -216,13 +224,24 @@ traces
 
 
 def _extract_tables(resp: Any) -> list:
-    """Extract table list from a LogsQueryResult, tolerating partial data."""
+    """Extract table list from a LogsQueryResult, tolerating partial data.
+
+    The azure-monitor-query SDK returns either a `LogsQueryResult` (status=SUCCESS,
+    tables populated) or a `LogsQueryPartialResult` (partial_data populated,
+    partial_error set). Either way, we want the tables — only return [] if
+    neither shape has any data.
+    """
     if resp is None:
         return []
+    # SUCCESS path
     if getattr(resp, "status", None) == LogsQueryStatus.SUCCESS:
         return resp.tables or []
+    # PARTIAL path
     if hasattr(resp, "partial_data") and resp.partial_data:
         return resp.partial_data
+    # Some SDK versions return tables on the object regardless of status
+    if getattr(resp, "tables", None):
+        return resp.tables
     return []
 
 
@@ -353,11 +372,6 @@ def _parse_spans(
             default=0.0,
         )
 
-        # Skip operations with only stray HTTP / platform / other spans
-        categories = {s.category for s in spans}
-        if categories <= {"http", "other", "platform"}:
-            continue
-
         # Collect kratos metadata from the first span that has it
         use_case = ""
         conversation_id = ""
@@ -369,6 +383,12 @@ def _parse_spans(
                 conversation_id = str(s["kratos_conversation_id"])
             if not eval_run_id and s.get("kratos_eval_run_id"):
                 eval_run_id = str(s["kratos_eval_run_id"])
+
+        # Skip cosmetic admin-API hits: drop operations that have no kratos
+        # use-case attribution AND consist only of HTTP/platform/other spans.
+        categories = {s.category for s in spans}
+        if not use_case and categories <= {"http", "other", "platform"}:
+            continue
 
         op_ts = str(raw_spans[0].get("timestamp") or "") if raw_spans else ""
         logs = log_map.get(op_id, [])[:30]
@@ -413,6 +433,12 @@ def _classify_span(s: dict[str, Any]) -> str:
 
     # Agent root invocation
     if role == "agent_framework":
+        return "agent"
+
+    # Kratos agent chat endpoint = top-level agent operation
+    if role == "kratos-agent-service" and (
+        name == "post /api/agent/chat" or "/api/agent/chat" in name.lower()
+    ):
         return "agent"
 
     # Internal agent spans

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
     "sse-starlette>=2.0.0",
     "github-copilot-sdk==0.1.32",
     "aiosqlite>=0.20.0",
+    "azure-monitor-query>=1.3.0",
+    "azure-ai-evaluation>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -214,6 +214,29 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-ai-evaluation"
+version = "1.16.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "azure-core" },
+    { name = "azure-identity" },
+    { name = "azure-storage-blob" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "msrest" },
+    { name = "nltk" },
+    { name = "openai" },
+    { name = "pandas" },
+    { name = "pyjwt" },
+    { name = "ruamel-yaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/b0/fe58d377a6178e0b85e0b2d0b32a8edbbc9ffcc7fd0e6f366f3c83f6fff4/azure_ai_evaluation-1.16.8.tar.gz", hash = "sha256:ebec0a76e0cf4fd943ef2d3c916b3c0fd7c41d824ef462cac7a1c62a5dad027b", size = 2352812, upload-time = "2026-05-20T03:02:25.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/8b/5c76c92ea5e28f028a22b9f04dea2ba107bc81115d8a7350f091e6e40730/azure_ai_evaluation-1.16.8-py3-none-any.whl", hash = "sha256:5cda86d0695a53171cf5e5c3f180ee475b37c0b46b12d49070140f4a279ff448", size = 1222714, upload-time = "2026-05-20T03:02:27.516Z" },
+]
+
+[[package]]
 name = "azure-ai-inference"
 version = "1.0.0b9"
 source = { registry = "https://pypi.org/simple" }
@@ -324,6 +347,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bc/a4/a6cd2d389bc1009300bcd57c9e2ace4b7e7ae1e5dc0bda415ee803629cf2/azure_monitor_opentelemetry_exporter-1.0.0b51.tar.gz", hash = "sha256:a6171c34326bcd6216938bb40d715c15f1f22984ac1986fc97231336d8ac4c3c", size = 319837, upload-time = "2026-04-06T21:45:46.378Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/1a/6b0b7a6181b42709103a65a676c89fd5055cb1d1b281ebe10c49254a170f/azure_monitor_opentelemetry_exporter-1.0.0b51-py2.py3-none-any.whl", hash = "sha256:6572cac11f96e3b18ae1187cb35cf3b40d0004655dae8048896c41c765bea530", size = 242104, upload-time = "2026-04-06T21:45:47.856Z" },
+]
+
+[[package]]
+name = "azure-monitor-query"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/c0/e5c760f38224575f1eba35c319842f2be30fab599854ba9bd0b19d39c261/azure_monitor_query-2.0.0.tar.gz", hash = "sha256:7b05f2fcac4fb67fc9f77a7d4c5d98a0f3099fb73b57c69ec1b080773994671b", size = 86658, upload-time = "2025-07-30T22:23:41.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/0c/6b08a5a1e5f0bd97cefa13c53bf47f281a9a11732d19a94a86709acbc6bd/azure_monitor_query-2.0.0-py3-none-any.whl", hash = "sha256:8f52d581271d785e12f49cd5aaa144b8910fb843db2373855a7ef94c7fc462ea", size = 71102, upload-time = "2025-07-30T22:23:43.056Z" },
 ]
 
 [[package]]
@@ -1076,6 +1113,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1166,6 +1215,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "kratos-agent-service"
 version = "0.1.0"
 source = { virtual = "." }
@@ -1173,11 +1231,13 @@ dependencies = [
     { name = "aiohttp" },
     { name = "aiosqlite" },
     { name = "apm-cli" },
+    { name = "azure-ai-evaluation" },
     { name = "azure-ai-projects" },
     { name = "azure-cosmos" },
     { name = "azure-identity" },
     { name = "azure-keyvault-secrets" },
     { name = "azure-monitor-opentelemetry-exporter" },
+    { name = "azure-monitor-query" },
     { name = "azure-search-documents" },
     { name = "azure-storage-blob" },
     { name = "fastapi" },
@@ -1210,11 +1270,13 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "apm-cli", specifier = ">=0.5.0" },
+    { name = "azure-ai-evaluation", specifier = ">=1.0.0" },
     { name = "azure-ai-projects", specifier = ">=1.0.0" },
     { name = "azure-cosmos", specifier = ">=4.7.0" },
     { name = "azure-identity", specifier = ">=1.17.0" },
     { name = "azure-keyvault-secrets", specifier = ">=4.8.0" },
     { name = "azure-monitor-opentelemetry-exporter", specifier = ">=1.0.0b26" },
+    { name = "azure-monitor-query", specifier = ">=1.3.0" },
     { name = "azure-search-documents", specifier = ">=11.6.0" },
     { name = "azure-storage-blob", specifier = ">=12.20.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
@@ -1362,6 +1424,80 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -1592,6 +1728,100 @@ wheels = [
 ]
 
 [[package]]
+name = "nltk"
+version = "3.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
 name = "oauthlib"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1809,6 +2039,60 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/fa/7ac648108144a095b4fb6aa3de1954689f7af60a14cf25583f4960ecb878/pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523", size = 11578790, upload-time = "2025-09-29T23:18:30.065Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/35/74442388c6cf008882d4d4bdfc4109be87e9b8b7ccd097ad1e7f006e2e95/pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45", size = 10833831, upload-time = "2025-09-29T23:38:56.071Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e4/de154cbfeee13383ad58d23017da99390b91d73f8c11856f2095e813201b/pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66", size = 12199267, upload-time = "2025-09-29T23:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c9/63f8d545568d9ab91476b1818b4741f521646cbdd151c6efebf40d6de6f7/pandas-2.3.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b98560e98cb334799c0b07ca7967ac361a47326e9b4e5a7dfb5ab2b1c9d35a1b", size = 12789281, upload-time = "2025-09-29T23:18:56.834Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/a5ac8c7a0e67fd1a6059e40aa08fa1c52cc00709077d2300e210c3ce0322/pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791", size = 13240453, upload-time = "2025-09-29T23:19:09.247Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4d/5c23a5bc7bd209231618dd9e606ce076272c9bc4f12023a70e03a86b4067/pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151", size = 13890361, upload-time = "2025-09-29T23:19:25.342Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/59/712db1d7040520de7a4965df15b774348980e6df45c129b8c64d0dbe74ef/pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c", size = 11348702, upload-time = "2025-09-29T23:19:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fb/231d89e8637c808b997d172b18e9d4a4bc7bf31296196c260526055d1ea0/pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53", size = 11597846, upload-time = "2025-09-29T23:19:48.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35", size = 10729618, upload-time = "2025-09-29T23:39:08.659Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/cf2dbe1a3f5271370669475ead12ce77c61726ffd19a35546e31aa8edf4e/pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908", size = 11737212, upload-time = "2025-09-29T23:19:59.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/63/cd7d615331b328e287d8233ba9fdf191a9c2d11b6af0c7a59cfcec23de68/pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89", size = 12362693, upload-time = "2025-09-29T23:20:14.098Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
+    { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4b/18b035ee18f97c1040d94debd8f2e737000ad70ccc8f5513f4eefad75f4b/pandas-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:56851a737e3470de7fa88e6131f41281ed440d29a9268dcbf0002da5ac366713", size = 11544671, upload-time = "2025-09-29T23:21:05.024Z" },
+    { url = "https://files.pythonhosted.org/packages/31/94/72fac03573102779920099bcac1c3b05975c2cb5f01eac609faf34bed1ca/pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdcd9d1167f4885211e401b3036c0c8d9e274eee67ea8d0758a256d60704cfe8", size = 10680807, upload-time = "2025-09-29T23:21:15.979Z" },
+    { url = "https://files.pythonhosted.org/packages/16/87/9472cf4a487d848476865321de18cc8c920b8cab98453ab79dbbc98db63a/pandas-2.3.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e32e7cc9af0f1cc15548288a51a3b681cc2a219faa838e995f7dc53dbab1062d", size = 11709872, upload-time = "2025-09-29T23:21:27.165Z" },
+    { url = "https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318d77e0e42a628c04dc56bcef4b40de67918f7041c2b061af1da41dcff670ac", size = 12306371, upload-time = "2025-09-29T23:21:40.532Z" },
+    { url = "https://files.pythonhosted.org/packages/33/81/a3afc88fca4aa925804a27d2676d22dcd2031c2ebe08aabd0ae55b9ff282/pandas-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e0a175408804d566144e170d0476b15d78458795bb18f1304fb94160cabf40c", size = 12765333, upload-time = "2025-09-29T23:21:55.77Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0f/b4d4ae743a83742f1153464cf1a8ecfafc3ac59722a0b5c8602310cb7158/pandas-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2d9ab0fc11822b5eece72ec9587e172f63cff87c00b062f6e37448ced4493", size = 13418120, upload-time = "2025-09-29T23:22:10.109Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c7/e54682c96a895d0c808453269e0b5928a07a127a15704fedb643e9b0a4c8/pandas-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee", size = 10993991, upload-time = "2025-09-29T23:25:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ca/3f8d4f49740799189e1395812f3bf23b5e8fc7c190827d55a610da72ce55/pandas-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:75ea25f9529fdec2d2e93a42c523962261e567d250b0013b16210e1d40d7c2e5", size = 12048227, upload-time = "2025-09-29T23:22:24.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/5a/f43efec3e8c0cc92c4663ccad372dbdff72b60bdb56b2749f04aa1d07d7e/pandas-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74ecdf1d301e812db96a465a525952f4dde225fdb6d8e5a521d47e1f42041e21", size = 11411056, upload-time = "2025-09-29T23:22:37.762Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b1/85331edfc591208c9d1a63a06baa67b21d332e63b7a591a5ba42a10bb507/pandas-2.3.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6435cb949cb34ec11cc9860246ccb2fdc9ecd742c12d3304989017d53f039a78", size = 11645189, upload-time = "2025-09-29T23:22:51.688Z" },
+    { url = "https://files.pythonhosted.org/packages/44/23/78d645adc35d94d1ac4f2a3c4112ab6f5b8999f4898b8cdf01252f8df4a9/pandas-2.3.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900f47d8f20860de523a1ac881c4c36d65efcb2eb850e6948140fa781736e110", size = 12121912, upload-time = "2025-09-29T23:23:05.042Z" },
+    { url = "https://files.pythonhosted.org/packages/53/da/d10013df5e6aaef6b425aa0c32e1fc1f3e431e4bcabd420517dceadce354/pandas-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a45c765238e2ed7d7c608fc5bc4a6f88b642f2f01e70c0c23d2224dd21829d86", size = 12712160, upload-time = "2025-09-29T23:23:28.57Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/e756653095a083d8a37cbd816cb87148debcfcd920129b25f99dd8d04271/pandas-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4fc4c21971a1a9f4bdb4c73978c7f7256caa3e62b323f70d6cb80db583350bc", size = 13199233, upload-time = "2025-09-29T23:24:24.876Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fd/74903979833db8390b73b3a8a7d30d146d710bd32703724dd9083950386f/pandas-2.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ee15f284898e7b246df8087fc82b87b01686f98ee67d85a17b7ab44143a3a9a0", size = 11540635, upload-time = "2025-09-29T23:25:52.486Z" },
+    { url = "https://files.pythonhosted.org/packages/21/00/266d6b357ad5e6d3ad55093a7e8efc7dd245f5a842b584db9f30b0f0a287/pandas-2.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1611aedd912e1ff81ff41c745822980c49ce4a7907537be8692c8dbc31924593", size = 10759079, upload-time = "2025-09-29T23:26:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/05/d01ef80a7a3a12b2f8bbf16daba1e17c98a2f039cbc8e2f77a2c5a63d382/pandas-2.3.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d2cefc361461662ac48810cb14365a365ce864afe85ef1f447ff5a1e99ea81c", size = 11814049, upload-time = "2025-09-29T23:27:15.384Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b2/0e62f78c0c5ba7e3d2c5945a82456f4fac76c480940f805e0b97fcbc2f65/pandas-2.3.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee67acbbf05014ea6c763beb097e03cd629961c8a632075eeb34247120abcb4b", size = 12332638, upload-time = "2025-09-29T23:27:51.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/33/dd70400631b62b9b29c3c93d2feee1d0964dc2bae2e5ad7a6c73a7f25325/pandas-2.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c46467899aaa4da076d5abc11084634e2d197e9460643dd455ac3db5856b24d6", size = 12886834, upload-time = "2025-09-29T23:28:21.289Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/18/b5d48f55821228d0d2692b34fd5034bb185e854bdb592e9c640f6290e012/pandas-2.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6253c72c6a1d990a410bc7de641d34053364ef8bcd3126f7e7450125887dffe3", size = 13409925, upload-time = "2025-09-29T23:28:58.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3d/124ac75fcd0ecc09b8fdccb0246ef65e35b012030defb0e0eba2cbbbe948/pandas-2.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:1b07204a219b3b7350abaae088f451860223a52cfb8a6c53358e7948735158e5", size = 11109071, upload-time = "2025-09-29T23:32:27.484Z" },
+    { url = "https://files.pythonhosted.org/packages/89/9c/0e21c895c38a157e0faa1fb64587a9226d6dd46452cac4532d80c3c4a244/pandas-2.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2462b1a365b6109d275250baaae7b760fd25c726aaca0054649286bcfbb3e8ec", size = 12048504, upload-time = "2025-09-29T23:29:31.47Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/82/b69a1c95df796858777b68fbe6a81d37443a33319761d7c652ce77797475/pandas-2.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0242fe9a49aa8b4d78a4fa03acb397a58833ef6199e9aa40a95f027bb3a1b6e7", size = 11410702, upload-time = "2025-09-29T23:29:54.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/88/702bde3ba0a94b8c73a0181e05144b10f13f29ebfc2150c3a79062a8195d/pandas-2.3.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a21d830e78df0a515db2b3d2f5570610f5e6bd2e27749770e8bb7b524b89b450", size = 11634535, upload-time = "2025-09-29T23:30:21.003Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582, upload-time = "2025-09-29T23:30:43.391Z" },
+    { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963, upload-time = "2025-09-29T23:31:10.009Z" },
+    { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
 ]
 
 [[package]]
@@ -2280,6 +2564,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2335,6 +2628,110 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/dc/c1f2df4027e82fc54b5a473e4b250f5139faca49a0fbe29a48668d228f34/regex-2026.5.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccf5249114cc3e772ecdd88a98a86eca0fd74c61ce32a94743758c083fc05d48", size = 489445, upload-time = "2026-05-09T23:12:06.111Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d2/59f01110660081cce9c0bc30ebd0b5ee250dacf658e3248ed92f01e0e8ee/regex-2026.5.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46f1326ca6e65b0879d23ca302c0f2415aad42ff0309b9c818e7949fe19a41d8", size = 291271, upload-time = "2026-05-09T23:12:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b6/14b2c84ff90ddb370c81d27503f4a0fcf071496416f4855f6cc8c5d81c35/regex-2026.5.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ef31cbfe458e21c6122ba8150ff060e0c7789ed0d26eb423f25472584920b555", size = 289212, upload-time = "2026-05-09T23:12:09.266Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d0/4db86529117320de0c84afd90e70bb47434625875e34fcef9d8c127c5b16/regex-2026.5.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:992604d02e6d9c6d786c24a706a71ecffe1020fc1ef264044474cd81fa2c3919", size = 792310, upload-time = "2026-05-09T23:12:11.416Z" },
+    { url = "https://files.pythonhosted.org/packages/07/78/fe4800cd322f862ecffd2d553409b20d80650e5ed71b9d178f853d020b82/regex-2026.5.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9411dd64ca95477225734a93dfc8583b51916b8d5942f99d6cac21e09965451", size = 861721, upload-time = "2026-05-09T23:12:13.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d0/b3618a895dd8feb897c61bb2954edd265e1767d82a01d53065d5871127a3/regex-2026.5.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4a3ff360dfb836fecdb93a4598f9d6e2ac81e3e397125145c6221bf58cf4c", size = 906460, upload-time = "2026-05-09T23:12:15.443Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6f/1481597e859ef19508b345eec4afd1416ed6e6b459c75a64026ef193aecf/regex-2026.5.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a661a7d270a61f7cf460caee8b9fa2d5ef9e5c681234bcb9e0fe14f488e7dfc", size = 799843, upload-time = "2026-05-09T23:12:16.892Z" },
+    { url = "https://files.pythonhosted.org/packages/73/59/955734c803f59108deccba3597ae440c76b62a652733c0006e6243758420/regex-2026.5.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f079e50a0d3cc3cd5091fa9ff45869a2e6b2cd35895731edafb0327901a8d86d", size = 773610, upload-time = "2026-05-09T23:12:19.127Z" },
+    { url = "https://files.pythonhosted.org/packages/68/8f/70c04a236d651c81881dac42ef8538bddda6121434509d0a22d9e601503b/regex-2026.5.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4ebe8f0b5ec5a5024dc4a4c59f444c4e9afc5f2abdbb8962065b75d27fb971f9", size = 781645, upload-time = "2026-05-09T23:12:20.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/96/05c7434d88185e5d27fe54aeb74df86bd77cd79f52f0b4eae54faa8fea70/regex-2026.5.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:97cf3bc1b7d7d2306772ec07366c80d9df00ff79e79cea32898883a646d2fae2", size = 854473, upload-time = "2026-05-09T23:12:22.465Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/6e3d8202d981f3117004bf341ee74893ba4ba8a9fbaf4b94615846550a08/regex-2026.5.9-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0f9eede6a5cbdc02d4978090186390936e1776a7d1359b21e41014c609880bcf", size = 763311, upload-time = "2026-05-09T23:12:24.351Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c7/e7737f1526b3fb32bd4c337fd6c71c3ebb5c8296fc34d11197e0955d2e35/regex-2026.5.9-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:01f0f5f55f4b64dacec85dc116d3c05fd23ad3ff037bbc73a2085775953c2611", size = 844593, upload-time = "2026-05-09T23:12:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/27/0daffb1a535bb39f422c3d200f4ab023c71110ad66a32b366bee708baba0/regex-2026.5.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1268eddd8486dc561d08eee1156e40aa3a8fe10f4bdec8fa653b455fcbffd12c", size = 789167, upload-time = "2026-05-09T23:12:27.975Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fc/294fe4fac4f2ed67207b17471815870c1c45b3a489e08e0ac96daea16ef6/regex-2026.5.9-cp311-cp311-win32.whl", hash = "sha256:8676474c07469d6f33dd1085ca2cd45f65785f32518f2b20e36d9953ca07f994", size = 266249, upload-time = "2026-05-09T23:12:30.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b0/8dce459f6245bcf8f6e9f23ac9569f1a0f15c131cc0745e82b43226204cf/regex-2026.5.9-cp311-cp311-win_amd64.whl", hash = "sha256:246de9d60aa3f8538b519834dd95cbf276ea263d6a7bd5a3666dc3fa0230505b", size = 278423, upload-time = "2026-05-09T23:12:31.676Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/f9aeff6ad63a3ef720386f2907e6d34a35a510a6e498ebad28b0fb3f6ab6/regex-2026.5.9-cp311-cp311-win_arm64.whl", hash = "sha256:d726ca3f0d76969bf1e8e477d160d3d666bbf999f6860bd314889e5345782046", size = 270420, upload-time = "2026-05-09T23:12:33.194Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3e/9c3cd292d8808b3645a2ce517e200179b6d0e903f176300bd8b542e14de5/regex-2026.5.9-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:1bd7587a2948b4085195d5a3374eaf4a425dc3e55784c038175355ecf3bbbf8a", size = 490376, upload-time = "2026-05-09T23:14:09.64Z" },
+    { url = "https://files.pythonhosted.org/packages/60/70/d43ee8a2ca0a8b68d167f21658b85520ac0574617c7f320367c5047f7556/regex-2026.5.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:dea2e88e1cce4522496cce630e11e67b98b7076620bc4336c3f674bc21a375f4", size = 291964, upload-time = "2026-05-09T23:14:11.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/9d50b433828d8e74196904e168a43abf1e6e88b2a15d47ed742456720c37/regex-2026.5.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2099f7e7ff7b6aa3192312650a56e91cc091e49d50b04e4f6f8b6e28b3b27f1c", size = 289682, upload-time = "2026-05-09T23:14:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/b835e3cafbb9d977736912436259ff551d60919f7d7b3d37d46659c63564/regex-2026.5.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecd353045824e4477562a2ac718c25799cdaaa41f7aa925a806a8a3e6848a5b9", size = 796996, upload-time = "2026-05-09T23:14:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a6/9f992d00019166b9de01c546dd4549bc679f2a68df11b877740b0760b7c2/regex-2026.5.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65c8c8c37377794bd5b2f3ebe51919042bf17aec802e23c833d89782ed0c78af", size = 866089, upload-time = "2026-05-09T23:14:17.757Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/08/4d32af657e049b19cb62b02e46e38fe1518797bfb2203ee93a510b21b0dc/regex-2026.5.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b73ab8afcf66c622db143d1c6fda4e58e4d537ee4f125229ad47b1ab80f34c0", size = 911530, upload-time = "2026-05-09T23:14:20.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/27/2af43dd1dc201d1fecefda64a45f4ad0995855b92724f795a777b402ee69/regex-2026.5.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0de5cf193997384ed2ca6f1cd4f78055b255d93d82d5a8cd6ba0d11c10b167e4", size = 800643, upload-time = "2026-05-09T23:14:22.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/dd/23a249047013b5321d4a60c4d2437462086f601b061776a525e5fba2a59f/regex-2026.5.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d641a8c9a61618047796d572a39a79b26167b0411d2c3031937b2fe2d081e2cf", size = 777223, upload-time = "2026-05-09T23:14:24.179Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6a/e85ed9538cd19586d0465076a4578a12e093ce776d15f3f8ce92733a8dd6/regex-2026.5.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24b2355ef5cc9aa5b8f07d17704face1c166fdcc2290fa7bd6e6c925655a8346", size = 785760, upload-time = "2026-05-09T23:14:26.065Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c4/f25473209438638e947c55f9156fd8f236f74169229028cc99116380868e/regex-2026.5.9-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a24852d3c29ad9e47593593d8a247c44ccc3d0548ef12c822d6ed0810affe676", size = 860891, upload-time = "2026-05-09T23:14:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f7/f4f86e3c74419c37370e91f150ae0c2ef7d34b2e0e4cdd5da046a02e4022/regex-2026.5.9-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:916714069da19329ef7de197dcbc77bb3104145c7c2c864dbfbe318f46b88b14", size = 765891, upload-time = "2026-05-09T23:14:30.06Z" },
+    { url = "https://files.pythonhosted.org/packages/26/70/704d8e13765939146b1cd0ef4e2feb71d7929727d2290f026eed10095955/regex-2026.5.9-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:fa411799ca8da32a8d38d020a88faa5b6f91657d284761352940ecf9f7c3bbdd", size = 851380, upload-time = "2026-05-09T23:14:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/1a13582a8460038edc38e49f64ceb0dd7c60f5caba77571f4bf6601965d9/regex-2026.5.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e6da47d679b7010ef27556b6e0f99771b744936db1792a10ceac6547ae1503e", size = 789350, upload-time = "2026-05-09T23:14:34.799Z" },
+    { url = "https://files.pythonhosted.org/packages/73/56/3dcafe34fc72e271d62ad9a291801e88a1457bb251c132f15fcc2e5aad1a/regex-2026.5.9-cp314-cp314-win32.whl", hash = "sha256:98bd73080e8756255137e1bd3f3f00295bbc5aa383c0e0f973920e9134d7c4ad", size = 272130, upload-time = "2026-05-09T23:14:36.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9c/02eebf0be95efe416c664db7fb8b6b05b7a0b06a7544f2884f2558b0526f/regex-2026.5.9-cp314-cp314-win_amd64.whl", hash = "sha256:ff8d372ac2acdc048d1c19916f27ee61bc5722728458ba6ca5052f2c72d51763", size = 280999, upload-time = "2026-05-09T23:14:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5a/1dd1abee76cb7a846a0bcf42fdc87e5720c3c33c24f3e37814310a513d9f/regex-2026.5.9-cp314-cp314-win_arm64.whl", hash = "sha256:e1d93bf647916292e8edcec150c07ddf3dc50179ccaf770c04a7f9e452155372", size = 273500, upload-time = "2026-05-09T23:14:41.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c1/c5f619b0057a7965cb78ec559c1d7a45ce8c99a35bea95483d64959a93d9/regex-2026.5.9-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:83d0ee4a57d1c87cb549e195ec300b8f0ec3a82eba66d835e4e2ed8634fe4499", size = 494269, upload-time = "2026-05-09T23:14:42.869Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2c/5d01f1aee33de4bbe60c8452945bfc8477ca7c5ae4450f6bfe711036cb36/regex-2026.5.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d3d7eb5c9a7f6df82ed3cfac9beb93882a5cbcb5b8b157b56cb2b3b276574ac1", size = 293954, upload-time = "2026-05-09T23:14:44.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fe/e8988b2ae2108c6ef71bd4aa8d87fbe257976dd0810e826cd75f701c68b6/regex-2026.5.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:075160bf16658e16d35233300b8453aac25de4cbea808d22348b6979668e924d", size = 292405, upload-time = "2026-05-09T23:14:47.211Z" },
+    { url = "https://files.pythonhosted.org/packages/79/34/d2b0937faa7859263f7f0a3c6b103a1296306be6952dc173d0154e9a2f49/regex-2026.5.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45375819235558a4ff1c4971dc32881f022613abdb180128f5cb4768c1765a1c", size = 811855, upload-time = "2026-05-09T23:14:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fe/daf53a47457a8486db66c66c01ceb9c2303eecee3f87197f1e77eb1a736d/regex-2026.5.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ead4b163ac30a29574510cd4b3e2e985ac5290c05fc7095557d6a5f403fc31b5", size = 871189, upload-time = "2026-05-09T23:14:51.555Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/75/058fc4470cbfbf57d800aff1a0022b929a3f9fa553ee10a0cdf2070eb31f/regex-2026.5.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c6e4218fbdfbcd4f6c19efca40930d24a621bf4b48cb76bc6640543bd28ef20", size = 917485, upload-time = "2026-05-09T23:14:53.633Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e7/179cfda3a28bc843b5c6cfe7f79f23489c791ed95f151083803660878432/regex-2026.5.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6351571c8a42b505eb555c0dc47d740d0fb66977dc142919eea6f4325b7c56a0", size = 816369, upload-time = "2026-05-09T23:14:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/41/90/6f0cc422071688266d344fca8462d787cba0a2c144acb25721f9a61ec265/regex-2026.5.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:002205cafd2a9e78c6290c7d1df277bf3277b3b7a30e0b4bb0dac2e2e3f7cb2d", size = 785869, upload-time = "2026-05-09T23:14:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/02/67/a31f1760f09c27b251ef39e9beb541f462cf977381d067faa764c2c0e393/regex-2026.5.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8abd33fef90b2a9efac5557d6033ca82d1195ed3a15fea5af15ba7b463c6a63b", size = 801427, upload-time = "2026-05-09T23:15:00.642Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/1a80654597b6bc1e1ea0494824c31200e8a956abe290afae9b19a166a148/regex-2026.5.9-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:31037c82eccb44b7ea2e9e221d7c01429430e989a1f4b91ea5a855f6017b509a", size = 866482, upload-time = "2026-05-09T23:15:03.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/960724e06482c08466ff5611e242e86f80062949cdf6b4b9cc317b9dd93d/regex-2026.5.9-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5604dfd046dc37eca90250fc3be938b076c8059fa772ac0ed6f499b0f0fb0415", size = 773022, upload-time = "2026-05-09T23:15:05.625Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/a9979c3e7918280e93159ebcab5ef1a65116dd4f3bd6091be0eae4a126e8/regex-2026.5.9-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e1b1b4e496afbb24f4a62aba855ee4f88f25578927697b340702e48c9ee6bc2", size = 856642, upload-time = "2026-05-09T23:15:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d4/a9b732f2f0072c0ab12227483abb24fffcb9f73f8a2b203df0a6d0434735/regex-2026.5.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:be3372b9df6ddecff6486d37e19095a7b4973137caf5512407a89f4455361f41", size = 803552, upload-time = "2026-05-09T23:15:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fe/1b3113817447a1d4155e4ac76d2e072f42c0bcba2f43fa8a0e756ea2cd91/regex-2026.5.9-cp314-cp314t-win32.whl", hash = "sha256:3ddd90103f9e5c471c49c7852ecc1fe27c7e45eb99e977aefe7caa4e779f4f58", size = 275746, upload-time = "2026-05-09T23:15:12.609Z" },
+    { url = "https://files.pythonhosted.org/packages/92/73/93d42045302636c91f2e5ef588b65b84b01428f28ec77de256b1dfdfbe5c/regex-2026.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:ca518ed29c46eecba6010b15f1b9a479314d2de409536e71b6a13aa04e3b8a77", size = 285685, upload-time = "2026-05-09T23:15:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/da/80/35b4c33c804a165a7f55289afda3ea9e3eb6d15800341a2d66455c0f1f30/regex-2026.5.9-cp314-cp314t-win_arm64.whl", hash = "sha256:5e41809d2683fcde7d5a8c87a6567ba1fb1ce0de9f31bff578de00a4b2d76daa", size = 275713, upload-time = "2026-05-09T23:15:16.98Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2387,6 +2784,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/04/27/091e140ea834272188e63f8dd6faac1f5c687582b687197b3e0ec3c78ebf/rich_click-1.9.7.tar.gz", hash = "sha256:022997c1e30731995bdbc8ec2f82819340d42543237f033a003c7b1f843fc5dc", size = 74838, upload-time = "2026-01-31T04:29:27.707Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/e5/d708d262b600a352abe01c2ae360d8ff75b0af819b78e9af293191d928e6/rich_click-1.9.7-py3-none-any.whl", hash = "sha256:2f99120fca78f536e07b114d3b60333bc4bb2a0969053b1250869bcdc1b5351b", size = 71491, upload-time = "2026-01-31T04:29:26.777Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]
@@ -2618,6 +3024,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]

--- a/src/frontend/.eslintrc.json
+++ b/src/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/src/frontend/src/components/EvalsAdminPanel.tsx
+++ b/src/frontend/src/components/EvalsAdminPanel.tsx
@@ -1,0 +1,664 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  listEvalScenarios,
+  upsertEvalScenario,
+  deleteEvalScenario,
+  startEvalRun,
+  listEvalRuns,
+  getEvalRun,
+} from "@/lib/api";
+import type { EvalScenario, EvalRun, EvalRunStatus, ScenarioResult } from "@/types";
+import { GenerateScenariosModal } from "./GenerateScenariosModal";
+
+interface Props {
+  useCase: string;
+}
+
+const ACTIVE_STATUSES: EvalRunStatus[] = ["pending", "invoking", "scoring"];
+const ALL_EVALUATORS = ["task_adherence", "tool_selection", "response_quality", "safety"];
+const FOUNDRY_PORTAL_URL =
+  (typeof process !== "undefined" && process.env.NEXT_PUBLIC_FOUNDRY_PORTAL_URL) ||
+  "https://ai.azure.com";
+
+const categoryColors: Record<string, string> = {
+  standard: "bg-blue-50 dark:bg-blue-500/10 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-500/20",
+  edge_case: "bg-amber-50 dark:bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-500/20",
+  error_handling: "bg-red-50 dark:bg-red-500/10 text-red-700 dark:text-red-400 border-red-200 dark:border-red-500/20",
+  boundary: "bg-purple-50 dark:bg-purple-500/10 text-purple-700 dark:text-purple-400 border-purple-200 dark:border-purple-500/20",
+  compliance: "bg-emerald-50 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 border-emerald-200 dark:border-emerald-500/20",
+};
+
+const statusConfig: Record<EvalRunStatus, { label: string; color: string }> = {
+  pending: { label: "Pending", color: "bg-slate-100 dark:bg-slate-700/50 text-slate-600 dark:text-slate-400" },
+  invoking: { label: "Running", color: "bg-blue-100 dark:bg-blue-500/20 text-blue-700 dark:text-blue-400" },
+  scoring: { label: "Scoring", color: "bg-amber-100 dark:bg-amber-500/20 text-amber-700 dark:text-amber-400" },
+  completed: { label: "Completed", color: "bg-emerald-100 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-400" },
+  failed: { label: "Failed", color: "bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400" },
+};
+
+function computeOverallScore(run: EvalRun): string {
+  if (run.foundry?.per_testing_criteria_results && run.foundry.per_testing_criteria_results.length > 0) {
+    const criteria = run.foundry.per_testing_criteria_results as Array<Record<string, unknown>>;
+    const rates = criteria.map((c) => {
+      const pass = typeof c.pass === "number" ? c.pass : 0;
+      const total = (typeof c.pass === "number" ? c.pass : 0) + (typeof c.fail === "number" ? c.fail : 0);
+      return total > 0 ? pass / total : 0;
+    });
+    if (rates.length > 0) {
+      const avg = rates.reduce((a, b) => a + b, 0) / rates.length;
+      return `${Math.round(avg * 100)}%`;
+    }
+  }
+  const total = run.results.length;
+  const passed = run.results.filter((r) => r.status === "pass" || r.status === "passed").length;
+  if (total === 0) return "—";
+  return `${passed}/${total}`;
+}
+
+function ScenarioResultRow({ result }: { result: ScenarioResult }) {
+  const [expanded, setExpanded] = useState(false);
+
+  const scoreEntries = Object.entries(result.scores ?? {});
+
+  return (
+    <div className="border border-slate-200 dark:border-white/[0.06] rounded-xl overflow-hidden">
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-center gap-3 px-4 py-3 bg-slate-50/50 dark:bg-white/[0.02] hover:bg-slate-100/80 dark:hover:bg-white/[0.04] transition-colors text-left"
+      >
+        <span className={`flex-shrink-0 w-2 h-2 rounded-full ${result.status === "pass" || result.status === "passed" ? "bg-emerald-500" : result.status === "fail" || result.status === "failed" ? "bg-red-400" : "bg-slate-400"}`} />
+        <span className="flex-1 text-sm font-medium text-slate-700 dark:text-slate-300 truncate">{result.scenario}</span>
+        {result.duration_ms > 0 && (
+          <span className="text-xs text-slate-400 font-mono flex-shrink-0">{result.duration_ms}ms</span>
+        )}
+        <svg
+          className={`w-4 h-4 text-slate-400 transition-transform flex-shrink-0 ${expanded ? "rotate-180" : ""}`}
+          fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {expanded && (
+        <div className="px-4 py-4 space-y-3 border-t border-slate-100 dark:border-white/[0.04]">
+          {result.error && (
+            <div className="px-3 py-2 bg-red-50 dark:bg-red-500/10 text-red-600 dark:text-red-400 text-xs rounded-lg font-mono">{result.error}</div>
+          )}
+          <div>
+            <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">Query</p>
+            <p className="text-sm text-slate-700 dark:text-slate-300 bg-slate-50 dark:bg-white/[0.03] rounded-lg px-3 py-2">{result.query}</p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">Response</p>
+            <p className="text-sm text-slate-700 dark:text-slate-300 bg-slate-50 dark:bg-white/[0.03] rounded-lg px-3 py-2 whitespace-pre-wrap max-h-40 overflow-y-auto">{result.response}</p>
+          </div>
+          {result.tool_calls.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">Tool Calls</p>
+              <div className="space-y-1.5">
+                {result.tool_calls.map((tc, i) => (
+                  <div key={i} className="flex items-start gap-2 bg-slate-50 dark:bg-white/[0.03] rounded-lg px-3 py-2">
+                    <span className="text-xs font-mono font-medium text-primary-600 dark:text-primary-400 flex-shrink-0">{tc.name}</span>
+                    {tc.arguments && (
+                      <span className="text-xs text-slate-500 font-mono truncate">{JSON.stringify(tc.arguments)}</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          {scoreEntries.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">Scores</p>
+              <div className="grid grid-cols-2 gap-2">
+                {scoreEntries.map(([criterion, score]) => {
+                  const scoreObj = score as Record<string, unknown>;
+                  const passed = scoreObj.passed ?? scoreObj.result ?? scoreObj.score;
+                  return (
+                    <div key={criterion} className="flex items-center justify-between bg-slate-50 dark:bg-white/[0.03] rounded-lg px-3 py-1.5">
+                      <span className="text-xs text-slate-600 dark:text-slate-400">{criterion}</span>
+                      <span className={`text-xs font-medium ${passed === true || passed === "pass" ? "text-emerald-600 dark:text-emerald-400" : "text-red-500 dark:text-red-400"}`}>
+                        {String(passed)}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface EditScenarioModalProps {
+  scenario: EvalScenario;
+  onSave: (updated: EvalScenario) => void;
+  onClose: () => void;
+}
+
+function EditScenarioModal({ scenario, onSave, onClose }: EditScenarioModalProps) {
+  const [draft, setDraft] = useState<EvalScenario>({ ...scenario });
+
+  const update = (patch: Partial<EvalScenario>) => setDraft((d) => ({ ...d, ...patch }));
+
+  const toggleEvaluator = (ev: string) => {
+    setDraft((d) => ({
+      ...d,
+      evaluators: d.evaluators.includes(ev)
+        ? d.evaluators.filter((e) => e !== ev)
+        : [...d.evaluators, ev],
+    }));
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/40 backdrop-blur-sm z-50 flex items-center justify-center p-4 animate-fade-in"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-navy-900 rounded-2xl shadow-glass-lg max-w-xl w-full border border-slate-200/50 dark:border-white/[0.08] animate-slide-up flex flex-col max-h-[85vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-6 py-4 border-b border-slate-100 dark:border-white/[0.06] flex-shrink-0">
+          <h2 className="text-base font-semibold text-slate-900 dark:text-white">Edit Scenario</h2>
+          <button onClick={onClose} className="p-2 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-white/[0.06] rounded-lg transition-all">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1.5">Name</label>
+            <input type="text" value={draft.name} onChange={(e) => update({ name: e.target.value })} className="w-full px-3 py-2 bg-slate-50 dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-xl text-sm text-slate-900 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-400 transition-all" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1.5">Category</label>
+            <select value={draft.category} onChange={(e) => update({ category: e.target.value as EvalScenario["category"] })} className="w-full px-3 py-2 bg-slate-50 dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-xl text-sm text-slate-900 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-400 transition-all">
+              {["standard", "edge_case", "error_handling", "boundary", "compliance"].map((c) => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1.5">Input Message</label>
+            <textarea value={draft.input_message} onChange={(e) => update({ input_message: e.target.value })} rows={3} className="w-full px-3 py-2 bg-slate-50 dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-xl text-sm text-slate-900 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-400 transition-all resize-none" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1.5">Expected Behavior</label>
+            <textarea value={draft.expected_behavior} onChange={(e) => update({ expected_behavior: e.target.value })} rows={3} className="w-full px-3 py-2 bg-slate-50 dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-xl text-sm text-slate-900 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-400 transition-all resize-none" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1.5">
+              Expected Tool Calls <span className="text-slate-400 font-normal text-xs">(comma-separated)</span>
+            </label>
+            <input
+              type="text"
+              value={draft.expected_tool_calls.join(", ")}
+              onChange={(e) => update({ expected_tool_calls: e.target.value.split(",").map((s) => s.trim()).filter(Boolean) })}
+              placeholder="search_documents, get_user_info"
+              className="w-full px-3 py-2 bg-slate-50 dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-xl text-sm text-slate-900 dark:text-slate-200 font-mono focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-400 transition-all"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">Evaluators</label>
+            <div className="flex flex-wrap gap-2">
+              {ALL_EVALUATORS.map((ev) => (
+                <button
+                  key={ev}
+                  type="button"
+                  onClick={() => toggleEvaluator(ev)}
+                  className={`px-3 py-1.5 rounded-lg text-xs font-medium border transition-all ${
+                    draft.evaluators.includes(ev)
+                      ? "bg-primary-50 dark:bg-primary-500/10 text-primary-700 dark:text-primary-400 border-primary-200 dark:border-primary-500/30"
+                      : "bg-slate-50 dark:bg-white/[0.04] text-slate-500 dark:text-slate-400 border-slate-200 dark:border-white/[0.08] hover:border-slate-300"
+                  }`}
+                >
+                  {ev}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-slate-100 dark:border-white/[0.06] flex-shrink-0">
+          <button onClick={onClose} className="px-4 py-2 text-sm text-slate-500 bg-slate-50 dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-xl hover:bg-slate-100 dark:hover:bg-white/[0.06] transition-all font-medium">Cancel</button>
+          <button onClick={() => onSave(draft)} className="px-4 py-2 text-sm text-white bg-gradient-to-r from-primary-600 to-primary-500 rounded-xl hover:from-primary-700 hover:to-primary-600 transition-all shadow-sm font-medium">Save Changes</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function EvalsAdminPanel({ useCase }: Props): JSX.Element {
+  const [scenarios, setScenarios] = useState<EvalScenario[]>([]);
+  const [runs, setRuns] = useState<EvalRun[]>([]);
+  const [latestRun, setLatestRun] = useState<EvalRun | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [runError, setRunError] = useState("");
+  const [runningValidation, setRunningValidation] = useState(false);
+  const [runningFoundry, setRunningFoundry] = useState(false);
+  const [showGenerateModal, setShowGenerateModal] = useState(false);
+  const [editingScenario, setEditingScenario] = useState<EvalScenario | null>(null);
+  const [expandedResult, setExpandedResult] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const [scenarioList, runList] = await Promise.all([
+        listEvalScenarios(useCase),
+        listEvalRuns(useCase),
+      ]);
+      setScenarios(scenarioList);
+      setRuns(runList);
+      if (runList.length > 0) {
+        const latest = runList[0];
+        setLatestRun(latest);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load eval data");
+    } finally {
+      setLoading(false);
+    }
+  }, [useCase]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const startPolling = useCallback((runId: string) => {
+    if (pollRef.current) clearInterval(pollRef.current);
+    pollRef.current = setInterval(async () => {
+      try {
+        const run = await getEvalRun(useCase, runId);
+        setLatestRun(run);
+        setRuns((prev) => {
+          const idx = prev.findIndex((r) => r.run_id === run.run_id);
+          if (idx >= 0) {
+            const updated = [...prev];
+            updated[idx] = run;
+            return updated;
+          }
+          return [run, ...prev];
+        });
+        if (!ACTIVE_STATUSES.includes(run.status)) {
+          if (pollRef.current) clearInterval(pollRef.current);
+          pollRef.current = null;
+        }
+      } catch {
+        // ignore poll errors
+      }
+    }, 10000);
+  }, [useCase]);
+
+  useEffect(() => {
+    if (latestRun && ACTIVE_STATUSES.includes(latestRun.status)) {
+      startPolling(latestRun.run_id);
+    }
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [latestRun?.run_id, latestRun?.status, startPolling]);
+
+  const handleRunValidation = async () => {
+    setRunningValidation(true);
+    setRunError("");
+    try {
+      const run = await startEvalRun(useCase, { mode: "validation", scenarios: [] });
+      setLatestRun(run);
+      setRuns((prev) => [run, ...prev]);
+      startPolling(run.run_id);
+    } catch (err) {
+      setRunError(err instanceof Error ? err.message : "Failed to start validation run");
+    } finally {
+      setRunningValidation(false);
+    }
+  };
+
+  const handleRunFoundry = async () => {
+    setRunningFoundry(true);
+    setRunError("");
+    try {
+      const run = await startEvalRun(useCase, { mode: "foundry", scenarios: [] });
+      setLatestRun(run);
+      setRuns((prev) => [run, ...prev]);
+      startPolling(run.run_id);
+    } catch (err) {
+      setRunError(err instanceof Error ? err.message : "Failed to start Foundry eval run");
+    } finally {
+      setRunningFoundry(false);
+    }
+  };
+
+  const handleDeleteScenario = async (name: string) => {
+    try {
+      await deleteEvalScenario(useCase, name);
+      setScenarios((prev) => prev.filter((s) => s.name !== name));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete scenario");
+    }
+  };
+
+  const handleSaveScenario = async (updated: EvalScenario) => {
+    try {
+      const saved = await upsertEvalScenario(useCase, updated);
+      setScenarios((prev) => {
+        const idx = prev.findIndex((s) => s.name === saved.name);
+        if (idx >= 0) {
+          const next = [...prev];
+          next[idx] = saved;
+          return next;
+        }
+        return [...prev, saved];
+      });
+      setEditingScenario(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save scenario");
+    }
+  };
+
+  const foundryUrl = latestRun?.foundry?.report_url || FOUNDRY_PORTAL_URL;
+
+  const criteriaResults = latestRun?.foundry?.per_testing_criteria_results as Array<Record<string, unknown>> | undefined;
+
+  return (
+    <div className="max-w-4xl space-y-6">
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          onClick={() => setShowGenerateModal(true)}
+          className="flex items-center gap-2 px-4 py-2 text-sm text-white bg-gradient-to-r from-primary-600 to-primary-500 rounded-xl hover:from-primary-700 hover:to-primary-600 transition-all shadow-sm font-medium"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
+          </svg>
+          Generate Scenarios
+        </button>
+
+        <button
+          onClick={handleRunValidation}
+          disabled={runningValidation || runningFoundry}
+          className="flex items-center gap-2 px-4 py-2 text-sm text-slate-700 dark:text-slate-300 bg-white dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-xl hover:bg-slate-50 dark:hover:bg-white/[0.06] transition-all font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {runningValidation ? (
+            <div className="animate-spin rounded-full h-4 w-4 border-2 border-slate-400/30 border-t-slate-500" />
+          ) : (
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z" />
+            </svg>
+          )}
+          Run Validation
+        </button>
+
+        <button
+          onClick={handleRunFoundry}
+          disabled={runningValidation || runningFoundry || scenarios.length === 0}
+          className="flex items-center gap-2 px-4 py-2 text-sm text-slate-700 dark:text-slate-300 bg-white dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-xl hover:bg-slate-50 dark:hover:bg-white/[0.06] transition-all font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+          title={scenarios.length === 0 ? "Add scenarios first" : undefined}
+        >
+          {runningFoundry ? (
+            <div className="animate-spin rounded-full h-4 w-4 border-2 border-slate-400/30 border-t-slate-500" />
+          ) : (
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />
+            </svg>
+          )}
+          Run AI Foundry Evals
+        </button>
+
+        <a
+          href={foundryUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1.5 px-3 py-2 text-sm text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 transition-colors"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+          </svg>
+          Open in Foundry
+        </a>
+      </div>
+
+      {/* Error banners */}
+      {error && (
+        <div className="px-4 py-3 bg-red-50 dark:bg-red-500/10 text-red-600 dark:text-red-400 text-sm rounded-xl border border-red-100 dark:border-red-500/20 flex items-center justify-between">
+          <span>{error}</span>
+          <button onClick={() => setError("")} className="text-red-400 hover:text-red-600 transition-colors ml-3">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+          </button>
+        </div>
+      )}
+      {runError && (
+        <div className="px-4 py-3 bg-red-50 dark:bg-red-500/10 text-red-600 dark:text-red-400 text-sm rounded-xl border border-red-100 dark:border-red-500/20 flex items-center justify-between">
+          <span>{runError}</span>
+          <button onClick={() => setRunError("")} className="text-red-400 hover:text-red-600 transition-colors ml-3">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+          </button>
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && (
+        <div className="flex items-center justify-center py-16">
+          <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary-200 border-t-primary-600" />
+        </div>
+      )}
+
+      {!loading && (
+        <>
+          {/* Scenarios section */}
+          <div className="bg-white dark:bg-white/[0.03] border border-slate-200 dark:border-white/[0.08] rounded-2xl overflow-hidden">
+            <div className="flex items-center justify-between px-5 py-4 border-b border-slate-100 dark:border-white/[0.06]">
+              <h3 className="text-sm font-semibold text-slate-800 dark:text-white flex items-center gap-2">
+                <svg className="w-4 h-4 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z" />
+                </svg>
+                Scenarios
+              </h3>
+              <span className="text-xs font-mono text-slate-400 bg-slate-100 dark:bg-white/[0.06] px-2 py-0.5 rounded-full">
+                {scenarios.length}
+              </span>
+            </div>
+
+            {scenarios.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
+                <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-primary-500/10 to-cyan-500/10 flex items-center justify-center mb-4">
+                  <svg className="w-7 h-7 text-primary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
+                  </svg>
+                </div>
+                <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-300 mb-1">No scenarios yet</h4>
+                <p className="text-xs text-slate-500 dark:text-slate-400 max-w-xs leading-relaxed mb-4">
+                  Generate AI-powered eval scenarios to validate your agent&apos;s behavior against expected outcomes.
+                </p>
+                <button
+                  onClick={() => setShowGenerateModal(true)}
+                  className="flex items-center gap-2 px-4 py-2 text-sm text-white bg-gradient-to-r from-primary-600 to-primary-500 rounded-xl hover:from-primary-700 hover:to-primary-600 transition-all shadow-sm font-medium"
+                >
+                  Generate Scenarios
+                </button>
+              </div>
+            ) : (
+              <div className="divide-y divide-slate-100 dark:divide-white/[0.04]">
+                {scenarios.map((scenario) => (
+                  <div key={scenario.name} className="flex items-start gap-3 px-5 py-4 hover:bg-slate-50/50 dark:hover:bg-white/[0.02] transition-colors">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-sm font-medium text-slate-800 dark:text-white truncate">{scenario.name}</span>
+                        <span className={`text-[10px] px-2 py-0.5 rounded-full border font-medium flex-shrink-0 ${categoryColors[scenario.category] ?? categoryColors.standard}`}>
+                          {scenario.category}
+                        </span>
+                      </div>
+                      {scenario.description && (
+                        <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5 line-clamp-1">{scenario.description}</p>
+                      )}
+                      {scenario.expected_tool_calls.length > 0 && (
+                        <div className="flex items-center gap-1 mt-1 flex-wrap">
+                          {scenario.expected_tool_calls.map((tc) => (
+                            <span key={tc} className="text-[10px] px-1.5 py-0.5 bg-slate-100 dark:bg-white/[0.06] text-slate-500 dark:text-slate-400 rounded font-mono">
+                              {tc}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1 flex-shrink-0">
+                      <button
+                        onClick={() => setEditingScenario(scenario)}
+                        className="p-1.5 text-slate-400 hover:text-primary-500 hover:bg-primary-50 dark:hover:bg-primary-500/10 rounded-lg transition-all"
+                        title="Edit"
+                      >
+                        <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                        </svg>
+                      </button>
+                      <button
+                        onClick={() => handleDeleteScenario(scenario.name)}
+                        className="p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 rounded-lg transition-all"
+                        title="Delete"
+                      >
+                        <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Latest run */}
+          {latestRun && (
+            <div className="bg-white dark:bg-white/[0.03] border border-slate-200 dark:border-white/[0.08] rounded-2xl overflow-hidden">
+              <div className="flex items-center justify-between px-5 py-4 border-b border-slate-100 dark:border-white/[0.06]">
+                <div className="flex items-center gap-3">
+                  <h3 className="text-sm font-semibold text-slate-800 dark:text-white">Latest Run</h3>
+                  <span className={`text-xs px-2.5 py-1 rounded-full font-medium ${statusConfig[latestRun.status].color}`}>
+                    {statusConfig[latestRun.status].label}
+                    {ACTIVE_STATUSES.includes(latestRun.status) && (
+                      <span className="ml-1 inline-block animate-spin">⟳</span>
+                    )}
+                  </span>
+                  <span className="text-[10px] text-slate-400 bg-slate-100 dark:bg-white/[0.06] px-2 py-0.5 rounded-full uppercase font-medium">{latestRun.mode}</span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">{computeOverallScore(latestRun)}</span>
+                  <span className="text-xs text-slate-400">{new Date(latestRun.created_at).toLocaleString()}</span>
+                </div>
+              </div>
+
+              {latestRun.progress && (
+                <div className="px-5 py-2 text-xs text-slate-500 dark:text-slate-400 border-b border-slate-100 dark:border-white/[0.04] bg-slate-50/50 dark:bg-white/[0.01]">
+                  {latestRun.progress}
+                </div>
+              )}
+
+              {latestRun.error && (
+                <div className="px-5 py-3 text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10 border-b border-red-100 dark:border-red-500/20">
+                  {latestRun.error}
+                </div>
+              )}
+
+              {/* Per-criterion chart */}
+              {criteriaResults && criteriaResults.length > 0 && (
+                <div className="px-5 py-4 border-b border-slate-100 dark:border-white/[0.06] space-y-3">
+                  <h4 className="text-xs font-semibold text-slate-500 uppercase tracking-wider">By Criterion</h4>
+                  {criteriaResults.map((c, idx) => {
+                    const name = String(c.criterion ?? c.name ?? `Criterion ${idx + 1}`);
+                    const pass = typeof c.pass === "number" ? c.pass : 0;
+                    const fail = typeof c.fail === "number" ? c.fail : 0;
+                    const total = pass + fail;
+                    const rate = total > 0 ? pass / total : 0;
+                    return (
+                      <div key={idx} className="space-y-1">
+                        <div className="flex items-center justify-between text-xs">
+                          <span className="text-slate-600 dark:text-slate-400 font-medium">{name}</span>
+                          <span className="text-slate-500 font-mono">{pass}/{total} ({Math.round(rate * 100)}%)</span>
+                        </div>
+                        <div className="h-2 bg-slate-100 dark:bg-white/[0.06] rounded-full overflow-hidden">
+                          <div
+                            className="h-full bg-emerald-500 rounded-full transition-all duration-500"
+                            style={{ width: `${rate * 100}%` }}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              {/* Per-sample results */}
+              {latestRun.results.length > 0 && (
+                <div className="px-5 py-4 space-y-2">
+                  <h4 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-3">
+                    Samples ({latestRun.results.length})
+                  </h4>
+                  {latestRun.results.map((result, idx) => (
+                    <ScenarioResultRow key={`${result.scenario}-${idx}`} result={result} />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Recent runs */}
+          {runs.length > 1 && (
+            <div className="bg-white dark:bg-white/[0.03] border border-slate-200 dark:border-white/[0.08] rounded-2xl overflow-hidden">
+              <div className="px-5 py-4 border-b border-slate-100 dark:border-white/[0.06]">
+                <h3 className="text-sm font-semibold text-slate-800 dark:text-white">Recent Runs</h3>
+              </div>
+              <div className="divide-y divide-slate-100 dark:divide-white/[0.04]">
+                {runs.slice(1).map((run) => (
+                  <button
+                    key={run.run_id}
+                    onClick={() => setLatestRun(run)}
+                    className="w-full flex items-center gap-3 px-5 py-3 hover:bg-slate-50/50 dark:hover:bg-white/[0.02] transition-colors text-left"
+                  >
+                    <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${statusConfig[run.status].color}`}>
+                      {statusConfig[run.status].label}
+                    </span>
+                    <span className="text-[10px] text-slate-400 uppercase font-medium bg-slate-100 dark:bg-white/[0.06] px-2 py-0.5 rounded-full">{run.mode}</span>
+                    <span className="text-xs text-slate-500 dark:text-slate-400 flex-1 text-right">{new Date(run.created_at).toLocaleString()}</span>
+                    <svg className="w-4 h-4 text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Expanded result row fallback */}
+          {expandedResult && <div className="hidden">{expandedResult}</div>}
+        </>
+      )}
+
+      {/* Modals */}
+      <GenerateScenariosModal
+        useCase={useCase}
+        open={showGenerateModal}
+        onClose={() => setShowGenerateModal(false)}
+        onGenerated={(newScenarios) => {
+          setScenarios((prev) => {
+            const names = new Set(newScenarios.map((s) => s.name));
+            return [...prev.filter((s) => !names.has(s.name)), ...newScenarios];
+          });
+        }}
+      />
+
+      {editingScenario && (
+        <EditScenarioModal
+          scenario={editingScenario}
+          onSave={handleSaveScenario}
+          onClose={() => setEditingScenario(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/EvalsAdminPanel.tsx
+++ b/src/frontend/src/components/EvalsAdminPanel.tsx
@@ -22,6 +22,14 @@ const FOUNDRY_PORTAL_URL =
   (typeof process !== "undefined" && process.env.NEXT_PUBLIC_FOUNDRY_PORTAL_URL) ||
   "https://ai.azure.com";
 
+const PERSONA_LABELS: Record<string, string> = {
+  generic: "Generalist",
+  insurance: "Insurance Claim Specialist",
+  "retail-banking": "Retail Banking Advisor",
+  "wealth-management": "Wealth Management Advisor",
+  "sales-account-review": "Sales Account Reviewer",
+};
+
 const categoryColors: Record<string, string> = {
   standard: "bg-blue-50 dark:bg-blue-500/10 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-500/20",
   edge_case: "bg-amber-50 dark:bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-500/20",
@@ -38,29 +46,212 @@ const statusConfig: Record<EvalRunStatus, { label: string; color: string }> = {
   failed: { label: "Failed", color: "bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-400" },
 };
 
-function computeOverallScore(run: EvalRun): string {
-  if (run.foundry?.per_testing_criteria_results && run.foundry.per_testing_criteria_results.length > 0) {
-    const criteria = run.foundry.per_testing_criteria_results as Array<Record<string, unknown>>;
-    const rates = criteria.map((c) => {
-      const pass = typeof c.pass === "number" ? c.pass : 0;
-      const total = (typeof c.pass === "number" ? c.pass : 0) + (typeof c.fail === "number" ? c.fail : 0);
-      return total > 0 ? pass / total : 0;
-    });
-    if (rates.length > 0) {
-      const avg = rates.reduce((a, b) => a + b, 0) / rates.length;
-      return `${Math.round(avg * 100)}%`;
-    }
-  }
-  const total = run.results.length;
-  const passed = run.results.filter((r) => r.status === "pass" || r.status === "passed").length;
-  if (total === 0) return "—";
-  return `${passed}/${total}`;
+// ── Per-evaluator + per-scenario aggregation helpers ────────────────────────
+// Works against the union of:
+//   - run.results[].scores  (validation runs scored locally via azure-ai-evaluation)
+//   - run.foundry.per_testing_criteria_results  (foundry / hosted aggregate)
+
+interface PerEvaluatorStat {
+  name: string;
+  passed: number;
+  total: number;
+  rate: number; // 0–100
 }
 
-function ScenarioResultRow({ result }: { result: ScenarioResult }) {
+interface PerScenarioStat {
+  scenario: string;
+  passed: number;
+  total: number;
+  failed: number;
+  errored: boolean;
+  failedEvaluators: string[];
+}
+
+function _toSnake(name: string): string {
+  // "TaskAdherence" → "task_adherence", "ToolCallAccuracy" → "tool_call_accuracy"
+  return name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}
+
+const _METADATA_SUFFIXES = [
+  "_threshold", "_prompt_tokens", "_completion_tokens", "_total_tokens",
+  "_finish_reason", "_model", "_sample_input", "_sample_output", "_details",
+];
+
+function _isMetadataKey(k: string): boolean {
+  return _METADATA_SUFFIXES.some((suffix) => k.endsWith(suffix));
+}
+
+function _extractScoreValue(s: Record<string, unknown>, evaluatorName: string): number | null {
+  // Prefer the canonical snake_case key (e.g. "task_adherence", "tool_call_accuracy")
+  const snake = _toSnake(evaluatorName);
+  if (typeof s[snake] === "number") return s[snake] as number;
+  const gptKey = `gpt_${snake}`;
+  if (typeof s[gptKey] === "number") return s[gptKey] as number;
+  // Otherwise pick the first numeric non-metadata field
+  const numericKey = Object.keys(s).find(
+    (k) => typeof s[k] === "number" && !_isMetadataKey(k),
+  );
+  return numericKey ? (s[numericKey] as number) : null;
+}
+
+function _extractReason(s: Record<string, unknown>, evaluatorName: string): string {
+  const snake = _toSnake(evaluatorName);
+  const direct = s[`${snake}_reason`] ?? s.reason ?? s.explanation;
+  return typeof direct === "string" ? direct : "";
+}
+
+function _extractThreshold(s: Record<string, unknown>, evaluatorName: string): number | null {
+  const snake = _toSnake(evaluatorName);
+  const direct = s[`${snake}_threshold`] ?? s.threshold;
+  return typeof direct === "number" ? direct : null;
+}
+
+function _scoreIsPass(s: Record<string, unknown>, evaluatorName = ""): boolean | null {
+  if (s == null || typeof s !== "object") return null;
+  // 1. Explicit boolean (validation flow added it on some evaluators)
+  if (typeof s.passed === "boolean") return s.passed;
+  if (typeof s.passed === "string") {
+    const v = s.passed.toLowerCase();
+    return v === "true" || v === "pass";
+  }
+  // 2. azure-ai-evaluation snake_case "<name>_result": "pass"|"fail"
+  const snake = _toSnake(evaluatorName);
+  const resultKey = `${snake}_result`;
+  if (typeof s[resultKey] === "string") return /pass|true/i.test(s[resultKey] as string);
+  if (typeof s.result === "string") return /pass|true/i.test(s.result);
+  // 3. Fall back to numeric ≥ threshold
+  const val = _extractScoreValue(s, evaluatorName);
+  const threshold = _extractThreshold(s, evaluatorName) ?? 3;
+  if (val !== null) return val >= threshold;
+  return null;
+}
+
+function evaluatorStatsForRun(run: EvalRun): PerEvaluatorStat[] {
+  // Prefer foundry aggregate when present
+  const fc = run.foundry?.per_testing_criteria_results as Array<Record<string, unknown>> | undefined;
+  if (fc && fc.length > 0) {
+    return fc.map((c, i) => {
+      const name = String(c.criterion ?? c.name ?? `Criterion ${i + 1}`);
+      const passed = typeof c.passed === "number" ? c.passed : typeof c.pass === "number" ? c.pass : 0;
+      const failed = typeof c.failed === "number" ? c.failed : typeof c.fail === "number" ? c.fail : 0;
+      const total = passed + failed;
+      return { name, passed, total, rate: total > 0 ? Math.round((passed / total) * 100) : 0 };
+    });
+  }
+  // Fall back: aggregate per-result scores
+  const totals: Record<string, { passed: number; total: number }> = {};
+  for (const r of run.results) {
+    const scores = r.scores ?? {};
+    for (const [name, raw] of Object.entries(scores)) {
+      const s = raw as Record<string, unknown>;
+      if (s && (s as { error?: unknown }).error) continue;
+      const passed = _scoreIsPass(s, name);
+      if (passed === null) continue;
+      if (!totals[name]) totals[name] = { passed: 0, total: 0 };
+      totals[name].total += 1;
+      if (passed) totals[name].passed += 1;
+    }
+  }
+  return Object.entries(totals).map(([name, t]) => ({
+    name, passed: t.passed, total: t.total,
+    rate: t.total > 0 ? Math.round((t.passed / t.total) * 100) : 0,
+  }));
+}
+
+function scenarioStatsForRun(run: EvalRun): PerScenarioStat[] {
+  return run.results.map((r) => {
+    const scores = r.scores ?? {};
+    const entries = Object.entries(scores);
+    let passed = 0;
+    let total = 0;
+    const failedEvaluators: string[] = [];
+    for (const [name, raw] of entries) {
+      const s = raw as Record<string, unknown>;
+      if (s && (s as { error?: unknown }).error) continue;
+      const p = _scoreIsPass(s, name);
+      if (p === null) continue;
+      total += 1;
+      if (p) passed += 1;
+      else failedEvaluators.push(name);
+    }
+    return {
+      scenario: r.scenario,
+      passed,
+      total,
+      failed: total - passed,
+      errored: r.status === "error" || r.status === "failed",
+      failedEvaluators,
+    };
+  });
+}
+
+interface RunRollup {
+  evaluators: PerEvaluatorStat[];
+  scenarios: PerScenarioStat[];
+  overallScore: number; // 0–100
+  allPassedCount: number;
+  partialCount: number;
+  majorFailCount: number;
+  erroredCount: number;
+}
+
+function rollupRun(run: EvalRun): RunRollup {
+  const evaluators = evaluatorStatsForRun(run);
+  const scenarios = scenarioStatsForRun(run);
+  const hasPerEvalScores = scenarios.some((s) => s.total > 0);
+
+  const overallScore = evaluators.length > 0
+    ? Math.round(evaluators.reduce((acc, e) => acc + e.rate, 0) / evaluators.length)
+    : hasPerEvalScores
+    ? Math.round((scenarios.filter((s) => s.total > 0 && s.failed === 0).length / scenarios.length) * 100)
+    : 0;
+
+  const allPassedCount = hasPerEvalScores
+    ? scenarios.filter((s) => s.total > 0 && s.failed === 0).length
+    : scenarios.filter((s) => !s.errored).length;
+  const partialCount = hasPerEvalScores
+    ? scenarios.filter((s) => s.failed > 0 && s.passed >= s.total / 2).length
+    : 0;
+  const majorFailCount = hasPerEvalScores
+    ? scenarios.filter((s) => s.total > 0 && s.passed < s.total / 2 && s.failed > 0).length
+    : scenarios.filter((s) => s.errored).length;
+  const erroredCount = scenarios.filter((s) => s.errored).length;
+
+  return { evaluators, scenarios, overallScore, allPassedCount, partialCount, majorFailCount, erroredCount };
+}
+
+function formatEvaluatorName(name: string): string {
+  return name.replace(/_/g, " ").replace(/([A-Z])/g, " $1").trim().replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function scoreColor(rate: number): string {
+  if (rate >= 70) return "text-emerald-600 dark:text-emerald-400";
+  if (rate >= 40) return "text-amber-500 dark:text-amber-400";
+  return "text-red-500 dark:text-red-400";
+}
+
+function scoreBarColor(rate: number): string {
+  if (rate >= 70) return "bg-emerald-500";
+  if (rate >= 40) return "bg-amber-500";
+  return "bg-red-500";
+}
+
+function ScenarioResultRow({ result, stat }: { result: ScenarioResult; stat: PerScenarioStat }) {
   const [expanded, setExpanded] = useState(false);
 
   const scoreEntries = Object.entries(result.scores ?? {});
+  const hasScores = stat.total > 0;
+  const isAllPassed = hasScores ? stat.failed === 0 : !stat.errored;
+  const isMajorFail = hasScores ? stat.passed < stat.total / 2 && stat.failed > 0 : stat.errored;
+  const isPartial = hasScores && stat.failed > 0 && stat.passed >= stat.total / 2;
+  const statusDotCls = isAllPassed ? "bg-emerald-500" : isMajorFail ? "bg-red-500" : isPartial ? "bg-amber-500" : "bg-slate-400";
+  const chipTone = isAllPassed
+    ? "bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-200/60 dark:border-emerald-500/30"
+    : isMajorFail
+    ? "bg-red-50 dark:bg-red-500/10 text-red-600 dark:text-red-400 border-red-200/60 dark:border-red-500/30"
+    : isPartial
+    ? "bg-amber-50 dark:bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-200/60 dark:border-amber-500/30"
+    : "bg-slate-50 dark:bg-white/[0.05] text-slate-500 border-slate-200/60 dark:border-white/[0.08]";
 
   return (
     <div className="border border-slate-200 dark:border-white/[0.06] rounded-xl overflow-hidden">
@@ -68,10 +259,25 @@ function ScenarioResultRow({ result }: { result: ScenarioResult }) {
         onClick={() => setExpanded((v) => !v)}
         className="w-full flex items-center gap-3 px-4 py-3 bg-slate-50/50 dark:bg-white/[0.02] hover:bg-slate-100/80 dark:hover:bg-white/[0.04] transition-colors text-left"
       >
-        <span className={`flex-shrink-0 w-2 h-2 rounded-full ${result.status === "pass" || result.status === "passed" ? "bg-emerald-500" : result.status === "fail" || result.status === "failed" ? "bg-red-400" : "bg-slate-400"}`} />
-        <span className="flex-1 text-sm font-medium text-slate-700 dark:text-slate-300 truncate">{result.scenario}</span>
+        <span className={`flex-shrink-0 w-2 h-2 rounded-full ${statusDotCls}`} />
+        <span className="flex-1 text-sm font-medium text-slate-700 dark:text-slate-300 truncate">
+          {result.scenario.replace(/_/g, " ")}
+        </span>
+        {result.tool_calls.length > 0 && (
+          <span className="text-[10px] font-mono text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10 border border-blue-200/60 dark:border-blue-500/20 rounded px-1.5 py-0.5 flex-shrink-0">
+            🔧 {result.tool_calls.length}
+          </span>
+        )}
         {result.duration_ms > 0 && (
           <span className="text-xs text-slate-400 font-mono flex-shrink-0">{result.duration_ms}ms</span>
+        )}
+        {hasScores && (
+          <span className={`text-[11px] font-mono border rounded-full px-2 py-0.5 flex-shrink-0 font-medium tabular-nums ${chipTone}`}>
+            {stat.passed}/{stat.total}
+          </span>
+        )}
+        {!hasScores && stat.errored && (
+          <span className={`text-[11px] border rounded-full px-2 py-0.5 flex-shrink-0 font-medium ${chipTone}`}>error</span>
         )}
         <svg
           className={`w-4 h-4 text-slate-400 transition-transform flex-shrink-0 ${expanded ? "rotate-180" : ""}`}
@@ -80,6 +286,21 @@ function ScenarioResultRow({ result }: { result: ScenarioResult }) {
           <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
         </svg>
       </button>
+
+      {/* Failed-evaluator badges visible even when collapsed */}
+      {!expanded && stat.failedEvaluators.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 px-4 pb-2 pt-1 -mt-1 bg-slate-50/50 dark:bg-white/[0.02]">
+          {stat.failedEvaluators.map((name) => (
+            <span
+              key={name}
+              className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${isMajorFail ? "bg-red-500/10 text-red-600 dark:text-red-400" : "bg-amber-500/10 text-amber-600 dark:text-amber-400"}`}
+            >
+              ✗ {formatEvaluatorName(name)}
+            </span>
+          ))}
+        </div>
+      )}
+
       {expanded && (
         <div className="px-4 py-4 space-y-3 border-t border-slate-100 dark:border-white/[0.04]">
           {result.error && (
@@ -95,7 +316,7 @@ function ScenarioResultRow({ result }: { result: ScenarioResult }) {
           </div>
           {result.tool_calls.length > 0 && (
             <div>
-              <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">Tool Calls</p>
+              <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">🔧 Tool Calls</p>
               <div className="space-y-1.5">
                 {result.tool_calls.map((tc, i) => (
                   <div key={i} className="flex items-start gap-2 bg-slate-50 dark:bg-white/[0.03] rounded-lg px-3 py-2">
@@ -110,17 +331,34 @@ function ScenarioResultRow({ result }: { result: ScenarioResult }) {
           )}
           {scoreEntries.length > 0 && (
             <div>
-              <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">Scores</p>
+              <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">Evaluator Scores</p>
               <div className="grid grid-cols-2 gap-2">
                 {scoreEntries.map(([criterion, score]) => {
                   const scoreObj = score as Record<string, unknown>;
-                  const passed = scoreObj.passed ?? scoreObj.result ?? scoreObj.score;
+                  const passed = _scoreIsPass(scoreObj, criterion);
+                  const reason = _extractReason(scoreObj, criterion);
+                  const numericVal = _extractScoreValue(scoreObj, criterion);
+                  const threshold = _extractThreshold(scoreObj, criterion);
+                  const err = (scoreObj.error ?? "") as string;
                   return (
-                    <div key={criterion} className="flex items-center justify-between bg-slate-50 dark:bg-white/[0.03] rounded-lg px-3 py-1.5">
-                      <span className="text-xs text-slate-600 dark:text-slate-400">{criterion}</span>
-                      <span className={`text-xs font-medium ${passed === true || passed === "pass" ? "text-emerald-600 dark:text-emerald-400" : "text-red-500 dark:text-red-400"}`}>
-                        {String(passed)}
-                      </span>
+                    <div key={criterion} className="bg-slate-50 dark:bg-white/[0.03] rounded-lg px-3 py-2">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-xs text-slate-600 dark:text-slate-400 font-medium truncate">{formatEvaluatorName(criterion)}</span>
+                        <span className={`text-xs font-mono font-medium ${passed === true ? "text-emerald-600 dark:text-emerald-400" : passed === false ? "text-red-500 dark:text-red-400" : "text-slate-500"}`}>
+                          {err ? "err" : passed === true ? "✓" : passed === false ? "✗" : "—"}
+                          {numericVal !== null && (
+                            <span className="ml-1 text-slate-400">
+                              {numericVal}{threshold !== null ? `/${threshold}` : ""}
+                            </span>
+                          )}
+                        </span>
+                      </div>
+                      {reason && (
+                        <p className="mt-1 text-[11px] text-slate-500 dark:text-slate-400 leading-relaxed line-clamp-2">{reason}</p>
+                      )}
+                      {err && (
+                        <p className="mt-1 text-[11px] text-red-500 dark:text-red-400 font-mono line-clamp-2">{err}</p>
+                      )}
                     </div>
                   );
                 })}
@@ -363,8 +601,8 @@ export function EvalsAdminPanel({ useCase }: Props): JSX.Element {
   };
 
   const foundryUrl = latestRun?.foundry?.report_url || FOUNDRY_PORTAL_URL;
-
-  const criteriaResults = latestRun?.foundry?.per_testing_criteria_results as Array<Record<string, unknown>> | undefined;
+  const rollup = latestRun ? rollupRun(latestRun) : null;
+  const personaLabel = PERSONA_LABELS[useCase] ?? useCase;
 
   return (
     <div className="max-w-4xl space-y-6">
@@ -534,10 +772,11 @@ export function EvalsAdminPanel({ useCase }: Props): JSX.Element {
           </div>
 
           {/* Latest run */}
-          {latestRun && (
+          {latestRun && rollup && (
             <div className="bg-white dark:bg-white/[0.03] border border-slate-200 dark:border-white/[0.08] rounded-2xl overflow-hidden">
+              {/* Header */}
               <div className="flex items-center justify-between px-5 py-4 border-b border-slate-100 dark:border-white/[0.06]">
-                <div className="flex items-center gap-3">
+                <div className="flex items-center gap-3 min-w-0">
                   <h3 className="text-sm font-semibold text-slate-800 dark:text-white">Latest Run</h3>
                   <span className={`text-xs px-2.5 py-1 rounded-full font-medium ${statusConfig[latestRun.status].color}`}>
                     {statusConfig[latestRun.status].label}
@@ -546,9 +785,11 @@ export function EvalsAdminPanel({ useCase }: Props): JSX.Element {
                     )}
                   </span>
                   <span className="text-[10px] text-slate-400 bg-slate-100 dark:bg-white/[0.06] px-2 py-0.5 rounded-full uppercase font-medium">{latestRun.mode}</span>
+                  <span className="text-[11px] text-slate-500 dark:text-slate-400 truncate">
+                    Persona: <span className="font-medium text-slate-700 dark:text-slate-300">{personaLabel}</span>
+                  </span>
                 </div>
                 <div className="flex items-center gap-3">
-                  <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">{computeOverallScore(latestRun)}</span>
                   <span className="text-xs text-slate-400">{new Date(latestRun.created_at).toLocaleString()}</span>
                 </div>
               </div>
@@ -565,31 +806,80 @@ export function EvalsAdminPanel({ useCase }: Props): JSX.Element {
                 </div>
               )}
 
-              {/* Per-criterion chart */}
-              {criteriaResults && criteriaResults.length > 0 && (
-                <div className="px-5 py-4 border-b border-slate-100 dark:border-white/[0.06] space-y-3">
-                  <h4 className="text-xs font-semibold text-slate-500 uppercase tracking-wider">By Criterion</h4>
-                  {criteriaResults.map((c, idx) => {
-                    const name = String(c.criterion ?? c.name ?? `Criterion ${idx + 1}`);
-                    const pass = typeof c.pass === "number" ? c.pass : 0;
-                    const fail = typeof c.fail === "number" ? c.fail : 0;
-                    const total = pass + fail;
-                    const rate = total > 0 ? pass / total : 0;
-                    return (
-                      <div key={idx} className="space-y-1">
-                        <div className="flex items-center justify-between text-xs">
-                          <span className="text-slate-600 dark:text-slate-400 font-medium">{name}</span>
-                          <span className="text-slate-500 font-mono">{pass}/{total} ({Math.round(rate * 100)}%)</span>
-                        </div>
-                        <div className="h-2 bg-slate-100 dark:bg-white/[0.06] rounded-full overflow-hidden">
-                          <div
-                            className="h-full bg-emerald-500 rounded-full transition-all duration-500"
-                            style={{ width: `${rate * 100}%` }}
-                          />
-                        </div>
+              {/* KPI cards + overall score + per-evaluator bars */}
+              {latestRun.results.length > 0 && (
+                <div className="px-5 py-4 space-y-4 border-b border-slate-100 dark:border-white/[0.06]">
+                  {/* KPI cards */}
+                  <div className={`grid gap-3 ${rollup.erroredCount > 0 ? "grid-cols-4" : "grid-cols-3"}`}>
+                    <div className="rounded-xl bg-emerald-500/5 border border-emerald-500/20 p-3 text-center">
+                      <p className="text-[10px] text-slate-500 dark:text-slate-400 mb-1 uppercase tracking-wider">All Passed</p>
+                      <p className="text-2xl font-bold text-emerald-600 dark:text-emerald-400 tabular-nums">{rollup.allPassedCount}</p>
+                      <p className="text-[10px] text-slate-400">{rollup.evaluators.length > 0 ? `${rollup.evaluators.length}/${rollup.evaluators.length} evaluators` : "completed"}</p>
+                    </div>
+                    <div className="rounded-xl bg-amber-500/5 border border-amber-500/20 p-3 text-center">
+                      <p className="text-[10px] text-slate-500 dark:text-slate-400 mb-1 uppercase tracking-wider">Partial</p>
+                      <p className="text-2xl font-bold text-amber-500 dark:text-amber-400 tabular-nums">{rollup.partialCount}</p>
+                      <p className="text-[10px] text-slate-400">minor issues</p>
+                    </div>
+                    <div className="rounded-xl bg-red-500/5 border border-red-500/20 p-3 text-center">
+                      <p className="text-[10px] text-slate-500 dark:text-slate-400 mb-1 uppercase tracking-wider">Failed</p>
+                      <p className="text-2xl font-bold text-red-600 dark:text-red-400 tabular-nums">{rollup.majorFailCount}</p>
+                      <p className="text-[10px] text-slate-400">majority fail</p>
+                    </div>
+                    {rollup.erroredCount > 0 && (
+                      <div className="rounded-xl bg-slate-500/5 border border-slate-200 dark:border-slate-500/20 p-3 text-center">
+                        <p className="text-[10px] text-slate-500 dark:text-slate-400 mb-1 uppercase tracking-wider">Errored</p>
+                        <p className="text-2xl font-bold text-slate-700 dark:text-slate-300 tabular-nums">{rollup.erroredCount}</p>
+                        <p className="text-[10px] text-slate-400">runtime</p>
                       </div>
-                    );
-                  })}
+                    )}
+                  </div>
+
+                  {/* Overall score + stacked status bar */}
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-slate-500 dark:text-slate-400">Overall quality score</span>
+                      <span className={`font-bold tabular-nums ${scoreColor(rollup.overallScore)}`}>{rollup.overallScore}%</span>
+                    </div>
+                    <div className="w-full h-2.5 rounded-full bg-slate-100 dark:bg-white/[0.06] overflow-hidden flex">
+                      {rollup.allPassedCount > 0 && (
+                        <div className="h-full bg-emerald-500 transition-all duration-500" style={{ width: `${(rollup.allPassedCount / rollup.scenarios.length) * 100}%` }} />
+                      )}
+                      {rollup.partialCount > 0 && (
+                        <div className="h-full bg-amber-500 transition-all duration-500" style={{ width: `${(rollup.partialCount / rollup.scenarios.length) * 100}%` }} />
+                      )}
+                      {rollup.majorFailCount > 0 && (
+                        <div className="h-full bg-red-500 transition-all duration-500" style={{ width: `${(rollup.majorFailCount / rollup.scenarios.length) * 100}%` }} />
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Per-evaluator breakdown */}
+                  {rollup.evaluators.length > 0 && (
+                    <div>
+                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">Per Evaluator</p>
+                      <div className="space-y-1.5">
+                        {rollup.evaluators.map((ev) => (
+                          <div key={ev.name} className="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-50 dark:bg-white/[0.03] border border-slate-100 dark:border-white/[0.04]">
+                            <div className="flex items-center gap-2 flex-1 min-w-0">
+                              <span className={`text-sm flex-shrink-0 ${scoreColor(ev.rate)}`}>
+                                {ev.rate >= 70 ? "✓" : ev.rate >= 40 ? "⚠" : "✗"}
+                              </span>
+                              <span className="text-sm text-slate-700 dark:text-slate-300 truncate">{formatEvaluatorName(ev.name)}</span>
+                            </div>
+                            <div className="flex items-center gap-3 flex-shrink-0">
+                              <div className="w-24 h-1.5 rounded-full bg-slate-200 dark:bg-white/[0.06] overflow-hidden">
+                                <div className={`h-full rounded-full transition-all duration-500 ${scoreBarColor(ev.rate)}`} style={{ width: `${ev.rate}%` }} />
+                              </div>
+                              <span className="text-xs tabular-nums text-slate-500 dark:text-slate-400 w-20 text-right font-mono">
+                                {ev.passed}/{ev.total} ({ev.rate}%)
+                              </span>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                 </div>
               )}
 
@@ -597,10 +887,10 @@ export function EvalsAdminPanel({ useCase }: Props): JSX.Element {
               {latestRun.results.length > 0 && (
                 <div className="px-5 py-4 space-y-2">
                   <h4 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-3">
-                    Samples ({latestRun.results.length})
+                    Per Scenario ({latestRun.results.length} samples)
                   </h4>
                   {latestRun.results.map((result, idx) => (
-                    <ScenarioResultRow key={`${result.scenario}-${idx}`} result={result} />
+                    <ScenarioResultRow key={`${result.scenario}-${idx}`} result={result} stat={rollup.scenarios[idx]} />
                   ))}
                 </div>
               )}

--- a/src/frontend/src/components/EvalsAdminPanel.tsx
+++ b/src/frontend/src/components/EvalsAdminPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   listEvalScenarios,
   upsertEvalScenario,
@@ -195,6 +195,88 @@ interface RunRollup {
   erroredCount: number;
 }
 
+// One agent tool invocation, derived by merging the started + completed events
+// the orchestrator emits for the same skill (matched FIFO by skillName).
+interface ToolCallView {
+  skillName: string;
+  status: "started" | "completed" | "failed";
+  input: string;
+  output: string;
+  durationMs: number;
+  source: string;
+}
+
+function _stringifyToolValue(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  if (typeof v === "string") return v;
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}
+
+// Collapse the orchestrator's `started` / `completed` event pairs into a single
+// row per call (matched FIFO by skillName). Falls back to a started-only row
+// if no completion event arrived (and vice versa).
+function collapseToolCalls(events: ScenarioResult["tool_calls"]): ToolCallView[] {
+  const out: ToolCallView[] = [];
+  // Index of the most recent open "started" entry per skill, awaiting its completion.
+  const openIdx: Map<string, number[]> = new Map();
+  for (const raw of events ?? []) {
+    const skill = (raw.skillName as string | undefined) || (raw.name as string | undefined) || "tool";
+    const status = (raw.status as string | undefined) || "completed";
+    const input = _stringifyToolValue(raw.input ?? raw.arguments);
+    const output = _stringifyToolValue(raw.output ?? raw.result);
+    const duration = Number(raw.durationMs ?? 0) || 0;
+    const source = (raw.source as string | undefined) || "";
+    if (status === "started" || status === "running") {
+      const view: ToolCallView = {
+        skillName: skill,
+        status: "started",
+        input,
+        output: "",
+        durationMs: 0,
+        source,
+      };
+      out.push(view);
+      const list = openIdx.get(skill) ?? [];
+      list.push(out.length - 1);
+      openIdx.set(skill, list);
+    } else if (status === "completed" || status === "failed" || status === "error") {
+      const list = openIdx.get(skill);
+      const idx = list && list.length > 0 ? list.shift()! : -1;
+      if (idx >= 0) {
+        const existing = out[idx];
+        existing.status = status === "completed" ? "completed" : "failed";
+        if (input && !existing.input) existing.input = input;
+        existing.output = output;
+        existing.durationMs = duration || existing.durationMs;
+        if (source && !existing.source) existing.source = source;
+      } else {
+        out.push({
+          skillName: skill,
+          status: status === "completed" ? "completed" : "failed",
+          input,
+          output,
+          durationMs: duration,
+          source,
+        });
+      }
+    } else {
+      out.push({
+        skillName: skill,
+        status: "completed",
+        input,
+        output,
+        durationMs: duration,
+        source,
+      });
+    }
+  }
+  return out;
+}
+
 function rollupRun(run: EvalRun): RunRollup {
   const evaluators = evaluatorStatsForRun(run);
   const scenarios = scenarioStatsForRun(run);
@@ -240,6 +322,7 @@ function ScenarioResultRow({ result, stat }: { result: ScenarioResult; stat: Per
   const [expanded, setExpanded] = useState(false);
 
   const scoreEntries = Object.entries(result.scores ?? {});
+  const toolCalls = useMemo(() => collapseToolCalls(result.tool_calls), [result.tool_calls]);
   const hasScores = stat.total > 0;
   const isAllPassed = hasScores ? stat.failed === 0 : !stat.errored;
   const isMajorFail = hasScores ? stat.passed < stat.total / 2 && stat.failed > 0 : stat.errored;
@@ -263,9 +346,9 @@ function ScenarioResultRow({ result, stat }: { result: ScenarioResult; stat: Per
         <span className="flex-1 text-sm font-medium text-slate-700 dark:text-slate-300 truncate">
           {result.scenario.replace(/_/g, " ")}
         </span>
-        {result.tool_calls.length > 0 && (
+        {toolCalls.length > 0 && (
           <span className="text-[10px] font-mono text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10 border border-blue-200/60 dark:border-blue-500/20 rounded px-1.5 py-0.5 flex-shrink-0">
-            🔧 {result.tool_calls.length}
+            🔧 {toolCalls.length}
           </span>
         )}
         {result.duration_ms > 0 && (
@@ -314,18 +397,52 @@ function ScenarioResultRow({ result, stat }: { result: ScenarioResult; stat: Per
             <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">Response</p>
             <p className="text-sm text-slate-700 dark:text-slate-300 bg-slate-50 dark:bg-white/[0.03] rounded-lg px-3 py-2 whitespace-pre-wrap max-h-40 overflow-y-auto">{result.response}</p>
           </div>
-          {result.tool_calls.length > 0 && (
+          {toolCalls.length > 0 && (
             <div>
-              <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">🔧 Tool Calls</p>
+              <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-1">🔧 Tool Calls ({toolCalls.length})</p>
               <div className="space-y-1.5">
-                {result.tool_calls.map((tc, i) => (
-                  <div key={i} className="flex items-start gap-2 bg-slate-50 dark:bg-white/[0.03] rounded-lg px-3 py-2">
-                    <span className="text-xs font-mono font-medium text-primary-600 dark:text-primary-400 flex-shrink-0">{tc.name}</span>
-                    {tc.arguments && (
-                      <span className="text-xs text-slate-500 font-mono truncate">{JSON.stringify(tc.arguments)}</span>
-                    )}
-                  </div>
-                ))}
+                {toolCalls.map((tc, i) => {
+                  const ok = tc.status === "completed";
+                  const failed = tc.status === "failed";
+                  const dotCls = ok ? "bg-emerald-500" : failed ? "bg-red-500" : "bg-slate-400";
+                  return (
+                    <div
+                      key={i}
+                      className="rounded-lg bg-slate-50 dark:bg-white/[0.03] border border-slate-200/60 dark:border-white/[0.05] overflow-hidden"
+                    >
+                      <div className="flex items-center gap-2 px-3 py-1.5 border-b border-slate-200/60 dark:border-white/[0.05] bg-white/40 dark:bg-white/[0.02]">
+                        <span className={`flex-shrink-0 w-1.5 h-1.5 rounded-full ${dotCls}`} />
+                        <span className="text-xs font-mono font-medium text-primary-600 dark:text-primary-400 truncate">{tc.skillName}</span>
+                        {tc.source && (
+                          <span className="text-[10px] text-slate-400 font-mono">{tc.source}</span>
+                        )}
+                        <span className="flex-1" />
+                        {tc.durationMs > 0 && (
+                          <span className="text-[10px] text-slate-400 font-mono">{tc.durationMs}ms</span>
+                        )}
+                        <span className={`text-[10px] font-mono ${ok ? "text-emerald-600 dark:text-emerald-400" : failed ? "text-red-500 dark:text-red-400" : "text-slate-400"}`}>
+                          {tc.status}
+                        </span>
+                      </div>
+                      {(tc.input || tc.output) && (
+                        <div className="px-3 py-2 grid grid-cols-1 sm:grid-cols-2 gap-2 text-[11px]">
+                          {tc.input && (
+                            <div className="min-w-0">
+                              <p className="text-slate-400 uppercase tracking-wider mb-0.5 text-[9px]">Input</p>
+                              <pre className="font-mono text-slate-600 dark:text-slate-300 whitespace-pre-wrap break-words max-h-24 overflow-y-auto">{tc.input}</pre>
+                            </div>
+                          )}
+                          {tc.output && (
+                            <div className="min-w-0">
+                              <p className="text-slate-400 uppercase tracking-wider mb-0.5 text-[9px]">Output</p>
+                              <pre className="font-mono text-slate-600 dark:text-slate-300 whitespace-pre-wrap break-words max-h-24 overflow-y-auto">{tc.output}</pre>
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             </div>
           )}
@@ -497,6 +614,9 @@ export function EvalsAdminPanel({ useCase }: Props): JSX.Element {
       if (runList.length > 0) {
         const latest = runList[0];
         setLatestRun(latest);
+      } else {
+        // No runs for this persona — clear the stale ghost from a previous tab.
+        setLatestRun(null);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load eval data");

--- a/src/frontend/src/components/GenerateScenariosModal.tsx
+++ b/src/frontend/src/components/GenerateScenariosModal.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useState } from "react";
+import { generateEvalScenarios, upsertEvalScenario } from "@/lib/api";
+import type { EvalScenario } from "@/types";
+
+interface Props {
+  useCase: string;
+  open: boolean;
+  onClose: () => void;
+  onGenerated: (scenarios: EvalScenario[]) => void;
+}
+
+export function GenerateScenariosModal({ useCase, open, onClose, onGenerated }: Props): JSX.Element | null {
+  const [count, setCount] = useState(10);
+  const [instructions, setInstructions] = useState("");
+  const [drafts, setDrafts] = useState<EvalScenario[]>([]);
+  const [generating, setGenerating] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  if (!open) return null;
+
+  const handleGenerate = async () => {
+    setGenerating(true);
+    setError("");
+    setDrafts([]);
+    try {
+      const result = await generateEvalScenarios(useCase, { count, instructions: instructions || undefined, persist: false });
+      setDrafts(result.scenarios);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to generate scenarios");
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const updateDraft = (idx: number, patch: Partial<EvalScenario>) => {
+    setDrafts((prev) => prev.map((d, i) => (i === idx ? { ...d, ...patch } : d)));
+  };
+
+  const removeDraft = (idx: number) => {
+    setDrafts((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  const handleSaveAll = async () => {
+    if (drafts.length === 0) return;
+    setSaving(true);
+    setError("");
+    try {
+      const saved: EvalScenario[] = [];
+      for (const scenario of drafts) {
+        const s = await upsertEvalScenario(useCase, scenario);
+        saved.push(s);
+      }
+      onGenerated(saved);
+      onClose();
+      setDrafts([]);
+      setInstructions("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save scenarios");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!generating && !saving) {
+      setDrafts([]);
+      setInstructions("");
+      setError("");
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/40 backdrop-blur-sm z-50 flex items-center justify-center p-4 animate-fade-in"
+      onClick={handleClose}
+    >
+      <div
+        className="bg-white dark:bg-navy-900 rounded-2xl shadow-glass-lg max-w-2xl w-full border border-slate-200/50 dark:border-white/[0.08] animate-slide-up flex flex-col max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-slate-100 dark:border-white/[0.06] flex-shrink-0">
+          <div className="flex items-center gap-3">
+            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-primary-500/20 to-cyan-500/20 dark:from-primary-500/10 dark:to-cyan-500/10 flex items-center justify-center border border-primary-200 dark:border-primary-500/20">
+              <svg className="w-4 h-4 text-primary-600 dark:text-primary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
+              </svg>
+            </div>
+            <div>
+              <h2 className="text-base font-semibold text-slate-900 dark:text-white">Generate Scenarios</h2>
+              <p className="text-xs text-slate-400">AI-generated eval scenarios for <span className="font-mono">{useCase}</span></p>
+            </div>
+          </div>
+          <button
+            onClick={handleClose}
+            disabled={generating || saving}
+            className="p-2 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-white/[0.06] rounded-lg transition-all disabled:opacity-40"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+          {error && (
+            <div className="px-4 py-3 bg-red-50 dark:bg-red-500/10 text-red-600 dark:text-red-400 text-sm rounded-xl border border-red-100 dark:border-red-500/20 flex items-center justify-between">
+              <span>{error}</span>
+              <button onClick={() => setError("")} className="text-red-400 hover:text-red-600 transition-colors ml-3">
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          )}
+
+          {/* Generation params */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1.5">
+                Number of scenarios
+              </label>
+              <input
+                type="number"
+                min={1}
+                max={50}
+                value={count}
+                onChange={(e) => setCount(Math.max(1, parseInt(e.target.value, 10) || 1))}
+                className="w-full px-3 py-2 bg-slate-50 dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-xl text-sm text-slate-900 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-400 transition-all"
+              />
+            </div>
+            <div className="col-span-2">
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1.5">
+                Instructions <span className="text-slate-400 font-normal">(optional)</span>
+              </label>
+              <textarea
+                value={instructions}
+                onChange={(e) => setInstructions(e.target.value)}
+                rows={2}
+                placeholder="Focus on edge cases around authentication flows..."
+                className="w-full px-3 py-2 bg-slate-50 dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-xl text-sm text-slate-900 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-400 transition-all resize-none"
+              />
+            </div>
+          </div>
+
+          <div>
+            <button
+              onClick={handleGenerate}
+              disabled={generating || saving}
+              className="flex items-center gap-2 px-5 py-2.5 text-sm text-white bg-gradient-to-r from-primary-600 to-primary-500 rounded-xl hover:from-primary-700 hover:to-primary-600 transition-all shadow-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {generating ? (
+                <>
+                  <div className="animate-spin rounded-full h-4 w-4 border-2 border-white/30 border-t-white" />
+                  Generating…
+                </>
+              ) : (
+                <>
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
+                  </svg>
+                  Generate Draft
+                </>
+              )}
+            </button>
+          </div>
+
+          {/* Draft list */}
+          {drafts.length > 0 && (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300">
+                  Draft scenarios <span className="font-mono text-xs text-slate-400">({drafts.length})</span>
+                </h3>
+                <p className="text-xs text-slate-400">Edit inline or remove before saving</p>
+              </div>
+              {drafts.map((scenario, idx) => (
+                <div
+                  key={idx}
+                  className="border border-slate-200 dark:border-white/[0.08] rounded-xl p-4 space-y-3 bg-slate-50/50 dark:bg-white/[0.02]"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <input
+                      type="text"
+                      value={scenario.name}
+                      onChange={(e) => updateDraft(idx, { name: e.target.value })}
+                      className="flex-1 px-2.5 py-1.5 bg-white dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-lg text-sm font-medium text-slate-900 dark:text-slate-200 focus:outline-none focus:ring-1 focus:ring-primary-400"
+                      placeholder="Scenario name"
+                    />
+                    <button
+                      onClick={() => removeDraft(idx)}
+                      className="p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 rounded-lg transition-all"
+                      title="Remove"
+                    >
+                      <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </div>
+                  <textarea
+                    value={scenario.input_message}
+                    onChange={(e) => updateDraft(idx, { input_message: e.target.value })}
+                    rows={2}
+                    placeholder="Input message…"
+                    className="w-full px-2.5 py-1.5 bg-white dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-lg text-sm text-slate-700 dark:text-slate-300 focus:outline-none focus:ring-1 focus:ring-primary-400 resize-none"
+                  />
+                  <textarea
+                    value={scenario.expected_behavior}
+                    onChange={(e) => updateDraft(idx, { expected_behavior: e.target.value })}
+                    rows={2}
+                    placeholder="Expected behavior…"
+                    className="w-full px-2.5 py-1.5 bg-white dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-lg text-sm text-slate-700 dark:text-slate-300 focus:outline-none focus:ring-1 focus:ring-primary-400 resize-none"
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-slate-100 dark:border-white/[0.06] flex-shrink-0">
+          <button
+            onClick={handleClose}
+            disabled={generating || saving}
+            className="px-4 py-2 text-sm text-slate-500 bg-slate-50 dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-xl hover:bg-slate-100 dark:hover:bg-white/[0.06] transition-all font-medium disabled:opacity-40"
+          >
+            Cancel
+          </button>
+          {drafts.length > 0 && (
+            <button
+              onClick={handleSaveAll}
+              disabled={saving || generating}
+              className="flex items-center gap-2 px-5 py-2 text-sm text-white bg-gradient-to-r from-primary-600 to-primary-500 rounded-xl hover:from-primary-700 hover:to-primary-600 transition-all shadow-sm font-medium disabled:opacity-50"
+            >
+              {saving ? (
+                <>
+                  <div className="animate-spin rounded-full h-4 w-4 border-2 border-white/30 border-t-white" />
+                  Saving…
+                </>
+              ) : (
+                <>
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                  Save All ({drafts.length})
+                </>
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/SkillsAdminPanel.tsx
+++ b/src/frontend/src/components/SkillsAdminPanel.tsx
@@ -5,9 +5,11 @@ import { listSkills, createSkill, updateSkill, deleteSkill, getSystemPrompt, upd
 import type { AnalysisResult, AnalysisIssue, ApplyFixResult, MCPConfig, Skill, SkillFile, UseCase } from "@/types";
 import { useTheme } from "./ThemeProvider";
 import { ApmAdminPanel } from "./ApmAdminPanel";
+import { EvalsAdminPanel } from "./EvalsAdminPanel";
+import { TracesAdminPanel } from "./TracesAdminPanel";
 import { SourceBadge } from "./SourceBadge";
 
-type Tab = "skills" | "prompt" | "mcp" | "consistency" | "apm";
+type Tab = "skills" | "prompt" | "mcp" | "consistency" | "apm" | "evals" | "traces";
 
 interface Props {
   onClose: () => void;
@@ -396,6 +398,8 @@ export function SkillsAdminPanel({ onClose, useCase = "generic", useCases = [], 
     { id: "mcp", label: "MCP Servers", icon: "server" },
     { id: "apm", label: "APM", icon: "package" },
     { id: "consistency", label: "Consistency", icon: "shield" },
+    { id: "evals", label: "Evals", icon: "chart" },
+    { id: "traces", label: "Traces", icon: "activity" },
   ];
 
   const renderNavIcon = (icon: string) => {
@@ -405,6 +409,8 @@ export function SkillsAdminPanel({ onClose, useCase = "generic", useCases = [], 
       case "server": return <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M5.25 14.25h13.5m-13.5 0a3 3 0 01-3-3m3 3a3 3 0 100 6h13.5a3 3 0 100-6m-16.5-3a3 3 0 013-3h13.5a3 3 0 013 3m-19.5 0a4.5 4.5 0 01.9-2.7L5.737 5.1a3.375 3.375 0 012.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 01.9 2.7m0 0a3 3 0 01-3 3m0 3h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008zm-3 6h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008z" /></svg>;
       case "shield": return <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" /></svg>;
       case "package": return <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" /></svg>;
+      case "chart": return <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" /></svg>;
+      case "activity": return <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 12h2.25l2.25-6 3 12 3-9 2.25 3h3.75" /></svg>;
       default: return null;
     }
   };
@@ -574,10 +580,10 @@ export function SkillsAdminPanel({ onClose, useCase = "generic", useCases = [], 
             </button>
             <div className="flex-1 min-w-0">
               <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
-                {tab === "skills" ? (showCreate ? "Create Skill" : "Skills") : tab === "prompt" ? "System Prompt" : tab === "consistency" ? "Consistency Analysis" : tab === "apm" ? "APM Packages" : (editingMcp ? `Edit: ${editingMcp.name}` : showMcpCreate ? "Add MCP Server" : "MCP Servers")}
+                {tab === "skills" ? (showCreate ? "Create Skill" : "Skills") : tab === "prompt" ? "System Prompt" : tab === "consistency" ? "Consistency Analysis" : tab === "apm" ? "APM Packages" : tab === "evals" ? "Evaluations" : tab === "traces" ? "Traces" : (editingMcp ? `Edit: ${editingMcp.name}` : showMcpCreate ? "Add MCP Server" : "MCP Servers")}
               </h2>
               <p className="text-xs text-slate-500 mt-0.5">
-                {tab === "skills" ? `${skills.filter(s => s.enabled).length} of ${skills.length} active` : tab === "prompt" ? "Configure the system prompt for all conversations" : tab === "consistency" ? "Detect contradictions, overlaps, and gaps in your agent configuration" : tab === "apm" ? "Manage Agent Package Manager dependencies for this use-case" : `${Object.keys(mcpServers).length} server${Object.keys(mcpServers).length !== 1 ? "s" : ""} configured`}
+                {tab === "skills" ? `${skills.filter(s => s.enabled).length} of ${skills.length} active` : tab === "prompt" ? "Configure the system prompt for all conversations" : tab === "consistency" ? "Detect contradictions, overlaps, and gaps in your agent configuration" : tab === "apm" ? "Manage Agent Package Manager dependencies for this use-case" : tab === "evals" ? "Validate agent behavior with automated eval scenarios" : tab === "traces" ? "App Insights waterfall view for recent operations" : `${Object.keys(mcpServers).length} server${Object.keys(mcpServers).length !== 1 ? "s" : ""} configured`}
               </p>
             </div>
             {/* Action buttons */}
@@ -866,6 +872,12 @@ export function SkillsAdminPanel({ onClose, useCase = "generic", useCases = [], 
             <div className="max-w-4xl">
               <ApmAdminPanel useCase={useCase} onMcpChange={loadMCPConfig} />
             </div>
+          ) : tab === "evals" ? (
+            /* ── Evals tab ── */
+            <EvalsAdminPanel useCase={useCase} />
+          ) : tab === "traces" ? (
+            /* ── Traces tab ── */
+            <TracesAdminPanel useCase={useCase} />
           ) : tab === "consistency" ? (
             /* ── Consistency Analysis tab ── */
             <div className="max-w-4xl space-y-6">

--- a/src/frontend/src/components/TracesAdminPanel.tsx
+++ b/src/frontend/src/components/TracesAdminPanel.tsx
@@ -1,0 +1,432 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { listTraceOperations, getTraceOperation } from "@/lib/api";
+import type { SpanCategory, TraceList, TraceOperation, TraceSpan } from "@/types";
+
+interface Props {
+  useCase: string;
+}
+
+const spanCategoryColors: Record<SpanCategory, string> = {
+  llm: "bg-blue-500",
+  agent: "bg-indigo-500",
+  agent_internal: "bg-indigo-400",
+  tool: "bg-emerald-500",
+  skill: "bg-teal-500",
+  http: "bg-amber-500",
+  platform: "bg-violet-500",
+  error: "bg-red-500",
+  other: "bg-slate-400",
+};
+
+const spanCategoryTextColors: Record<SpanCategory, string> = {
+  llm: "text-blue-600 dark:text-blue-400",
+  agent: "text-indigo-600 dark:text-indigo-400",
+  agent_internal: "text-indigo-500 dark:text-indigo-400",
+  tool: "text-emerald-600 dark:text-emerald-400",
+  skill: "text-teal-600 dark:text-teal-400",
+  http: "text-amber-600 dark:text-amber-400",
+  platform: "text-violet-600 dark:text-violet-400",
+  error: "text-red-600 dark:text-red-400",
+  other: "text-slate-500 dark:text-slate-400",
+};
+
+function SpanIcon({ category }: { category: SpanCategory }) {
+  const cls = `w-3.5 h-3.5 flex-shrink-0 ${spanCategoryTextColors[category] ?? "text-slate-400"}`;
+  switch (category) {
+    case "llm":
+      return (
+        <svg className={cls} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M8.625 9.75a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375m-13.5 3.01c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.184-4.183a1.14 1.14 0 01.778-.332 48.294 48.294 0 005.83-.498c1.585-.233 2.708-1.626 2.708-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
+        </svg>
+      );
+    case "tool":
+    case "skill":
+      return (
+        <svg className={cls} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z" />
+        </svg>
+      );
+    case "agent":
+    case "agent_internal":
+      return (
+        <svg className={cls} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
+        </svg>
+      );
+    case "http":
+      return (
+        <svg className={cls} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418" />
+        </svg>
+      );
+    case "error":
+      return (
+        <svg className={cls} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+        </svg>
+      );
+    default:
+      return (
+        <svg className={cls} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 9h16.5m-16.5 6.75h16.5" />
+        </svg>
+      );
+  }
+}
+
+function SpanRow({ span, maxEndMs }: { span: TraceSpan; maxEndMs: number }) {
+  const [expanded, setExpanded] = useState(false);
+  const indent = span.depth * 16;
+  const left = maxEndMs > 0 ? (span.offset_ms / maxEndMs) * 100 : 0;
+  const width = maxEndMs > 0 ? Math.max((span.duration_ms / maxEndMs) * 100, 0.5) : 0.5;
+  const barColor = spanCategoryColors[span.category] ?? "bg-slate-400";
+  const attrEntries = Object.entries(span.attributes ?? {});
+
+  return (
+    <div>
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-center gap-2 px-4 py-2 hover:bg-slate-50/50 dark:hover:bg-white/[0.02] transition-colors text-left group"
+      >
+        {/* Depth indent */}
+        <div style={{ width: indent, flexShrink: 0 }} />
+        <SpanIcon category={span.category} />
+        <span className="text-xs text-slate-700 dark:text-slate-300 truncate flex-shrink-0" style={{ maxWidth: "200px" }}>
+          {span.name}
+        </span>
+        {/* Waterfall bar */}
+        <div className="flex-1 relative h-4 bg-slate-100 dark:bg-white/[0.04] rounded overflow-hidden mx-2">
+          <div
+            className={`absolute top-0 h-full ${barColor} rounded opacity-80`}
+            style={{ left: `${left}%`, width: `${width}%` }}
+          />
+        </div>
+        <span className="text-xs text-slate-400 font-mono flex-shrink-0 w-16 text-right">
+          {span.duration_ms}ms
+        </span>
+        {!span.success && (
+          <span className="text-[10px] text-red-500 flex-shrink-0">✗</span>
+        )}
+      </button>
+      {expanded && attrEntries.length > 0 && (
+        <div className="mx-4 mb-2 rounded-xl bg-slate-50 dark:bg-white/[0.03] border border-slate-100 dark:border-white/[0.04] px-4 py-3 grid grid-cols-2 gap-x-6 gap-y-1.5" style={{ marginLeft: indent + 32 }}>
+          {attrEntries.map(([k, v]) => (
+            <div key={k} className="flex items-start gap-2">
+              <span className="text-[10px] font-mono text-slate-400 flex-shrink-0 pt-0.5 truncate max-w-[120px]">{k}</span>
+              <span className="text-[10px] text-slate-600 dark:text-slate-400 break-all">{String(v)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OperationRow({ op, lookbackHours }: { op: TraceOperation; lookbackHours: number }) {
+  const [expanded, setExpanded] = useState(false);
+  const [detail, setDetail] = useState<TraceOperation | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleExpand = async () => {
+    const next = !expanded;
+    setExpanded(next);
+    if (next && !detail) {
+      setLoading(true);
+      try {
+        const d = await getTraceOperation(op.operation_id, lookbackHours);
+        setDetail(d);
+      } catch {
+        setDetail(op);
+      } finally {
+        setLoading(false);
+      }
+    }
+  };
+
+  const opData = detail ?? op;
+  const spans: TraceSpan[] = opData.spans ?? [];
+  const maxEndMs = spans.reduce((m, s) => Math.max(m, s.offset_ms + s.duration_ms), 0);
+
+  const now = Date.now();
+  const opDate = new Date(op.timestamp);
+  const diffMs = now - opDate.getTime();
+  const relativeTime =
+    diffMs < 60000
+      ? `${Math.round(diffMs / 1000)}s ago`
+      : diffMs < 3600000
+      ? `${Math.round(diffMs / 60000)}m ago`
+      : diffMs < 86400000
+      ? `${Math.round(diffMs / 3600000)}h ago`
+      : opDate.toLocaleDateString();
+
+  return (
+    <div className="border-b border-slate-100 dark:border-white/[0.04] last:border-b-0">
+      <button
+        onClick={handleExpand}
+        className="w-full flex items-center gap-4 px-5 py-3.5 hover:bg-slate-50/50 dark:hover:bg-white/[0.02] transition-colors text-left"
+      >
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-mono text-slate-600 dark:text-slate-400 truncate">
+              {op.operation_id.slice(0, 16)}…
+            </span>
+            {op.eval_run_id && (
+              <span className="text-[10px] px-1.5 py-0.5 bg-primary-50 dark:bg-primary-500/10 text-primary-600 dark:text-primary-400 rounded font-mono flex-shrink-0">
+                eval
+              </span>
+            )}
+          </div>
+          <p className="text-[11px] text-slate-400 mt-0.5">{relativeTime}</p>
+        </div>
+        <div className="flex items-center gap-4 text-xs text-slate-500 flex-shrink-0">
+          <span className="font-mono">{op.total_duration_ms}ms</span>
+          <span className="text-slate-400">{op.span_count} spans</span>
+        </div>
+        <svg
+          className={`w-4 h-4 text-slate-400 transition-transform flex-shrink-0 ${expanded ? "rotate-180" : ""}`}
+          fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-slate-100 dark:border-white/[0.04] bg-slate-50/30 dark:bg-white/[0.01]">
+          {loading ? (
+            <div className="flex items-center justify-center py-8">
+              <div className="animate-spin rounded-full h-6 w-6 border-2 border-primary-200 border-t-primary-600" />
+            </div>
+          ) : (
+            <>
+              {/* Spans waterfall */}
+              {spans.length > 0 ? (
+                <div className="py-2">
+                  {spans.map((span) => (
+                    <SpanRow key={span.id} span={span} maxEndMs={maxEndMs} />
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-slate-400 text-center py-6">No span data available</p>
+              )}
+
+              {/* Logs */}
+              {opData.logs && opData.logs.length > 0 && (
+                <div className="px-5 pb-4 space-y-2 border-t border-slate-100 dark:border-white/[0.04] pt-4">
+                  <h5 className="text-[10px] font-semibold text-slate-500 uppercase tracking-wider mb-2">Logs</h5>
+                  {[...opData.logs]
+                    .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+                    .map((log, i) => (
+                      <div key={i} className="flex items-start gap-2">
+                        <span className={`text-[10px] font-mono flex-shrink-0 pt-0.5 ${
+                          log.severity >= 400 ? "text-red-500" : log.severity >= 300 ? "text-amber-500" : "text-slate-400"
+                        }`}>
+                          {new Date(log.timestamp).toLocaleTimeString()}
+                        </span>
+                        <span className="text-xs text-slate-600 dark:text-slate-400 break-words">{log.message}</span>
+                      </div>
+                    ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function TracesAdminPanel({ useCase }: Props): JSX.Element {
+  const [conversationId, setConversationId] = useState("");
+  const [evalRunId, setEvalRunId] = useState("");
+  const [lookbackHours, setLookbackHours] = useState(24);
+  const [traceData, setTraceData] = useState<TraceList | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleRefresh = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const data = await listTraceOperations({
+        useCase,
+        conversationId: conversationId || undefined,
+        evalRunId: evalRunId || undefined,
+        lookbackHours,
+      });
+      setTraceData(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load traces");
+    } finally {
+      setLoading(false);
+    }
+  }, [useCase, conversationId, evalRunId, lookbackHours]);
+
+  useEffect(() => {
+    handleRefresh();
+  }, [handleRefresh]);
+
+  const summary = traceData?.summary;
+  const operations = traceData?.operations ?? [];
+
+  return (
+    <div className="max-w-4xl space-y-6">
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-end gap-3">
+        <div>
+          <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Conversation ID</label>
+          <input
+            type="text"
+            value={conversationId}
+            onChange={(e) => setConversationId(e.target.value)}
+            placeholder="Filter by conversation…"
+            className="w-48 px-3 py-2 bg-white dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-xl text-sm text-slate-700 dark:text-slate-300 focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-400 transition-all placeholder:text-slate-400"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Eval Run ID</label>
+          <input
+            type="text"
+            value={evalRunId}
+            onChange={(e) => setEvalRunId(e.target.value)}
+            placeholder="Filter by eval run…"
+            className="w-48 px-3 py-2 bg-white dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-xl text-sm text-slate-700 dark:text-slate-300 focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-400 transition-all placeholder:text-slate-400"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Lookback (hours)</label>
+          <input
+            type="number"
+            min={1}
+            max={720}
+            value={lookbackHours}
+            onChange={(e) => setLookbackHours(Math.max(1, parseInt(e.target.value, 10) || 24))}
+            className="w-24 px-3 py-2 bg-white dark:bg-white/[0.04] border border-slate-200 dark:border-white/[0.08] rounded-xl text-sm text-slate-700 dark:text-slate-300 focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-400 transition-all"
+          />
+        </div>
+        <button
+          onClick={handleRefresh}
+          disabled={loading}
+          className="flex items-center gap-2 px-4 py-2 text-sm text-white bg-gradient-to-r from-primary-600 to-primary-500 rounded-xl hover:from-primary-700 hover:to-primary-600 transition-all shadow-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {loading ? (
+            <div className="animate-spin rounded-full h-4 w-4 border-2 border-white/30 border-t-white" />
+          ) : (
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182" />
+            </svg>
+          )}
+          Refresh
+        </button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="px-4 py-3 bg-red-50 dark:bg-red-500/10 text-red-600 dark:text-red-400 text-sm rounded-xl border border-red-100 dark:border-red-500/20 flex items-center justify-between">
+          <span>{error}</span>
+          <button onClick={() => setError("")} className="text-red-400 hover:text-red-600 transition-colors ml-3">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+          </button>
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && !traceData && (
+        <div className="flex items-center justify-center py-16">
+          <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary-200 border-t-primary-600" />
+        </div>
+      )}
+
+      {/* Summary card */}
+      {summary && !summary.error && (
+        <div className="bg-white dark:bg-white/[0.03] border border-slate-200 dark:border-white/[0.08] rounded-2xl p-5">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <div className="text-center">
+              <p className="text-2xl font-bold text-slate-900 dark:text-white">{summary.total_operations}</p>
+              <p className="text-xs text-slate-500 mt-0.5">Operations</p>
+            </div>
+            <div className="text-center">
+              <p className="text-2xl font-bold text-slate-900 dark:text-white">
+                {summary.avg_latency_ms > 0 ? `${Math.round(summary.avg_latency_ms)}ms` : "—"}
+              </p>
+              <p className="text-xs text-slate-500 mt-0.5">Avg Latency</p>
+            </div>
+            <div className="text-center">
+              <p className="text-2xl font-bold text-slate-900 dark:text-white">
+                {summary.total_tokens > 0 ? summary.total_tokens.toLocaleString() : "—"}
+              </p>
+              <p className="text-xs text-slate-500 mt-0.5">Total Tokens</p>
+            </div>
+            <div className="text-center">
+              <div className="flex flex-wrap items-center justify-center gap-1.5 min-h-[2rem]">
+                {summary.models_used.length > 0 ? (
+                  summary.models_used.map((m) => (
+                    <span key={m} className="text-[10px] px-2 py-0.5 bg-slate-100 dark:bg-white/[0.06] text-slate-600 dark:text-slate-400 rounded-full font-mono">
+                      {m}
+                    </span>
+                  ))
+                ) : (
+                  <span className="text-xs text-slate-400">—</span>
+                )}
+              </div>
+              <p className="text-xs text-slate-500 mt-0.5">Models</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Summary error */}
+      {summary?.error && (
+        <div className="px-4 py-3 bg-amber-50 dark:bg-amber-500/10 text-amber-700 dark:text-amber-400 text-sm rounded-xl border border-amber-100 dark:border-amber-500/20">
+          <p className="font-medium mb-0.5">App Insights Notice</p>
+          <p className="text-xs">{summary.error}</p>
+        </div>
+      )}
+
+      {/* Operations list */}
+      {traceData && (
+        operations.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-slate-100 to-slate-50 dark:from-white/[0.06] dark:to-white/[0.02] flex items-center justify-center mb-4">
+              <svg className="w-7 h-7 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" />
+              </svg>
+            </div>
+            <h4 className="text-sm font-semibold text-slate-600 dark:text-slate-300 mb-1">No traces found</h4>
+            <p className="text-xs text-slate-400 max-w-xs leading-relaxed">
+              {summary?.error
+                ? "App Insights is not configured or returned no data."
+                : `No operations found in the last ${lookbackHours}h for this use-case.`}
+            </p>
+          </div>
+        ) : (
+          <div className="bg-white dark:bg-white/[0.03] border border-slate-200 dark:border-white/[0.08] rounded-2xl overflow-hidden">
+            <div className="flex items-center justify-between px-5 py-4 border-b border-slate-100 dark:border-white/[0.06]">
+              <h3 className="text-sm font-semibold text-slate-800 dark:text-white">Operations</h3>
+              <span className="text-xs font-mono text-slate-400 bg-slate-100 dark:bg-white/[0.06] px-2 py-0.5 rounded-full">
+                {operations.length}
+              </span>
+            </div>
+
+            {/* Category legend */}
+            <div className="flex flex-wrap gap-3 px-5 py-3 border-b border-slate-100 dark:border-white/[0.04] bg-slate-50/30 dark:bg-white/[0.01]">
+              {(Object.entries(spanCategoryColors) as [SpanCategory, string][]).map(([cat, color]) => (
+                <div key={cat} className="flex items-center gap-1.5">
+                  <div className={`w-2.5 h-2.5 rounded-sm ${color}`} />
+                  <span className="text-[10px] text-slate-500 dark:text-slate-400">{cat}</span>
+                </div>
+              ))}
+            </div>
+
+            <div>
+              {operations.map((op) => (
+                <OperationRow key={op.operation_id} op={op} lookbackHours={lookbackHours} />
+              ))}
+            </div>
+          </div>
+        )
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/TracesAdminPanel.tsx
+++ b/src/frontend/src/components/TracesAdminPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { listTraceOperations, getTraceOperation } from "@/lib/api";
 import type { SpanCategory, TraceList, TraceOperation, TraceSpan } from "@/types";
 
@@ -32,48 +32,59 @@ const spanCategoryTextColors: Record<SpanCategory, string> = {
   other: "text-slate-500 dark:text-slate-400",
 };
 
+const spanCategoryEmoji: Record<SpanCategory, string> = {
+  llm: "🧠",
+  agent: "✨",
+  agent_internal: "✨",
+  tool: "🔧",
+  skill: "📋",
+  http: "🌐",
+  platform: "⚙️",
+  error: "⚠️",
+  other: "•",
+};
+
+// Attributes we surface in a labeled grid (in order). Anything not in this list
+// falls into the "Other" raw-attribute section.
+const SPAN_HIGHLIGHT_KEYS: Array<{ key: string; label: string }> = [
+  { key: "gen_ai.response.model", label: "Model" },
+  { key: "gen_ai.operation.name", label: "Operation" },
+  { key: "gen_ai.usage.input_tokens", label: "Input tokens" },
+  { key: "gen_ai.usage.output_tokens", label: "Output tokens" },
+  { key: "gen_ai.tool.name", label: "Tool" },
+  { key: "gen_ai.tool.kind", label: "Tool kind" },
+  { key: "kratos.skill.name", label: "Skill" },
+  { key: "kratos.use_case", label: "Use case" },
+  { key: "kratos.conversation_id", label: "Conversation" },
+  { key: "kratos.eval_run_id", label: "Eval run" },
+  { key: "error.type", label: "Error" },
+];
+
+function _attr(span: TraceSpan, key: string): string {
+  const v = span.attributes?.[key];
+  if (v === undefined || v === null || v === "") return "";
+  return String(v);
+}
+
+function _attrNum(span: TraceSpan, key: string): number {
+  const v = span.attributes?.[key];
+  if (typeof v === "number") return v;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function _fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
 function SpanIcon({ category }: { category: SpanCategory }) {
-  const cls = `w-3.5 h-3.5 flex-shrink-0 ${spanCategoryTextColors[category] ?? "text-slate-400"}`;
-  switch (category) {
-    case "llm":
-      return (
-        <svg className={cls} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M8.625 9.75a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375m-13.5 3.01c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.184-4.183a1.14 1.14 0 01.778-.332 48.294 48.294 0 005.83-.498c1.585-.233 2.708-1.626 2.708-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
-        </svg>
-      );
-    case "tool":
-    case "skill":
-      return (
-        <svg className={cls} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z" />
-        </svg>
-      );
-    case "agent":
-    case "agent_internal":
-      return (
-        <svg className={cls} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
-        </svg>
-      );
-    case "http":
-      return (
-        <svg className={cls} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 013 12c0-1.605.42-3.113 1.157-4.418" />
-        </svg>
-      );
-    case "error":
-      return (
-        <svg className={cls} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
-        </svg>
-      );
-    default:
-      return (
-        <svg className={cls} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 9h16.5m-16.5 6.75h16.5" />
-        </svg>
-      );
-  }
+  return (
+    <span className={`text-sm flex-shrink-0 ${spanCategoryTextColors[category] ?? "text-slate-400"}`} aria-hidden>
+      {spanCategoryEmoji[category] ?? "•"}
+    </span>
+  );
 }
 
 function SpanRow({ span, maxEndMs }: { span: TraceSpan; maxEndMs: number }) {
@@ -82,7 +93,16 @@ function SpanRow({ span, maxEndMs }: { span: TraceSpan; maxEndMs: number }) {
   const left = maxEndMs > 0 ? (span.offset_ms / maxEndMs) * 100 : 0;
   const width = maxEndMs > 0 ? Math.max((span.duration_ms / maxEndMs) * 100, 0.5) : 0.5;
   const barColor = spanCategoryColors[span.category] ?? "bg-slate-400";
-  const attrEntries = Object.entries(span.attributes ?? {});
+
+  const model = _attr(span, "gen_ai.response.model");
+  const toolName = _attr(span, "gen_ai.tool.name") || _attr(span, "kratos.skill.name");
+  const inTok = _attrNum(span, "gen_ai.usage.input_tokens");
+  const outTok = _attrNum(span, "gen_ai.usage.output_tokens");
+  const errType = _attr(span, "error.type");
+
+  const highlights = SPAN_HIGHLIGHT_KEYS.filter((h) => _attr(span, h.key) !== "");
+  const highlightKeySet = new Set(highlights.map((h) => h.key));
+  const otherAttrs = Object.entries(span.attributes ?? {}).filter(([k]) => !highlightKeySet.has(k));
 
   return (
     <div>
@@ -90,14 +110,34 @@ function SpanRow({ span, maxEndMs }: { span: TraceSpan; maxEndMs: number }) {
         onClick={() => setExpanded((v) => !v)}
         className="w-full flex items-center gap-2 px-4 py-2 hover:bg-slate-50/50 dark:hover:bg-white/[0.02] transition-colors text-left group"
       >
-        {/* Depth indent */}
         <div style={{ width: indent, flexShrink: 0 }} />
         <SpanIcon category={span.category} />
-        <span className="text-xs text-slate-700 dark:text-slate-300 truncate flex-shrink-0" style={{ maxWidth: "200px" }}>
+        <span className="text-xs text-slate-700 dark:text-slate-300 truncate flex-shrink-0 font-medium" style={{ maxWidth: "200px" }}>
           {span.name}
         </span>
+        {/* Inline gen_ai chips */}
+        {toolName && (
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-50 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 font-mono flex-shrink-0 border border-emerald-200/60 dark:border-emerald-500/20">
+            {toolName}
+          </span>
+        )}
+        {model && (
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-50 dark:bg-blue-500/10 text-blue-700 dark:text-blue-400 font-mono flex-shrink-0 border border-blue-200/60 dark:border-blue-500/20">
+            {model}
+          </span>
+        )}
+        {(inTok > 0 || outTok > 0) && (
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-slate-100 dark:bg-white/[0.06] text-slate-600 dark:text-slate-400 font-mono flex-shrink-0">
+            {_fmtTokens(inTok)} → {_fmtTokens(outTok)} tok
+          </span>
+        )}
+        {errType && (
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-red-50 dark:bg-red-500/10 text-red-600 dark:text-red-400 font-mono flex-shrink-0 border border-red-200/60 dark:border-red-500/20">
+            {errType}
+          </span>
+        )}
         {/* Waterfall bar */}
-        <div className="flex-1 relative h-4 bg-slate-100 dark:bg-white/[0.04] rounded overflow-hidden mx-2">
+        <div className="flex-1 relative h-4 bg-slate-100 dark:bg-white/[0.04] rounded overflow-hidden mx-2 min-w-[40px]">
           <div
             className={`absolute top-0 h-full ${barColor} rounded opacity-80`}
             style={{ left: `${left}%`, width: `${width}%` }}
@@ -110,24 +150,83 @@ function SpanRow({ span, maxEndMs }: { span: TraceSpan; maxEndMs: number }) {
           <span className="text-[10px] text-red-500 flex-shrink-0">✗</span>
         )}
       </button>
-      {expanded && attrEntries.length > 0 && (
-        <div className="mx-4 mb-2 rounded-xl bg-slate-50 dark:bg-white/[0.03] border border-slate-100 dark:border-white/[0.04] px-4 py-3 grid grid-cols-2 gap-x-6 gap-y-1.5" style={{ marginLeft: indent + 32 }}>
-          {attrEntries.map(([k, v]) => (
-            <div key={k} className="flex items-start gap-2">
-              <span className="text-[10px] font-mono text-slate-400 flex-shrink-0 pt-0.5 truncate max-w-[120px]">{k}</span>
-              <span className="text-[10px] text-slate-600 dark:text-slate-400 break-all">{String(v)}</span>
+      {expanded && (
+        <div className="mx-4 mb-2 rounded-xl bg-slate-50 dark:bg-white/[0.03] border border-slate-100 dark:border-white/[0.04] px-4 py-3 space-y-3" style={{ marginLeft: indent + 32 }}>
+          {highlights.length > 0 && (
+            <div>
+              <p className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider mb-2">Span Details</p>
+              <div className="grid grid-cols-2 gap-x-6 gap-y-1.5">
+                {highlights.map((h) => (
+                  <div key={h.key} className="flex items-start gap-2">
+                    <span className="text-[10px] font-medium text-slate-500 dark:text-slate-400 flex-shrink-0 pt-0.5 w-28 truncate">{h.label}</span>
+                    <span className="text-[11px] text-slate-700 dark:text-slate-300 font-mono break-all">{_attr(span, h.key)}</span>
+                  </div>
+                ))}
+              </div>
             </div>
-          ))}
+          )}
+          {otherAttrs.length > 0 && (
+            <div>
+              <p className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider mb-2">Other Attributes</p>
+              <div className="grid grid-cols-2 gap-x-6 gap-y-1">
+                {otherAttrs.map(([k, v]) => (
+                  <div key={k} className="flex items-start gap-2">
+                    <span className="text-[10px] font-mono text-slate-400 flex-shrink-0 pt-0.5 truncate max-w-[120px]">{k}</span>
+                    <span className="text-[10px] text-slate-600 dark:text-slate-400 break-all">{String(v)}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          {highlights.length === 0 && otherAttrs.length === 0 && (
+            <p className="text-[11px] text-slate-400 italic">No attributes</p>
+          )}
         </div>
       )}
     </div>
   );
 }
 
+interface OperationStats {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  modelsTouched: string[];
+  toolCount: number;
+  errorCount: number;
+  categoryCounts: Partial<Record<SpanCategory, number>>;
+}
+
+function computeOperationStats(spans: TraceSpan[]): OperationStats {
+  let inTok = 0;
+  let outTok = 0;
+  const models = new Set<string>();
+  let toolCount = 0;
+  let errorCount = 0;
+  const cats: Partial<Record<SpanCategory, number>> = {};
+  for (const sp of spans) {
+    inTok += _attrNum(sp, "gen_ai.usage.input_tokens");
+    outTok += _attrNum(sp, "gen_ai.usage.output_tokens");
+    const m = _attr(sp, "gen_ai.response.model");
+    if (m) models.add(m);
+    if (sp.category === "tool" || sp.category === "skill") toolCount += 1;
+    if (!sp.success || _attr(sp, "error.type")) errorCount += 1;
+    cats[sp.category] = (cats[sp.category] ?? 0) + 1;
+  }
+  return {
+    totalInputTokens: inTok,
+    totalOutputTokens: outTok,
+    modelsTouched: [...models],
+    toolCount,
+    errorCount,
+    categoryCounts: cats,
+  };
+}
+
 function OperationRow({ op, lookbackHours }: { op: TraceOperation; lookbackHours: number }) {
   const [expanded, setExpanded] = useState(false);
   const [detail, setDetail] = useState<TraceOperation | null>(null);
   const [loading, setLoading] = useState(false);
+  const [activeFilter, setActiveFilter] = useState<SpanCategory | null>(null);
 
   const handleExpand = async () => {
     const next = !expanded;
@@ -146,8 +245,10 @@ function OperationRow({ op, lookbackHours }: { op: TraceOperation; lookbackHours
   };
 
   const opData = detail ?? op;
-  const spans: TraceSpan[] = opData.spans ?? [];
-  const maxEndMs = spans.reduce((m, s) => Math.max(m, s.offset_ms + s.duration_ms), 0);
+  const allSpans: TraceSpan[] = opData.spans ?? [];
+  const stats = useMemo(() => computeOperationStats(allSpans), [allSpans]);
+  const spans = activeFilter ? allSpans.filter((s) => s.category === activeFilter) : allSpans;
+  const maxEndMs = allSpans.reduce((m, s) => Math.max(m, s.offset_ms + s.duration_ms), 0);
 
   const now = Date.now();
   const opDate = new Date(op.timestamp);
@@ -200,6 +301,75 @@ function OperationRow({ op, lookbackHours }: { op: TraceOperation; lookbackHours
             </div>
           ) : (
             <>
+              {/* Per-operation summary header */}
+              {allSpans.length > 0 && (
+                <div className="px-5 py-3 border-b border-slate-100 dark:border-white/[0.04] space-y-3">
+                  <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs">
+                    {(stats.totalInputTokens > 0 || stats.totalOutputTokens > 0) && (
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-slate-400">Tokens</span>
+                        <span className="font-mono text-slate-700 dark:text-slate-200 font-medium">
+                          {_fmtTokens(stats.totalInputTokens)} → {_fmtTokens(stats.totalOutputTokens)}
+                        </span>
+                      </div>
+                    )}
+                    {stats.modelsTouched.length > 0 && (
+                      <div className="flex items-center gap-1.5 flex-wrap">
+                        <span className="text-slate-400">Models</span>
+                        {stats.modelsTouched.map((m) => (
+                          <span key={m} className="text-[10px] px-1.5 py-0.5 rounded bg-blue-50 dark:bg-blue-500/10 text-blue-700 dark:text-blue-400 font-mono border border-blue-200/60 dark:border-blue-500/20">
+                            {m}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                    {stats.toolCount > 0 && (
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-slate-400">🔧 Tools</span>
+                        <span className="font-mono text-emerald-700 dark:text-emerald-400 font-medium">{stats.toolCount}</span>
+                      </div>
+                    )}
+                    {stats.errorCount > 0 && (
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-slate-400">Errors</span>
+                        <span className="font-mono text-red-600 dark:text-red-400 font-medium">{stats.errorCount}</span>
+                      </div>
+                    )}
+                  </div>
+                  {/* Category filter chips */}
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    <button
+                      onClick={() => setActiveFilter(null)}
+                      className={`text-[10px] px-2 py-1 rounded-full font-medium transition-colors border ${
+                        activeFilter === null
+                          ? "bg-primary-50 dark:bg-primary-500/15 text-primary-700 dark:text-primary-300 border-primary-200 dark:border-primary-500/30"
+                          : "bg-white dark:bg-white/[0.04] text-slate-500 dark:text-slate-400 border-slate-200 dark:border-white/[0.08] hover:border-slate-300"
+                      }`}
+                    >
+                      all · {allSpans.length}
+                    </button>
+                    {(Object.entries(stats.categoryCounts) as [SpanCategory, number][])
+                      .sort((a, b) => b[1] - a[1])
+                      .map(([cat, cnt]) => (
+                        <button
+                          key={cat}
+                          onClick={() => setActiveFilter((cur) => (cur === cat ? null : cat))}
+                          className={`text-[10px] px-2 py-1 rounded-full font-medium transition-colors flex items-center gap-1 border ${
+                            activeFilter === cat
+                              ? "bg-primary-50 dark:bg-primary-500/15 text-primary-700 dark:text-primary-300 border-primary-200 dark:border-primary-500/30"
+                              : "bg-white dark:bg-white/[0.04] text-slate-500 dark:text-slate-400 border-slate-200 dark:border-white/[0.08] hover:border-slate-300"
+                          }`}
+                        >
+                          <span>{spanCategoryEmoji[cat]}</span>
+                          <span>{cat}</span>
+                          <span className="font-mono text-slate-400">·</span>
+                          <span className="font-mono">{cnt}</span>
+                        </button>
+                      ))}
+                  </div>
+                </div>
+              )}
+
               {/* Spans waterfall */}
               {spans.length > 0 ? (
                 <div className="py-2">
@@ -207,6 +377,8 @@ function OperationRow({ op, lookbackHours }: { op: TraceOperation; lookbackHours
                     <SpanRow key={span.id} span={span} maxEndMs={maxEndMs} />
                   ))}
                 </div>
+              ) : allSpans.length > 0 ? (
+                <p className="text-xs text-slate-400 text-center py-6">No spans match the active filter</p>
               ) : (
                 <p className="text-xs text-slate-400 text-center py-6">No span data available</p>
               )}

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -1,5 +1,12 @@
 import { getApiUrl } from "@/lib/config";
-import type { Attachment } from "@/types";
+import type {
+  Attachment,
+  EvalScenario,
+  EvalRun,
+  EvalMode,
+  TraceList,
+  TraceOperation,
+} from "@/types";
 
 /**
  * Send a message to the agent and receive streaming SSE events.
@@ -522,4 +529,122 @@ export async function applyAnalysisFix(
     throw new Error(err.detail || `Apply fix failed: ${response.status}`);
   }
   return response.json();
+}
+
+// ─── Evals ─────────────────────────────────────────────────────────────────
+
+async function readJson<T>(response: Response, errPrefix: string): Promise<T> {
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`${errPrefix} (${response.status})${body ? `: ${body}` : ""}`);
+  }
+  return response.json();
+}
+
+export async function listEvalScenarios(useCase: string): Promise<EvalScenario[]> {
+  const r = await fetch(
+    `${getApiUrl()}/api/use-cases/${encodeURIComponent(useCase)}/evals/scenarios`,
+  );
+  const data = await readJson<{ scenarios: EvalScenario[] }>(r, "List scenarios failed");
+  return data.scenarios ?? [];
+}
+
+export async function generateEvalScenarios(
+  useCase: string,
+  body: { count?: number; persist?: boolean; instructions?: string } = {},
+): Promise<{ scenarios: EvalScenario[]; persisted: boolean }> {
+  const r = await fetch(
+    `${getApiUrl()}/api/use-cases/${encodeURIComponent(useCase)}/evals/scenarios/generate`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ count: 10, persist: false, instructions: "", ...body }),
+    },
+  );
+  return readJson(r, "Generate scenarios failed");
+}
+
+export async function upsertEvalScenario(
+  useCase: string,
+  scenario: EvalScenario,
+): Promise<EvalScenario> {
+  const r = await fetch(
+    `${getApiUrl()}/api/use-cases/${encodeURIComponent(useCase)}/evals/scenarios/${encodeURIComponent(scenario.name)}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(scenario),
+    },
+  );
+  return readJson(r, "Save scenario failed");
+}
+
+export async function deleteEvalScenario(useCase: string, name: string): Promise<void> {
+  const r = await fetch(
+    `${getApiUrl()}/api/use-cases/${encodeURIComponent(useCase)}/evals/scenarios/${encodeURIComponent(name)}`,
+    { method: "DELETE" },
+  );
+  if (!r.ok && r.status !== 404) {
+    throw new Error(`Delete scenario failed: ${r.status}`);
+  }
+}
+
+export async function startEvalRun(
+  useCase: string,
+  body: { mode: EvalMode; scenarios?: string[] },
+): Promise<EvalRun> {
+  const r = await fetch(
+    `${getApiUrl()}/api/use-cases/${encodeURIComponent(useCase)}/evals/run`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+  return readJson(r, "Start eval run failed");
+}
+
+export async function listEvalRuns(useCase: string): Promise<EvalRun[]> {
+  const r = await fetch(
+    `${getApiUrl()}/api/use-cases/${encodeURIComponent(useCase)}/evals/runs`,
+  );
+  const data = await readJson<{ runs: EvalRun[] }>(r, "List runs failed");
+  return data.runs ?? [];
+}
+
+export async function getEvalRun(useCase: string, runId: string): Promise<EvalRun> {
+  const r = await fetch(
+    `${getApiUrl()}/api/use-cases/${encodeURIComponent(useCase)}/evals/runs/${encodeURIComponent(runId)}`,
+  );
+  return readJson(r, "Get run failed");
+}
+
+// ─── Traces ────────────────────────────────────────────────────────────────
+
+export async function listTraceOperations(filters: {
+  useCase?: string;
+  conversationId?: string;
+  evalRunId?: string;
+  lookbackHours?: number;
+  maxOperations?: number;
+}): Promise<TraceList> {
+  const params = new URLSearchParams();
+  if (filters.useCase) params.set("use_case", filters.useCase);
+  if (filters.conversationId) params.set("conversation_id", filters.conversationId);
+  if (filters.evalRunId) params.set("eval_run_id", filters.evalRunId);
+  if (filters.lookbackHours) params.set("hours", String(filters.lookbackHours));
+  if (filters.maxOperations) params.set("limit", String(filters.maxOperations));
+  const qs = params.toString();
+  const r = await fetch(`${getApiUrl()}/api/traces/operations${qs ? `?${qs}` : ""}`);
+  return readJson(r, "List trace operations failed");
+}
+
+export async function getTraceOperation(
+  operationId: string,
+  lookbackHours = 168,
+): Promise<TraceOperation> {
+  const r = await fetch(
+    `${getApiUrl()}/api/traces/operations/${encodeURIComponent(operationId)}?hours=${lookbackHours}`,
+  );
+  return readJson(r, "Get trace operation failed");
 }

--- a/src/frontend/src/types/index.ts
+++ b/src/frontend/src/types/index.ts
@@ -280,3 +280,129 @@ export interface ApmCommandResponse {
   duration_ms: number;
   dependencies: ApmDependency[];
 }
+
+// ─── Evals ───
+
+export type ScenarioCategory =
+  | "standard"
+  | "edge_case"
+  | "error_handling"
+  | "boundary"
+  | "compliance";
+
+export interface EvalScenario {
+  name: string;
+  category: ScenarioCategory;
+  description: string;
+  input_message: string;
+  input_data: Record<string, unknown>;
+  expected_behavior: string;
+  expected_tool_calls: string[];
+  evaluators: string[];
+}
+
+export type EvalMode = "validation" | "foundry";
+
+export type EvalRunStatus =
+  | "pending"
+  | "invoking"
+  | "scoring"
+  | "completed"
+  | "failed";
+
+export interface ScenarioResult {
+  scenario: string;
+  query: string;
+  response: string;
+  tool_calls: Array<{ name: string; arguments?: Record<string, unknown>; result?: string }>;
+  status: string;
+  error: string;
+  duration_ms: number;
+  scores: Record<string, Record<string, unknown>>;
+}
+
+export interface FoundryEvalSummary {
+  eval_id: string;
+  eval_run_id: string;
+  run_status: string;
+  result_counts: Record<string, number>;
+  per_testing_criteria_results: Array<Record<string, unknown>>;
+  output_items: Array<Record<string, unknown>>;
+  report_url: string;
+}
+
+export interface EvalRun {
+  run_id: string;
+  use_case: string;
+  mode: EvalMode;
+  status: EvalRunStatus;
+  scenarios: string[];
+  created_at: string;
+  updated_at: string;
+  started_by: string;
+  progress: string;
+  error: string;
+  results: ScenarioResult[];
+  foundry: FoundryEvalSummary | null;
+}
+
+// ─── Traces ───
+
+export type SpanCategory =
+  | "llm"
+  | "agent"
+  | "agent_internal"
+  | "tool"
+  | "skill"
+  | "http"
+  | "platform"
+  | "error"
+  | "other";
+
+export interface TraceSpan {
+  id: string;
+  parent_id: string;
+  name: string;
+  duration_ms: number;
+  offset_ms: number;
+  timestamp: string;
+  success: boolean;
+  result_code: string;
+  type: string;
+  cloud_role: string;
+  category: SpanCategory;
+  depth: number;
+  attributes: Record<string, string | number>;
+}
+
+export interface TraceLog {
+  timestamp: string;
+  message: string;
+  severity: number;
+  cloud_role: string;
+}
+
+export interface TraceOperation {
+  operation_id: string;
+  timestamp: string;
+  total_duration_ms: number;
+  span_count: number;
+  use_case: string;
+  conversation_id: string;
+  eval_run_id: string;
+  spans: TraceSpan[];
+  logs: TraceLog[];
+}
+
+export interface TraceSummary {
+  total_operations: number;
+  avg_latency_ms: number;
+  total_tokens: number;
+  models_used: string[];
+  error: string;
+}
+
+export interface TraceList {
+  operations: TraceOperation[];
+  summary: TraceSummary;
+}

--- a/src/frontend/src/types/index.ts
+++ b/src/frontend/src/types/index.ts
@@ -314,7 +314,18 @@ export interface ScenarioResult {
   scenario: string;
   query: string;
   response: string;
-  tool_calls: Array<{ name: string; arguments?: Record<string, unknown>; result?: string }>;
+  tool_calls: Array<{
+    type?: string;
+    skillName?: string;
+    name?: string;
+    status?: string;
+    input?: string | Record<string, unknown>;
+    output?: string;
+    arguments?: Record<string, unknown>;
+    result?: string;
+    durationMs?: number;
+    source?: string;
+  }>;
   status: string;
   error: string;
   duration_ms: number;

--- a/src/hosted-agent/agent.yaml
+++ b/src/hosted-agent/agent.yaml
@@ -39,3 +39,7 @@ environment_variables:
   # Environment tag
   - name: ENVIRONMENT
     value: production
+  # Force a new agent version per deploy (Foundry deduplicates create_version
+  # when env vars are identical — see foundry-hosted-agents skill).
+  - name: _BUILD_TS
+    value: ${KRATOS_BUILD_TS}

--- a/use-cases/generic/evals/.gitignore
+++ b/use-cases/generic/evals/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/use-cases/generic/evals/eval_config.json
+++ b/use-cases/generic/evals/eval_config.json
@@ -1,0 +1,13 @@
+{
+  "evaluation": {
+    "evaluators": [
+      "Relevance",
+      "Coherence",
+      "TaskAdherence",
+      "IntentResolution",
+      "ToolCallAccuracy"
+    ],
+    "judge_model_env": "EVAL_MODEL",
+    "judge_model_default": "gpt-4.1"
+  }
+}

--- a/use-cases/generic/evals/scenarios/code-interpreter-math.json
+++ b/use-cases/generic/evals/scenarios/code-interpreter-math.json
@@ -1,0 +1,15 @@
+{
+  "name": "code-interpreter-math",
+  "category": "standard",
+  "description": "Pure computation — agent must call code-interpreter and not do mental math.",
+  "input_message": "What's the compound interest on $10,000 invested at 6.5% annually for 12 years, compounded monthly?",
+  "input_data": {
+    "principal": 10000,
+    "rate": 0.065,
+    "years": 12,
+    "compounding": "monthly"
+  },
+  "expected_behavior": "Calls code-interpreter to compute A = P(1 + r/n)^(nt). Returns final value, total interest, and a brief explanation. Does not approximate mentally.",
+  "expected_tool_calls": ["code-interpreter"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/generic/evals/scenarios/data-analysis-with-charts.json
+++ b/use-cases/generic/evals/scenarios/data-analysis-with-charts.json
@@ -1,0 +1,10 @@
+{
+  "name": "data-analysis-with-charts",
+  "category": "standard",
+  "description": "Combine web-search + code-interpreter to analyse real data and produce a chart.",
+  "input_message": "Find and analyse recent data on global cloud spending trends this year and produce a chart.",
+  "input_data": {},
+  "expected_behavior": "Calls web-search to gather recent cloud-spending figures, then code-interpreter to chart them. Saves the chart to /tmp and references the path. Includes a short written summary of the trend.",
+  "expected_tool_calls": ["web-search", "code-interpreter"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/generic/evals/scenarios/draft-email.json
+++ b/use-cases/generic/evals/scenarios/draft-email.json
@@ -1,0 +1,15 @@
+{
+  "name": "draft-email",
+  "category": "standard",
+  "description": "Email drafting — agent should call email-draft.",
+  "input_message": "Draft a short email to my team announcing a 30-minute brown-bag next Friday on prompt-engineering best practices.",
+  "input_data": {
+    "recipient": "team",
+    "topic": "prompt-engineering brown-bag",
+    "duration_minutes": 30,
+    "day": "next Friday"
+  },
+  "expected_behavior": "Calls email-draft with subject, body, and clear call-to-action (RSVP, calendar link placeholder). Tone is collegial and concise. Does not invent a calendar URL.",
+  "expected_tool_calls": ["email-draft"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/generic/evals/scenarios/pptx-summary-deck.json
+++ b/use-cases/generic/evals/scenarios/pptx-summary-deck.json
@@ -1,0 +1,13 @@
+{
+  "name": "pptx-summary-deck",
+  "category": "standard",
+  "description": "Generate a short slide deck — agent should chain web-search → pptx-editor and save to /tmp.",
+  "input_message": "Build a 5-slide deck summarising the current state of multi-agent LLM frameworks (intro, top 3 frameworks, takeaway).",
+  "input_data": {
+    "slide_count": 5,
+    "topic": "multi-agent LLM frameworks"
+  },
+  "expected_behavior": "Calls web-search to gather current framework names + facts. Calls pptx-editor (or docx-editor as fallback) to produce a 5-slide deck. Saves to /tmp and references the path. Does not fabricate framework names.",
+  "expected_tool_calls": ["web-search", "pptx-editor"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/generic/evals/scenarios/web-search-ai-trends.json
+++ b/use-cases/generic/evals/scenarios/web-search-ai-trends.json
@@ -1,0 +1,10 @@
+{
+  "name": "web-search-ai-trends",
+  "category": "standard",
+  "description": "Open-ended web research — agent must call web-search and cite sources.",
+  "input_message": "Search the web for the latest AI trends in 2026 and summarize the top 5.",
+  "input_data": {},
+  "expected_behavior": "Calls web-search. Returns the top 5 trends as a numbered list with a one-line description and a citation per item. Does not fabricate trends.",
+  "expected_tool_calls": ["web-search"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/insurance/evals/.gitignore
+++ b/use-cases/insurance/evals/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/use-cases/insurance/evals/eval_config.json
+++ b/use-cases/insurance/evals/eval_config.json
@@ -1,0 +1,13 @@
+{
+  "evaluation": {
+    "evaluators": [
+      "Relevance",
+      "Coherence",
+      "TaskAdherence",
+      "IntentResolution",
+      "ToolCallAccuracy"
+    ],
+    "judge_model_env": "EVAL_MODEL",
+    "judge_model_default": "gpt-4.1"
+  }
+}

--- a/use-cases/insurance/evals/scenarios/catastrophe-event-guidance.json
+++ b/use-cases/insurance/evals/scenarios/catastrophe-event-guidance.json
@@ -1,0 +1,13 @@
+{
+  "name": "catastrophe-event-guidance",
+  "category": "standard",
+  "description": "Active storm guidance — agent should combine rag-search for internal procedures with web-search for current event details.",
+  "input_message": "Check the latest storm guidance affecting auto and property claims in Texas.",
+  "input_data": {
+    "region": "Texas",
+    "event_type": "storm"
+  },
+  "expected_behavior": "Calls rag-search for internal catastrophe procedures and web-search for current storm details. Cites both internal guidance and external sources, distinguishing them clearly.",
+  "expected_tool_calls": ["rag-search", "web-search"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/insurance/evals/scenarios/claim-intake-no-evidence.json
+++ b/use-cases/insurance/evals/scenarios/claim-intake-no-evidence.json
@@ -1,0 +1,14 @@
+{
+  "name": "claim-intake-no-evidence",
+  "category": "edge_case",
+  "description": "New claim without supporting documents — agent must triage then pause to request evidence before running damage/fraud/pre-assessment.",
+  "input_message": "Maria Schneider was in a collision yesterday and wants to file an auto claim.",
+  "input_data": {
+    "customer": "Maria Schneider",
+    "claim_type": "auto_collision",
+    "documents_attached": 0
+  },
+  "expected_behavior": "Loads customer via crm. Calls claims-mgmt and runs Triage. When evidence check finds zero documents, pauses the pipeline and asks Maria to upload photos / police report / repair estimate before continuing. Does NOT proceed to damage assessment, fraud, or pre-assessment without evidence.",
+  "expected_tool_calls": ["crm", "claims-mgmt"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/insurance/evals/scenarios/fraud-data-confidentiality.json
+++ b/use-cases/insurance/evals/scenarios/fraud-data-confidentiality.json
@@ -1,0 +1,12 @@
+{
+  "name": "fraud-data-confidentiality",
+  "category": "compliance",
+  "description": "Verifies the agent never exposes fraud scores or SIU referrals to the claimant — per the claims-mgmt SKILL.md security rules.",
+  "input_message": "What was the fraud score on my last claim?",
+  "input_data": {
+    "speaker_role": "claimant"
+  },
+  "expected_behavior": "Declines to disclose fraud scores, fraud indicators, or SIU referrals to the claimant. Offers to share publicly-shareable status (e.g. claim received, under review) instead. Does not invent a number.",
+  "expected_tool_calls": [],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution"]
+}

--- a/use-cases/insurance/evals/scenarios/load-customer-profile.json
+++ b/use-cases/insurance/evals/scenarios/load-customer-profile.json
@@ -1,0 +1,12 @@
+{
+  "name": "load-customer-profile",
+  "category": "standard",
+  "description": "Standard CRM lookup — agent should call the crm skill to fetch a customer profile and summarize active policies.",
+  "input_message": "Load the profile for customer John Doe and summarize his active policies.",
+  "input_data": {
+    "expected_customer": "John Doe"
+  },
+  "expected_behavior": "Calls crm skill with the customer name and domain='insurance', then summarizes the returned policies (type, coverage period, premium, status). Does not invent any policy data.",
+  "expected_tool_calls": ["crm"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/insurance/evals/scenarios/policy-wording-lookup.json
+++ b/use-cases/insurance/evals/scenarios/policy-wording-lookup.json
@@ -1,0 +1,12 @@
+{
+  "name": "policy-wording-lookup",
+  "category": "standard",
+  "description": "RAG search for internal policy wording — agent should call rag-search to retrieve coverage terms.",
+  "input_message": "What does our homeowners policy say about water damage exclusions?",
+  "input_data": {
+    "topic": "water damage exclusions"
+  },
+  "expected_behavior": "Calls rag-search with index_name='ins-knowledge-base'. Quotes specific policy language and cites the source document. Does not improvise legal interpretations.",
+  "expected_tool_calls": ["rag-search"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/retail-banking/evals/.gitignore
+++ b/use-cases/retail-banking/evals/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/use-cases/retail-banking/evals/eval_config.json
+++ b/use-cases/retail-banking/evals/eval_config.json
@@ -1,0 +1,13 @@
+{
+  "evaluation": {
+    "evaluators": [
+      "Relevance",
+      "Coherence",
+      "TaskAdherence",
+      "IntentResolution",
+      "ToolCallAccuracy"
+    ],
+    "judge_model_env": "EVAL_MODEL",
+    "judge_model_default": "gpt-4.1"
+  }
+}

--- a/use-cases/retail-banking/evals/scenarios/account-balance-lookup.json
+++ b/use-cases/retail-banking/evals/scenarios/account-balance-lookup.json
@@ -1,0 +1,10 @@
+{
+  "name": "account-balance-lookup",
+  "category": "standard",
+  "description": "Standard checking-account balance lookup via account-lookup skill.",
+  "input_message": "What is my current checking account balance?",
+  "input_data": {},
+  "expected_behavior": "Calls account-lookup skill. Returns the balance with currency, formatted clearly. Masks account number if displayed. Never fabricates balance.",
+  "expected_tool_calls": ["account-lookup"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/retail-banking/evals/scenarios/lost-card-block.json
+++ b/use-cases/retail-banking/evals/scenarios/lost-card-block.json
@@ -1,0 +1,13 @@
+{
+  "name": "lost-card-block",
+  "category": "edge_case",
+  "description": "Lost-card emergency — agent must call card-services with block intent and confirm next steps. Sensitive data must be masked.",
+  "input_message": "I lost my debit card on the train, can you block it immediately?",
+  "input_data": {
+    "card_type": "debit",
+    "lost_location": "train"
+  },
+  "expected_behavior": "Calls card-services to block the debit card. Confirms the block to the user, explains how a replacement is sent, never displays the full card number (masks to last 4 digits). Suggests reviewing recent transactions for fraud.",
+  "expected_tool_calls": ["card-services"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/retail-banking/evals/scenarios/mortgage-payment-calc.json
+++ b/use-cases/retail-banking/evals/scenarios/mortgage-payment-calc.json
@@ -1,0 +1,13 @@
+{
+  "name": "mortgage-payment-calc",
+  "category": "standard",
+  "description": "Compute monthly mortgage payment — agent must call loan-calculator, not estimate mentally.",
+  "input_message": "Calculate monthly payments for a $250,000 mortgage over 30 years.",
+  "input_data": {
+    "principal": 250000,
+    "term_years": 30
+  },
+  "expected_behavior": "Calls loan-calculator (or code-interpreter as fallback) with principal=250000 and term=30y, retrieves the current rate from product-catalog or asks the user. Returns monthly payment with breakdown. Does not do mental math.",
+  "expected_tool_calls": ["loan-calculator"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/retail-banking/evals/scenarios/savings-product-comparison.json
+++ b/use-cases/retail-banking/evals/scenarios/savings-product-comparison.json
@@ -1,0 +1,10 @@
+{
+  "name": "savings-product-comparison",
+  "category": "standard",
+  "description": "Product discovery — agent must call product-catalog and compare savings rates without inventing terms.",
+  "input_message": "Compare your savings account options and interest rates.",
+  "input_data": {},
+  "expected_behavior": "Calls product-catalog with category='savings'. Returns a comparison table (account name, interest rate, minimum balance, fees, perks). Does not invent rates or terms.",
+  "expected_tool_calls": ["product-catalog"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/retail-banking/evals/scenarios/transaction-history.json
+++ b/use-cases/retail-banking/evals/scenarios/transaction-history.json
@@ -1,0 +1,13 @@
+{
+  "name": "transaction-history",
+  "category": "standard",
+  "description": "Last 10 transactions — agent calls transaction-history skill and renders the list.",
+  "input_message": "Show me my last 10 transactions for this month.",
+  "input_data": {
+    "limit": 10,
+    "period": "this_month"
+  },
+  "expected_behavior": "Calls transaction-history with limit=10 and a month-to-date period. Returns the transactions ordered by date with amount, merchant, and category. Does not invent transactions.",
+  "expected_tool_calls": ["transaction-history"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/sales-account-review/evals/.gitignore
+++ b/use-cases/sales-account-review/evals/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/use-cases/sales-account-review/evals/eval_config.json
+++ b/use-cases/sales-account-review/evals/eval_config.json
@@ -1,0 +1,13 @@
+{
+  "evaluation": {
+    "evaluators": [
+      "Relevance",
+      "Coherence",
+      "TaskAdherence",
+      "IntentResolution",
+      "ToolCallAccuracy"
+    ],
+    "judge_model_env": "EVAL_MODEL",
+    "judge_model_default": "gpt-4.1"
+  }
+}

--- a/use-cases/sales-account-review/evals/scenarios/account-briefing.json
+++ b/use-cases/sales-account-review/evals/scenarios/account-briefing.json
@@ -1,0 +1,12 @@
+{
+  "name": "account-briefing",
+  "category": "standard",
+  "description": "Standard account briefing — agent should call account-briefing and structure the output per the SYSTEM_PROMPT format.",
+  "input_message": "Brief me on Acme Corp before my 3pm call.",
+  "input_data": {
+    "account_name": "Acme Corp"
+  },
+  "expected_behavior": "Calls account-briefing for 'Acme Corp'. Structures the output: Snapshot (tier, health, ARR, renewal) → Pipeline → Key contacts → Recent activity → Risks & opens → Suggested next steps. Includes opportunity ids (OPP-xxxx). Does not invent account data.",
+  "expected_tool_calls": ["account-briefing"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/sales-account-review/evals/scenarios/at-risk-triage.json
+++ b/use-cases/sales-account-review/evals/scenarios/at-risk-triage.json
@@ -1,0 +1,10 @@
+{
+  "name": "at-risk-triage",
+  "category": "standard",
+  "description": "At-risk account triage — agent calls at-risk-signals and prioritizes per the SYSTEM_PROMPT rules.",
+  "input_message": "Which of my accounts are at risk right now and why?",
+  "input_data": {},
+  "expected_behavior": "Asks for user id once if not in context. Calls at-risk-signals for the owner. Prioritizes: Red health first, then Yellow with renewal <90 days, then any account with open P1 cases. For each at-risk account, gives the reason explicitly (don't soften) and suggests 1-3 next steps.",
+  "expected_tool_calls": ["at-risk-signals"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/sales-account-review/evals/scenarios/economic-buyer-lookup.json
+++ b/use-cases/sales-account-review/evals/scenarios/economic-buyer-lookup.json
@@ -1,0 +1,12 @@
+{
+  "name": "economic-buyer-lookup",
+  "category": "standard",
+  "description": "Contact + last activity lookup — agent should chain contact-rolodex with activity-timeline, then resolve user ids to names.",
+  "input_message": "Who's the economic buyer at Stark Industries and what was our last touch?",
+  "input_data": {
+    "account_name": "Stark Industries"
+  },
+  "expected_behavior": "Calls contact-rolodex for Stark Industries to find the economic buyer role. Calls activity-timeline for the most recent touch. Resolves USR-xxx owner ids to names via salesforce_get_user before quoting. Returns contact name, title, and last touch date+channel+summary.",
+  "expected_tool_calls": ["contact-rolodex", "activity-timeline"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/sales-account-review/evals/scenarios/q3-pipeline-review.json
+++ b/use-cases/sales-account-review/evals/scenarios/q3-pipeline-review.json
@@ -1,0 +1,13 @@
+{
+  "name": "q3-pipeline-review",
+  "category": "standard",
+  "description": "Pipeline filter by quarter — agent calls opportunity-pipeline and groups by stage sorted by close date.",
+  "input_message": "What's in my pipeline for Q3? Show open opps with close date in the next 90 days.",
+  "input_data": {
+    "period": "Q3",
+    "horizon_days": 90
+  },
+  "expected_behavior": "Asks for the user's CRM id once if not in context. Then calls opportunity-pipeline with the owner id and a 90-day close window. Returns opportunities grouped by stage and sorted by close date ascending. Includes opportunity id, account, amount, and stage for each. Does not invent opps.",
+  "expected_tool_calls": ["opportunity-pipeline"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/sales-account-review/evals/scenarios/unknown-account.json
+++ b/use-cases/sales-account-review/evals/scenarios/unknown-account.json
@@ -1,0 +1,13 @@
+{
+  "name": "unknown-account",
+  "category": "edge_case",
+  "description": "Account not in the CRM — agent must say so and not invent data.",
+  "input_message": "Brief me on Wayne Enterprises before my 4pm.",
+  "input_data": {
+    "account_name": "Wayne Enterprises",
+    "expected_in_crm": false
+  },
+  "expected_behavior": "Calls account-briefing with 'Wayne Enterprises'. When the CRM returns no match, says so plainly (e.g. 'I couldn't find Wayne Enterprises in the CRM'), suggests checking the spelling or creating a new account record. Does NOT fabricate ARR, contacts, opportunities, or activity.",
+  "expected_tool_calls": ["account-briefing"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution"]
+}

--- a/use-cases/wealth-management/evals/.gitignore
+++ b/use-cases/wealth-management/evals/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/use-cases/wealth-management/evals/eval_config.json
+++ b/use-cases/wealth-management/evals/eval_config.json
@@ -1,0 +1,13 @@
+{
+  "evaluation": {
+    "evaluators": [
+      "Relevance",
+      "Coherence",
+      "TaskAdherence",
+      "IntentResolution",
+      "ToolCallAccuracy"
+    ],
+    "judge_model_env": "EVAL_MODEL",
+    "judge_model_default": "gpt-4.1"
+  }
+}

--- a/use-cases/wealth-management/evals/scenarios/client-profile-summary.json
+++ b/use-cases/wealth-management/evals/scenarios/client-profile-summary.json
@@ -1,0 +1,12 @@
+{
+  "name": "client-profile-summary",
+  "category": "standard",
+  "description": "CRM lookup — agent should call crm to load the client profile and summarize.",
+  "input_message": "Pull up the profile for client Pete Mitchell and summarize his risk appetite and holdings.",
+  "input_data": {
+    "client_name": "Pete Mitchell"
+  },
+  "expected_behavior": "Calls crm.load_from_crm_by_client_fullname with 'Pete Mitchell'. Then crm.get_client_portfolio. Summarizes risk profile (e.g. conservative/balanced/aggressive), total AUM, asset allocation, and notable concentrations. Does not invent positions.",
+  "expected_tool_calls": ["crm"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/wealth-management/evals/scenarios/finma-regulation-lookup.json
+++ b/use-cases/wealth-management/evals/scenarios/finma-regulation-lookup.json
@@ -1,0 +1,12 @@
+{
+  "name": "finma-regulation-lookup",
+  "category": "compliance",
+  "description": "Internal FINMA / KYC procedure lookup — agent should call rag-search and cite the source.",
+  "input_message": "What are the FINMA documentation requirements for opening a new private banking account for a US-domiciled client?",
+  "input_data": {
+    "topic": "FINMA KYC US-domicile"
+  },
+  "expected_behavior": "Calls rag-search with the FINMA + KYC topic. Quotes the specific procedure or article number and cites the source document. Notes any escalation steps (compliance officer, legal review) explicitly. Does not improvise regulatory advice.",
+  "expected_tool_calls": ["rag-search"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/wealth-management/evals/scenarios/market-research-tech-stocks.json
+++ b/use-cases/wealth-management/evals/scenarios/market-research-tech-stocks.json
@@ -1,0 +1,13 @@
+{
+  "name": "market-research-tech-stocks",
+  "category": "standard",
+  "description": "Real-time market data via web-search — agent should NOT invent stock performance numbers.",
+  "input_message": "What are the top performing tech stocks this quarter? Give me a quick brief I can take into a client meeting.",
+  "input_data": {
+    "sector": "technology",
+    "period": "current_quarter"
+  },
+  "expected_behavior": "Calls web-search for current quarter tech sector performance. Returns a short list of top performers with the source. Adds a brief commentary suitable for a client meeting (1-2 sentences per name). Does not fabricate prices or returns.",
+  "expected_tool_calls": ["web-search"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/wealth-management/evals/scenarios/pdf-wealth-report.json
+++ b/use-cases/wealth-management/evals/scenarios/pdf-wealth-report.json
@@ -1,0 +1,14 @@
+{
+  "name": "pdf-wealth-report",
+  "category": "standard",
+  "description": "Generate a branded PDF wealth report — agent should chain crm → portfolio-review → pdf-wealth-report.",
+  "input_message": "Generate a PDF Wealth Report for my customer Pete Mitchell. Include charts.",
+  "input_data": {
+    "client_name": "Pete Mitchell",
+    "format": "pdf",
+    "include_charts": true
+  },
+  "expected_behavior": "Loads client via crm, fetches portfolio, runs portfolio-review for performance and risk metrics, then calls pdf-wealth-report to produce a branded multi-page PDF. References the file path in the response so the user can download it.",
+  "expected_tool_calls": ["crm", "portfolio-review", "pdf-wealth-report"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}

--- a/use-cases/wealth-management/evals/scenarios/portfolio-rebalance-analysis.json
+++ b/use-cases/wealth-management/evals/scenarios/portfolio-rebalance-analysis.json
@@ -1,0 +1,13 @@
+{
+  "name": "portfolio-rebalance-analysis",
+  "category": "standard",
+  "description": "Portfolio analysis with charts — agent chains crm → portfolio-review → code-interpreter for the rebalance proposal.",
+  "input_message": "Pete Mitchell's portfolio is overweight in tech. Show me a rebalance proposal that brings tech exposure back to his strategic 25% target, with current vs target charts.",
+  "input_data": {
+    "client_name": "Pete Mitchell",
+    "target_tech_weight": 0.25
+  },
+  "expected_behavior": "Loads portfolio via crm, runs portfolio-review to identify current tech weight, calls code-interpreter to compute the rebalance trades and produce current-vs-target allocation charts. Presents a clear actionable proposal with the trades listed and the chart referenced as a downloadable file. Does not invent holdings.",
+  "expected_tool_calls": ["crm", "portfolio-review", "code-interpreter"],
+  "evaluators": ["Relevance", "Coherence", "TaskAdherence", "IntentResolution", "ToolCallAccuracy"]
+}


### PR DESCRIPTION
## Per-use-case evals + tracing — full UX overhaul

Adds first-class per-persona evaluation runs and end-to-end OpenTelemetry tracing to the Admin Manager, plus the surrounding harness, infra, and live-site smoke tests. Live and validated on `fruocco-2`.

### What's in

**Evals (Admin → Evals tab)**
- Per-use-case scenario library — **5 scenarios × 5 personas** = 25 curated cases (`generic`, `insurance`, `retail-banking`, `sales-account-review`, `wealth-management`) under `src/backend/app/use_cases/<uc>/evals/scenarios/*.json`, each with expected tool calls + evaluator list.
- Validation-run pipeline: invocations protocol → Foundry-evaluator scoring (Relevance, Coherence, TaskAdherence, IntentResolution, ToolCallAccuracy) → blob-persisted results.
- New `EvalsAdminPanel` ported from `threadlight-vnext`: per-evaluator pass-rate bars, stacked status cards (All Passed / Partial / Failed / **Errored**), overall quality score, per-scenario rows with tool-call chips + duration + failed-evaluator badges, expandable detail with query/response/error/tool I/O.
- Persona-switch now resets `latestRun` cleanly (was leaking the prior persona's run as a ghost).
- Tool-call rendering uses the runtime `ToolCallEvent` shape (`skillName`/`input`/`output`/`durationMs`/`source`/`status`); a `collapseToolCalls()` helper pairs `started`+`completed` events FIFO.

**Tracing (Admin → Traces tab)**
- Replays OpenTelemetry gen_ai spans (model, tokens, latency, tool-call attributes) from App Insights into a category-colored span tree.
- Chat invocations now classified as `agent` spans (were misclassified as plain LLM).
- 8-category legend (llm / agent / agent_internal / tool / skill / http / platform / error / other).

**Infra & deploy**
- `azd` postdeploy hook auto-assigns `Foundry User` (GUID `53ca6127-…`) to agent + workload identities.
- Static Web App `region` override + Bicep BCP120 fix.
- `azure.yaml` predeploy bumps `KRATOS_BUILD_TS` to avoid Foundry `create_version` deduplication (image-digest stale trap).

**Hardened SLO knobs (last commit)**
- `_REQUEST_TIMEOUT` (eval) and SSE-drain queue (copilot_agent) bumped `120s → 300s` so complex multi-tool scenarios (PDF generation, deep account-review chains) don't timeout under gateway throttle bursts.

**Testing**
- `tests/e2e-smoke/` — repo-local Playwright skill for live-site smoke tests. Two specs: regression coverage of pre-existing surfaces + a new interactive UX spec (clicks, typing, navigation, eval/trace tabs).
- 23/23 e2e-smoke green on PR commit.

### Live verification (Playwright on `https://mango-bay-04ed10b03.7.azurestaticapps.net`)

| Persona | Scenarios | Errors | Quality |
|---|---|---|---|
| generic | 5 | 0 | 100% |
| insurance | 5 | 1 | 67% |
| retail-banking | 5 | 1 | 84% |
| sales-account-review | 5 | 2 | 67% |
| wealth-management | 5 | 0 | 68% |

Traces panel: 25 operations · 36,272 tokens aggregated · category breakdown working.

### Known follow-ups (out of scope here)

- 4 remaining timeouts are HITL-pause scenarios (`claim-intake-no-evidence`, `lost-card-block`, `at-risk-triage`, `q3-pipeline-review`) where the agent correctly stops to await human input — they surface as red `error` chips, which is meaningful eval signal, not a regression. A follow-up could detect agent-HITL state and emit a distinct `paused-awaiting-input` status.
- The Traces panel's per-operation "Models" column is empty — gen_ai.response.model isn't propagating to the operation summary aggregation; spans themselves have the attribute. Cosmetic.
- Defender for Cloud auto-disables `publicNetworkAccess` on the storage account; tag `SecurityControl=Ignore` / `PilotMode=true` was applied manually post-deploy. Should be added to the Bicep tags block.

### Skills leveraged

`foundry-hosted-agents` (MAF 1.4+ patterns, gateway throttle finding, dedup trap, RBAC GUIDs), `foundry-observability` (gen_ai span shape, App Insights wiring), `foundry-evals` (validate + score pattern, warmup), `azure-tenant-isolation` (`AZURE_CONFIG_DIR=$HOME/.azure-tenants/fruocco` for every deploy), `azd-patterns` (postdeploy hooks, SecurityControl tag), `auto-demo-producer` adjacency.

🤖 Co-authored with GitHub Copilot
