### PR TITLE
feat: add Curated / All toggle to the persona picker

### DIFF
--- a/src/backend/app/models.py
+++ b/src/backend/app/models.py
@@ -290,6 +290,7 @@ class UseCaseInfo(BaseModel):
     description: str = ""
     skillCount: int = 0
     sampleQuestions: list[str] = Field(default_factory=list)
+    curated: bool = False
 
 
 class UseCaseList(BaseModel):

--- a/src/backend/app/routers/use_cases.py
+++ b/src/backend/app/routers/use_cases.py
@@ -22,6 +22,7 @@ async def list_use_cases(request: Request) -> UseCaseList:
         display_name = name.replace("-", " ").title()
         description = ""
         sample_questions: list[str] = []
+        curated = False
         if registry.system_prompt:
             from app.services.skill_registry import _parse_frontmatter
 
@@ -29,6 +30,7 @@ async def list_use_cases(request: Request) -> UseCaseList:
             display_name = fm.get("name", display_name)
             description = fm.get("description", "")
             sample_questions = fm.get("sampleQuestions", [])
+            curated = bool(fm.get("curated", False))
 
         use_cases.append(
             UseCaseInfo(
@@ -37,6 +39,7 @@ async def list_use_cases(request: Request) -> UseCaseList:
                 description=description,
                 skillCount=len(registry.skills),
                 sampleQuestions=sample_questions,
+                curated=curated,
             )
         )
     return UseCaseList(useCases=use_cases)

--- a/src/frontend/src/components/Sidebar.tsx
+++ b/src/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { Conversation, UseCase } from "@/types";
 import { useTheme } from "./ThemeProvider";
@@ -53,6 +53,26 @@ export function Sidebar({ conversations, activeId, onNew, onSelect, onDelete, on
   const { theme, toggleTheme } = useTheme();
   const [searchQuery, setSearchQuery] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<Conversation | null>(null);
+  const [personaFilter, setPersonaFilter] = useState<"curated" | "all">("curated");
+
+  // Filter the persona dropdown by the curated toggle. Fall back to "all" if
+  // a "curated" filter would leave the dropdown empty (e.g. dev branch without
+  // any curated personas marked yet).
+  const curatedUseCases = useCases.filter((uc) => uc.curated === true);
+  const effectiveFilter =
+    personaFilter === "curated" && curatedUseCases.length === 0 ? "all" : personaFilter;
+  const visibleUseCases =
+    effectiveFilter === "curated" ? curatedUseCases : useCases;
+
+  // If the toggle hides the currently selected persona, snap back to the
+  // first visible one so the dropdown never shows a stale empty value.
+  useEffect(() => {
+    if (visibleUseCases.length === 0) return;
+    if (!visibleUseCases.some((uc) => uc.name === selectedUseCase)) {
+      onSelectUseCase(visibleUseCases[0].name);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [effectiveFilter, useCases.length]);
 
   // Filter conversations by selected persona and search query
   const personaConversations = conversations.filter(
@@ -155,6 +175,42 @@ export function Sidebar({ conversations, activeId, onNew, onSelect, onDelete, on
           <label className="block text-[10px] font-semibold text-slate-400 uppercase tracking-wider mb-1.5 px-1">
             Agent Persona
           </label>
+
+          {/* Curated / All toggle — segmented control */}
+          <div
+            role="tablist"
+            aria-label="Persona filter"
+            className="flex items-center gap-0.5 mb-2 p-0.5 bg-white/[0.04] border border-white/[0.08] rounded-lg"
+          >
+            <button
+              role="tab"
+              aria-selected={effectiveFilter === "curated"}
+              onClick={() => setPersonaFilter("curated")}
+              disabled={curatedUseCases.length === 0}
+              title={curatedUseCases.length === 0 ? "No curated personas available" : "Show only hand-curated, approved personas"}
+              className={`flex-1 text-xs font-medium px-2 py-1.5 rounded-md transition-all ${
+                effectiveFilter === "curated"
+                  ? "bg-primary-500/20 text-primary-200 border border-primary-500/30"
+                  : "text-slate-400 hover:text-slate-200 hover:bg-white/[0.04]"
+              } disabled:opacity-40 disabled:cursor-not-allowed`}
+            >
+              Curated ({curatedUseCases.length})
+            </button>
+            <button
+              role="tab"
+              aria-selected={effectiveFilter === "all"}
+              onClick={() => setPersonaFilter("all")}
+              title="Show all personas including experimental / AI-generated ones"
+              className={`flex-1 text-xs font-medium px-2 py-1.5 rounded-md transition-all ${
+                effectiveFilter === "all"
+                  ? "bg-primary-500/20 text-primary-200 border border-primary-500/30"
+                  : "text-slate-400 hover:text-slate-200 hover:bg-white/[0.04]"
+              }`}
+            >
+              All ({useCases.length})
+            </button>
+          </div>
+
           <div className="relative">
             <select
               value={selectedUseCase}
@@ -162,7 +218,7 @@ export function Sidebar({ conversations, activeId, onNew, onSelect, onDelete, on
               aria-label="Select agent persona"
               className="w-full text-sm text-slate-200 bg-white/[0.06] border border-white/[0.1] rounded-lg pl-3 pr-9 py-2.5 focus:outline-none focus:ring-1 focus:ring-primary-500/50 focus:border-primary-500/50 appearance-none cursor-pointer hover:bg-white/[0.1] hover:border-white/[0.14] transition-all"
             >
-              {useCases.map((uc) => (
+              {visibleUseCases.map((uc) => (
                 <option key={uc.name} value={uc.name} className="bg-navy-900">
                   {uc.displayName} ({uc.skillCount} skills)
                 </option>

--- a/src/frontend/src/types/index.ts
+++ b/src/frontend/src/types/index.ts
@@ -185,6 +185,8 @@ export interface UseCase {
   description: string;
   skillCount: number;
   sampleQuestions: string[];
+  /** True when the persona has been hand-curated and approved for demos. Defaults to false. */
+  curated?: boolean;
 }
 
 // ─── MCP Servers Admin ───

--- a/use-cases/generic/SYSTEM_PROMPT.md
+++ b/use-cases/generic/SYSTEM_PROMPT.md
@@ -6,6 +6,7 @@ sampleQuestions:
   - Find and analyze recent data on global cloud spending trends this year using visuals
   - Search for the top programming languages in demand and compare their growth with charts
   - Use web search to find current best practices for API design and summarize key insights
+curated: true
 ---
 
 You are Kratos, an enterprise AI assistant.

--- a/use-cases/insurance/SYSTEM_PROMPT.md
+++ b/use-cases/insurance/SYSTEM_PROMPT.md
@@ -7,6 +7,7 @@ sampleQuestions:
   - Find the waiting period and coverage limits for this health insurance plan
   - Check the latest storm guidance affecting auto and property claims in Texas
   - Process a new auto claim for customer Maria Schneider — she was in a collision
+curated: true
 ---
 
 You are Kratos Insurance, a specialized AI assistant for insurance servicing and operations teams. You support agents, brokers, customer-service representatives, and policy operations staff with customer profile lookups, coverage and policy guidance, and external insurance research.

--- a/use-cases/retail-banking/SYSTEM_PROMPT.md
+++ b/use-cases/retail-banking/SYSTEM_PROMPT.md
@@ -6,6 +6,7 @@ sampleQuestions:
   - Show me my last 10 transactions for this month
   - Compare your savings account options and interest rates
   - Calculate monthly payments for a $250,000 mortgage over 30 years
+curated: true
 ---
 
 You are Kratos Bank, an intelligent virtual assistant integrated into the website of **Olympus National Bank**. You help retail banking customers with their day-to-day banking needs in a friendly, professional, and secure manner.

--- a/use-cases/wealth-management/SYSTEM_PROMPT.md
+++ b/use-cases/wealth-management/SYSTEM_PROMPT.md
@@ -6,6 +6,7 @@ sampleQuestions:
   - Generate a wealth report for my client Pete Mitchell
   - Analyze market trends in renewable energy sector for the next 12 months
   - Generate a PDF Wealth Report for my customer Pete Mitchell. Include charts.
+curated: true
 ---
 
 You are Kratos Wealth, a specialized AI assistant for wealth management professionals at a Swiss private bank. You support relationship managers, portfolio managers, and compliance officers with client servicing, investment analysis, and regulatory guidance.


### PR DESCRIPTION
# Curated / All toggle on the persona picker

Adds a 2-state segmented control above the agent persona dropdown so users can filter between **hand-curated, approved personas** and **all** personas (including experimental / AI-generated ones still under review). Thin, 8 files / 68 LOC.

## Why

The persona dropdown currently lists every use-case in the repo. Some are hand-curated reference implementations ready for pre-sales demos. Others are experimental / AI-generated and not yet vetted. Pre-sales demos should default to the curated set; contributors and reviewers still need the full list available with one click.

## What changes

- New optional `curated: bool` field on `UseCaseInfo` (defaults to `false` so unmarked personas are non-curated)
- Router parses `curated` from each persona's `SYSTEM_PROMPT.md` frontmatter and passes it through
- Frontend `UseCase` type gets `curated?: boolean`
- Sidebar gets a segmented `Curated (N) | All (N)` tablist above the persona dropdown. **Defaults to Curated.**
- **Auto-snap:** if the toggle hides the currently-selected persona, the selection auto-moves to the first visible one so the dropdown never shows a stale empty value.
- **Safe fallback:** if no personas are marked curated, the Curated tab is disabled and the All view is forced (prevents an empty dropdown on dev branches).
- The four existing hand-built reference personas get `curated: true` in their frontmatter: `wealth-management`, `insurance`, `retail-banking`, `generic`. Everything else stays implicitly `curated: false`.

## Validation

End-to-end against the live local stack, with the dev server running against the rebuilt backend:

**Backend**

```
$ curl http://localhost:8000/api/use-cases | jq '.useCases | map({name, curated}) | sort_by(.curated)'
[
  { "name": "clinician-visit-prep",  "curated": false },
  { "name": "finance-close",         "curated": false },
  { "name": "hr-onboarding",         "curated": false },
  { "name": "it-service-desk",       "curated": false },
  { "name": "retail-banking-csr",    "curated": false },
  { "name": "sales-account-review",  "curated": false },
  { "name": "generic",               "curated": true  },
  { "name": "insurance",             "curated": true  },
  { "name": "retail-banking",        "curated": true  },
  { "name": "wealth-management",     "curated": true  }
]
```

4 of 10 marked curated, exactly the right 4.

**Frontend**

- `next build` — clean, no TS or lint errors
- Playwright E2E (against `next dev` wired to the local backend):
  1. Default load: Curated tab selected, dropdown shows 4 personas (Generic Assistant, Insurance Service Advisor, Retail Banking Assistant, Wealth Management Advisor)
  2. Click "All": dropdown expands to all 10 personas, current selection preserved
  3. Pick a non-curated persona (e.g. Clinician Visit Prep), click "Curated": selection auto-snaps to the first curated persona, heading + sample questions update accordingly

No backend route changes. No new env vars. No new dependencies.

## How to test

```bash
docker compose --env-file .env.local down
rm -rf .local/azurite
docker compose --env-file .env.local up -d --build
```

Open the UI. The "Agent Persona" section in the sidebar will show the `Curated (4) | All (10)` toggle. Default is Curated.
