### PR TITLE
Fix unreadable text across UI: replace broken/hardcoded color tokens with theme tokens

### DIFF
--- a/src/frontend/src/app/page.tsx
+++ b/src/frontend/src/app/page.tsx
@@ -139,7 +139,7 @@ export default function Home() {
       {/* Skip to content link for accessibility */}
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:bg-primary-600 focus:text-white focus:rounded-lg focus:text-sm focus:font-medium focus:shadow-lg"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:bg-accent focus:text-accent-fg focus:rounded-lg focus:text-sm focus:font-medium focus:shadow-lg"
       >
         Skip to content
       </a>
@@ -234,7 +234,7 @@ export default function Home() {
 
                 {/* Chat input bar */}
                 <div className="relative mb-8">
-                  <div className="flex items-end gap-2 p-2 bg-surface border border-border-soft rounded-2xl shadow-lg focus-within:border-primary-400/60 dark:focus-within:border-primary-500/40 focus-within:shadow-[0_0_0_3px_rgba(99,102,241,0.1),0_8px_32px_rgba(0,0,0,0.06)] transition-all duration-300">
+                  <div className="flex items-end gap-2 p-2 bg-surface border border-border-soft rounded-2xl shadow-lg focus-within:border-accent focus-within:shadow-[0_0_0_3px_var(--accent-soft),0_8px_32px_rgba(0,0,0,0.06)] transition-all duration-300">
                     <textarea
                       ref={landingInputRef}
                       value={landingInput}
@@ -278,15 +278,15 @@ export default function Home() {
                       <button
                         key={i}
                         onClick={() => handleSampleQuestion(q)}
-                        className="group text-left px-4 py-3.5 rounded-xl border border-border-soft bg-surface hover:border-accent hover:bg-hover transition-all duration-300 hover:shadow-md hover:shadow-primary-500/[0.06] dark:hover:shadow-primary-500/[0.08] animate-slide-up-stagger active:scale-[0.98] backdrop-blur-sm"
+                        className="group text-left px-4 py-3.5 rounded-xl border border-border-soft bg-surface hover:border-accent hover:bg-hover transition-all duration-300 hover:shadow-md animate-slide-up-stagger active:scale-[0.98] backdrop-blur-sm"
                       >
                         <div className="flex items-start gap-3">
-                          <div className="w-7 h-7 rounded-lg bg-accent-soft flex items-center justify-center flex-shrink-0 group-hover:bg-primary-100 dark:group-hover:bg-primary-500/20 transition-colors">
+                          <div className="w-7 h-7 rounded-lg bg-accent-soft flex items-center justify-center flex-shrink-0 group-hover:bg-accent-soft transition-colors">
                             <svg className="w-3.5 h-3.5 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                               <path strokeLinecap="round" strokeLinejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z" />
                             </svg>
                           </div>
-                          <span className="text-sm text-text group-hover:text-slate-900 dark:group-hover:text-slate-200 transition-colors leading-snug">{q}</span>
+                          <span className="text-sm text-text group-hover:text-text-strong transition-colors leading-snug">{q}</span>
                         </div>
                       </button>
                     ))}

--- a/src/frontend/src/components/ApmAdminPanel.tsx
+++ b/src/frontend/src/components/ApmAdminPanel.tsx
@@ -297,7 +297,7 @@ export function ApmAdminPanel({ useCase, onMcpChange }: Props) {
           </div>
           <h3 className="text-sm font-semibold text-text">APM is disabled</h3>
           <p className="mt-1 text-xs text-muted">
-            Set <code className="px-1 py-0.5 rounded bg-slate-200/80 font-mono text-[11px]">APM_ENABLED=true</code> in the backend environment to manage packages from the UI.
+            Set <code className="px-1 py-0.5 rounded bg-surface-2 font-mono text-[11px]">APM_ENABLED=true</code> in the backend environment to manage packages from the UI.
           </p>
         </div>
       </div>
@@ -363,7 +363,7 @@ export function ApmAdminPanel({ useCase, onMcpChange }: Props) {
       <div className="bg-surface border border-border-soft rounded-2xl overflow-hidden">
         {loading ? (
           <div className="flex items-center justify-center py-12">
-            <div className="animate-spin rounded-full h-8 w-8 border-2 border-accent border-t-primary-600" />
+            <div className="animate-spin rounded-full h-8 w-8 border-2 border-accent border-t-transparent" />
           </div>
         ) : dependencies.length === 0 ? (
           <div className="px-6 py-10 text-center text-sm text-muted">
@@ -385,7 +385,7 @@ export function ApmAdminPanel({ useCase, onMcpChange }: Props) {
                 {dependencies.map((dep) => {
                   const tag = `uninstall:${dep.name}`;
                   return (
-                    <tr key={dep.name} className="hover:bg-slate-50/60 transition-colors">
+                    <tr key={dep.name} className="hover:bg-hover transition-colors">
                       <td className="px-4 py-2.5 font-mono text-text">{dep.name}</td>
                       <td className="px-4 py-2.5 font-mono text-text">{dep.ref ?? "—"}</td>
                       <td className="px-4 py-2.5 font-mono text-text truncate max-w-[220px]" title={dep.resolved ?? ""}>
@@ -452,7 +452,7 @@ export function ApmAdminPanel({ useCase, onMcpChange }: Props) {
                   const pending = !s.command && !s.url;
                   const tag = `uninstall-mcp:${s.name}`;
                   return (
-                    <tr key={s.name} className="hover:bg-slate-50/60 transition-colors">
+                    <tr key={s.name} className="hover:bg-hover transition-colors">
                       <td className="px-4 py-2.5 font-mono text-text">{s.name}</td>
                       <td className="px-4 py-2.5">
                         <span className={`inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium ${
@@ -508,7 +508,7 @@ export function ApmAdminPanel({ useCase, onMcpChange }: Props) {
             return (
               <div
                 key={s.id}
-                className="flex flex-col gap-2 p-4 bg-slate-50/70 border border-border-soft rounded-xl"
+                className="flex flex-col gap-2 p-4 bg-surface-2 border border-border-soft rounded-xl"
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
@@ -684,7 +684,7 @@ export function ApmAdminPanel({ useCase, onMcpChange }: Props) {
             return (
               <div
                 key={pkg.id}
-                className="flex flex-col gap-2 p-4 bg-slate-50/70 border border-border-soft rounded-xl"
+                className="flex flex-col gap-2 p-4 bg-surface-2 border border-border-soft rounded-xl"
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">

--- a/src/frontend/src/components/ChatWindow.tsx
+++ b/src/frontend/src/components/ChatWindow.tsx
@@ -392,7 +392,7 @@ export function ChatWindow({ conversation, onTitleChange, initialMessage, onOpen
           {onOpenSidebar && (
             <button
               onClick={onOpenSidebar}
-              className="lg:hidden p-2 -ml-1 text-muted hover:text-text rounded-lg hover:bg-slate-100/80 transition-all flex-shrink-0"
+              className="lg:hidden p-2 -ml-1 text-muted hover:text-text rounded-lg hover:bg-hover transition-all flex-shrink-0"
             >
               <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
@@ -449,8 +449,8 @@ export function ChatWindow({ conversation, onTitleChange, initialMessage, onOpen
           {/* Awaiting a response that is still being generated on the backend
               (e.g. after navigating back to this conversation mid-run). */}
           {!isStreaming && awaitingResponse && (
-            <div className="ml-11 flex items-center gap-2.5 text-sm text-slate-500 dark:text-slate-400">
-              <svg className="w-4 h-4 animate-spin text-primary-500" fill="none" viewBox="0 0 24 24">
+            <div className="ml-11 flex items-center gap-2.5 text-sm text-muted">
+              <svg className="w-4 h-4 animate-spin text-accent" fill="none" viewBox="0 0 24 24">
                 <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                 <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
               </svg>
@@ -507,8 +507,8 @@ export function ChatWindow({ conversation, onTitleChange, initialMessage, onOpen
           {!isStreaming && followUpQuestions.length > 0 && (
             <div className="ml-11 animate-fade-in">
               <div className="flex items-center gap-2 mb-2.5">
-                <div className="w-5 h-5 rounded-md bg-accent dark:from-violet-500/20 dark:to-primary-500/20 flex items-center justify-center">
-                  <svg className="w-3 h-3 text-accent" viewBox="0 0 24 24" fill="currentColor">
+                <div className="w-5 h-5 rounded-md bg-accent flex items-center justify-center">
+                  <svg className="w-3 h-3 text-accent-fg" viewBox="0 0 24 24" fill="currentColor">
                     <path fillRule="evenodd" d="M14.615 1.595a.75.75 0 01.359.852L12.982 9.75h7.268a.75.75 0 01.548 1.262l-10.5 11.25a.75.75 0 01-1.272-.71l1.992-7.302H3.75a.75.75 0 01-.548-1.262l10.5-11.25a.75.75 0 01.913-.143z" clipRule="evenodd" />
                   </svg>
                 </div>
@@ -524,10 +524,10 @@ export function ChatWindow({ conversation, onTitleChange, initialMessage, onOpen
                     }}
                     className="group flex items-center gap-3 px-3.5 py-2.5 text-[13px] text-left rounded-xl border border-transparent hover:bg-hover hover:border-border hover:shadow-sm transition-all duration-300 animate-slide-up-stagger active:scale-[0.98]"
                   >
-                    <svg className="w-4 h-4 text-text-strong group-hover:text-primary-500 transition-colors flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <svg className="w-4 h-4 text-text-strong group-hover:text-accent transition-colors flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
                     </svg>
-                    <span className="text-muted group-hover:text-slate-800 dark:group-hover:text-slate-200 transition-colors">
+                    <span className="text-muted group-hover:text-text-strong transition-colors">
                       {question}
                     </span>
                   </button>
@@ -570,7 +570,7 @@ export function ChatWindow({ conversation, onTitleChange, initialMessage, onOpen
       {/* Input area */}
       <div className="px-3 sm:px-4 pb-4 sm:pb-5 pt-2">
         <div className="max-w-5xl mx-auto">
-          <div className="flex items-end gap-2 bg-surface rounded-2xl border border-border-soft px-3 py-2 focus-within:border-primary-400/60 dark:focus-within:border-primary-500/40 focus-within:shadow-[0_0_0_3px_rgba(99,102,241,0.1),0_4px_16px_rgba(0,0,0,0.04)] shadow-lg transition-all duration-300">
+          <div className="flex items-end gap-2 bg-surface rounded-2xl border border-border-soft px-3 py-2 focus-within:border-accent focus-within:shadow-[0_0_0_3px_var(--accent-soft),0_4px_16px_rgba(0,0,0,0.04)] shadow-lg transition-all duration-300">
             <input
               ref={fileInputRef}
               type="file"

--- a/src/frontend/src/components/EvalsAdminPanel.tsx
+++ b/src/frontend/src/components/EvalsAdminPanel.tsx
@@ -340,7 +340,7 @@ function ScenarioResultRow({ result, stat }: { result: ScenarioResult; stat: Per
     <div className="border border-border-soft rounded-xl overflow-hidden">
       <button
         onClick={() => setExpanded((v) => !v)}
-        className="w-full flex items-center gap-3 px-4 py-3 bg-slate-50/50 hover:bg-slate-100/80 transition-colors text-left"
+        className="w-full flex items-center gap-3 px-4 py-3 bg-surface-2 hover:bg-hover transition-colors text-left"
       >
         <span className={`flex-shrink-0 w-2 h-2 rounded-full ${statusDotCls}`} />
         <span className="flex-1 text-sm font-medium text-text truncate">
@@ -372,7 +372,7 @@ function ScenarioResultRow({ result, stat }: { result: ScenarioResult; stat: Per
 
       {/* Failed-evaluator badges visible even when collapsed */}
       {!expanded && stat.failedEvaluators.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 px-4 pb-2 pt-1 -mt-1 bg-slate-50/50">
+        <div className="flex flex-wrap gap-1.5 px-4 pb-2 pt-1 -mt-1 bg-surface-2">
           {stat.failedEvaluators.map((name) => (
             <span
               key={name}
@@ -568,8 +568,8 @@ function EditScenarioModal({ scenario, onSave, onClose }: EditScenarioModalProps
                   onClick={() => toggleEvaluator(ev)}
                   className={`px-3 py-1.5 rounded-lg text-xs font-medium border transition-all ${
                     draft.evaluators.includes(ev)
-                      ? "bg-primary-50 dark:bg-primary-500/10 text-primary-700 dark:text-primary-400 border-primary-200 dark:border-primary-500/30"
-                      : "bg-slate-50 dark:bg-white/[0.04] text-slate-500 dark:text-slate-400 border-slate-200 dark:border-white/[0.08] hover:border-slate-300"
+                      ? "bg-accent-soft text-accent border-accent"
+                      : "bg-surface text-muted border-border-soft hover:border-border"
                   }`}
                 >
                   {ev}
@@ -803,7 +803,7 @@ export function EvalsAdminPanel({ useCase }: Props): JSX.Element {
       {/* Loading */}
       {loading && (
         <div className="flex items-center justify-center py-16">
-          <div className="animate-spin rounded-full h-8 w-8 border-2 border-accent border-t-primary-600" />
+          <div className="animate-spin rounded-full h-8 w-8 border-2 border-accent border-t-transparent" />
         </div>
       )}
 
@@ -844,7 +844,7 @@ export function EvalsAdminPanel({ useCase }: Props): JSX.Element {
             ) : (
               <div className="divide-y divide-slate-100 dark:divide-white/[0.04]">
                 {scenarios.map((scenario) => (
-                  <div key={scenario.name} className="flex items-start gap-3 px-5 py-4 hover:bg-slate-50/50 transition-colors">
+                  <div key={scenario.name} className="flex items-start gap-3 px-5 py-4 hover:bg-hover transition-colors">
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 flex-wrap">
                         <span className="text-sm font-medium text-text truncate">{scenario.name}</span>
@@ -915,7 +915,7 @@ export function EvalsAdminPanel({ useCase }: Props): JSX.Element {
               </div>
 
               {latestRun.progress && (
-                <div className="px-5 py-2 text-xs text-muted border-b border-border-soft bg-slate-50/50">
+                <div className="px-5 py-2 text-xs text-muted border-b border-border-soft bg-surface-2">
                   {latestRun.progress}
                 </div>
               )}
@@ -1028,7 +1028,7 @@ export function EvalsAdminPanel({ useCase }: Props): JSX.Element {
                   <button
                     key={run.run_id}
                     onClick={() => setLatestRun(run)}
-                    className="w-full flex items-center gap-3 px-5 py-3 hover:bg-slate-50/50 transition-colors text-left"
+                    className="w-full flex items-center gap-3 px-5 py-3 hover:bg-hover transition-colors text-left"
                   >
                     <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${statusConfig[run.status].color}`}>
                       {statusConfig[run.status].label}

--- a/src/frontend/src/components/GenerateScenariosModal.tsx
+++ b/src/frontend/src/components/GenerateScenariosModal.tsx
@@ -85,8 +85,8 @@ export function GenerateScenariosModal({ useCase, open, onClose, onGenerated }: 
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-border-soft flex-shrink-0">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 rounded-xl bg-accent dark:from-primary-500/10 dark:to-cyan-500/10 flex items-center justify-center border border-accent">
-              <svg className="w-4 h-4 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <div className="w-9 h-9 rounded-xl bg-accent flex items-center justify-center border border-accent">
+              <svg className="w-4 h-4 text-accent-fg" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
               </svg>
             </div>
@@ -182,7 +182,7 @@ export function GenerateScenariosModal({ useCase, open, onClose, onGenerated }: 
               {drafts.map((scenario, idx) => (
                 <div
                   key={idx}
-                  className="border border-border-soft rounded-xl p-4 space-y-3 bg-slate-50/50"
+                  className="border border-border-soft rounded-xl p-4 space-y-3 bg-surface-2"
                 >
                   <div className="flex items-start justify-between gap-3">
                     <input

--- a/src/frontend/src/components/MessageBubble.tsx
+++ b/src/frontend/src/components/MessageBubble.tsx
@@ -163,8 +163,8 @@ export function MessageBubble({ message }: Props) {
       <div
         className={`max-w-[75%] ${
           isUser
-            ? "rounded-2xl rounded-br-sm px-4 py-3 bg-gradient-to-br from-primary-600 to-violet-600 text-white shadow-md shadow-primary-500/20"
-            : "rounded-2xl rounded-bl-sm px-4 py-3 bg-white dark:bg-navy-900/80 border border-slate-100 dark:border-white/[0.06] text-slate-800 dark:text-slate-200 shadow-sm shadow-slate-100/50 dark:shadow-black/10"
+            ? "rounded-2xl rounded-br-sm px-4 py-3 bg-gradient-to-br from-accent to-accent-hover text-accent-fg shadow-md"
+            : "rounded-2xl rounded-bl-sm px-4 py-3 bg-surface border border-border-soft text-text shadow-sm"
         }`}
       >
         {isUser ? (
@@ -175,7 +175,7 @@ export function MessageBubble({ message }: Props) {
             )}
           </>
         ) : (
-          <div className="text-sm leading-relaxed prose prose-sm dark:prose-invert max-w-none prose-p:my-1.5 prose-li:my-0 prose-table:my-2 prose-th:px-3 prose-th:py-2 prose-td:px-3 prose-td:py-2 prose-th:text-left prose-th:bg-slate-50 dark:prose-th:bg-white/[0.04] prose-th:font-semibold prose-table:border-collapse prose-table:w-full prose-headings:text-slate-900 dark:prose-headings:text-white prose-a:text-primary-600 dark:prose-a:text-primary-400 prose-strong:text-slate-900 dark:prose-strong:text-white">
+          <div className="text-sm leading-relaxed prose prose-sm dark:prose-invert max-w-none prose-p:my-1.5 prose-li:my-0 prose-table:my-2 prose-th:px-3 prose-th:py-2 prose-td:px-3 prose-td:py-2 prose-th:text-left prose-th:bg-surface-2 prose-th:font-semibold prose-table:border-collapse prose-table:w-full prose-headings:text-text-strong prose-a:text-accent prose-strong:text-text-strong">
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
               components={{
@@ -212,7 +212,7 @@ export function MessageBubble({ message }: Props) {
                         href={href}
                         download={urlFilename}
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1.5 text-accent hover:text-accent underline decoration-primary-300 underline-offset-2 cursor-pointer bg-transparent border-none p-0 font-inherit text-inherit transition-colors"
+                        className="inline-flex items-center gap-1.5 text-accent hover:text-accent underline decoration-accent/40 underline-offset-2 cursor-pointer bg-transparent border-none p-0 font-inherit text-inherit transition-colors"
                       >
                         <svg className="w-4 h-4 inline-block flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -226,7 +226,7 @@ export function MessageBubble({ message }: Props) {
                       href={href}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-accent hover:text-accent underline decoration-primary-300 underline-offset-2 transition-colors"
+                      className="inline-flex items-center gap-1 text-accent hover:text-accent underline decoration-accent/40 underline-offset-2 transition-colors"
                     >
                       {children}
                     </a>

--- a/src/frontend/src/components/SettingsModal.tsx
+++ b/src/frontend/src/components/SettingsModal.tsx
@@ -145,7 +145,7 @@ export function SettingsModal({ open, onClose }: Props) {
         </div>
 
         {/* Footer */}
-        <div className="flex justify-end gap-3 px-6 py-4 border-t border-border-soft bg-slate-50/50 rounded-b-2xl">
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-border-soft bg-surface-2 rounded-b-2xl">
           <button
             onClick={onClose}
             className="px-5 py-2.5 text-sm text-text bg-surface border border-border-soft rounded-xl hover:bg-hover transition-all font-medium"

--- a/src/frontend/src/components/SkillsAdminPanel.tsx
+++ b/src/frontend/src/components/SkillsAdminPanel.tsx
@@ -427,7 +427,7 @@ export function SkillsAdminPanel({ onClose, useCase = "generic", useCases = [], 
 
       {/* Left sidebar navigation */}
       <aside className={`
-        fixed inset-y-0 left-0 z-50 w-[280px] bg-navy-950 border-r border-white/[0.06] flex flex-col
+        fixed inset-y-0 left-0 z-50 w-[280px] bg-surface-2 border-r border-border-soft flex flex-col
         transform transition-transform duration-300 ease-out
         md:relative md:translate-x-0 md:z-auto
         ${mobileNavOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0"}
@@ -445,7 +445,7 @@ export function SkillsAdminPanel({ onClose, useCase = "generic", useCases = [], 
               </svg>
             </button>
             <div className="flex-1 min-w-0">
-              <h1 className="font-semibold text-accent-fg text-sm tracking-tight">Agent Manager</h1>
+              <h1 className="font-semibold text-text-strong text-sm tracking-tight">Agent Manager</h1>
               <p className="text-[11px] text-muted">Configure skills, prompts &amp; MCP</p>
             </div>
             {/* Mobile close */}
@@ -470,7 +470,7 @@ export function SkillsAdminPanel({ onClose, useCase = "generic", useCases = [], 
               <select
                 value={useCase}
                 onChange={(e) => onSelectUseCase?.(e.target.value)}
-                className="w-full text-sm text-text-strong bg-hover border border-border-soft rounded-lg pl-3 pr-9 py-2.5 focus:outline-none focus:ring-1 focus:ring-accent focus:border-accent appearance-none cursor-pointer hover:bg-hover hover:border-white/[0.14] transition-all"
+                className="w-full text-sm text-text-strong bg-hover border border-border-soft rounded-lg pl-3 pr-9 py-2.5 focus:outline-none focus:ring-1 focus:ring-accent focus:border-accent appearance-none cursor-pointer hover:bg-hover hover:border-border transition-all"
               >
                 {useCases.map((uc) => (
                   <option key={uc.name} value={uc.name} className="bg-surface-2">
@@ -497,11 +497,11 @@ export function SkillsAdminPanel({ onClose, useCase = "generic", useCases = [], 
               onClick={() => { setTab(item.id); setMobileNavOpen(false); setEditingSkill(null); setShowCreate(false); setEditingMcp(null); setShowMcpCreate(false); }}
               className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm transition-all duration-150 ${
                 tab === item.id
-                  ? "bg-white/[0.12] text-white font-medium"
-                  : "text-slate-300 hover:text-white hover:bg-white/[0.06]"
+                  ? "bg-hover text-text-strong font-medium"
+                  : "text-muted hover:text-text-strong hover:bg-hover"
               }`}
             >
-              <span className={tab === item.id ? "text-primary-400" : "text-slate-400"}>
+              <span className={tab === item.id ? "text-accent" : "text-muted"}>
                 {renderNavIcon(item.icon)}
               </span>
               {item.label}
@@ -641,7 +641,7 @@ export function SkillsAdminPanel({ onClose, useCase = "generic", useCases = [], 
             /* ── MCP Servers tab ── */
             mcpLoading ? (
               <div className="flex items-center justify-center py-12">
-                <div className="animate-spin rounded-full h-8 w-8 border-2 border-accent border-t-primary-600" />
+                <div className="animate-spin rounded-full h-8 w-8 border-2 border-accent border-t-transparent" />
               </div>
             ) : editingMcp ? (
               /* ── MCP Edit view ── */
@@ -918,7 +918,7 @@ export function SkillsAdminPanel({ onClose, useCase = "generic", useCases = [], 
                 <div className="flex flex-col items-center justify-center py-16 animate-fade-in">
                   <div className="relative mb-6">
                     <div className="w-16 h-16 rounded-2xl bg-accent flex items-center justify-center">
-                      <div className="animate-spin rounded-full h-8 w-8 border-2 border-accent border-t-primary-500" />
+                      <div className="animate-spin rounded-full h-8 w-8 border-2 border-accent-fg/30 border-t-accent-fg" />
                     </div>
                   </div>
                   <p className="text-sm text-muted">Analyzing system prompt and {skills.length} skills for inconsistencies...</p>
@@ -1188,7 +1188,7 @@ export function SkillsAdminPanel({ onClose, useCase = "generic", useCases = [], 
               {/* Empty state */}
               {!analysisResult && !analysisLoading && (
                 <div className="flex flex-col items-center justify-center py-16">
-                  <div className="w-16 h-16 rounded-2xl bg-accent dark:from-primary-500/5 dark:to-cyan-500/5 flex items-center justify-center mb-4">
+                  <div className="w-16 h-16 rounded-2xl bg-accent-soft flex items-center justify-center mb-4">
                     <svg className="w-8 h-8 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
                     </svg>
@@ -1296,8 +1296,8 @@ export function SkillsAdminPanel({ onClose, useCase = "generic", useCases = [], 
                     key={skill.name}
                     className={`flex flex-col p-5 border rounded-2xl transition-all ${
                       isEditing
-                        ? "col-span-full border-primary-300 dark:border-primary-500/30 bg-white dark:bg-navy-800 shadow-lg ring-1 ring-primary-200 dark:ring-primary-500/20"
-                        : "border-slate-200 dark:border-white/[0.06] bg-white dark:bg-navy-800 hover:border-slate-300 dark:hover:border-white/[0.1] hover:shadow-card-hover group"
+                        ? "col-span-full border-accent bg-surface shadow-lg ring-1 ring-accent/30"
+                        : "border-border-soft bg-surface hover:border-border hover:shadow-card-hover group"
                     }`}
                   >
                     <div className="flex items-start justify-between gap-3 mb-3">
@@ -1331,7 +1331,7 @@ export function SkillsAdminPanel({ onClose, useCase = "generic", useCases = [], 
                       <button
                         onClick={() => handleToggle(skill)}
                         className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full transition-colors ${
-                          skill.enabled ? "bg-primary-600" : "bg-slate-300 dark:bg-slate-600"
+                          skill.enabled ? "bg-accent" : "bg-border"
                         }`}
                       >
                         <span

--- a/src/frontend/src/components/ThoughtChain.tsx
+++ b/src/frontend/src/components/ThoughtChain.tsx
@@ -112,7 +112,7 @@ function formatToolLabel(rawName: string): string {
 
 /** Colour palette for tool status badges */
 const STATUS_COLORS = {
-  started: { bg: "bg-primary-50", text: "text-primary-600", border: "border-primary-200", dot: "bg-primary-400" },
+  started: { bg: "bg-accent-soft", text: "text-accent", border: "border-accent", dot: "bg-accent" },
   completed: { bg: "bg-emerald-50", text: "text-emerald-600", border: "border-emerald-200", dot: "bg-emerald-400" },
   failed: { bg: "bg-red-50", text: "text-red-600", border: "border-red-200", dot: "bg-red-400" },
 } as const;
@@ -435,7 +435,7 @@ export function ThoughtChain({
         <div className="rounded-xl border border-border-soft bg-surface shadow-card dark:shadow-none overflow-hidden text-sm">
           <button
             onClick={() => setShowDetails(!showDetails)}
-            className="w-full flex items-center gap-2 px-4 py-2.5 hover:bg-slate-50/80 transition-colors cursor-pointer"
+            className="w-full flex items-center gap-2 px-4 py-2.5 hover:bg-hover transition-colors cursor-pointer"
           >
             <svg
               className="w-3.5 h-3.5 text-accent flex-shrink-0"
@@ -550,7 +550,7 @@ function MetricCell({
   };
 
   return (
-    <div className="rounded-xl border border-border-soft bg-slate-50/50 px-3 py-2.5 flex items-center gap-2.5">
+    <div className="rounded-xl border border-border-soft bg-surface-2 px-3 py-2.5 flex items-center gap-2.5">
       {iconSvg[icon]}
       <div>
         <div className="text-[10px] text-muted leading-tight font-medium">{label}</div>

--- a/src/frontend/src/components/TracesAdminPanel.tsx
+++ b/src/frontend/src/components/TracesAdminPanel.tsx
@@ -108,7 +108,7 @@ function SpanRow({ span, maxEndMs }: { span: TraceSpan; maxEndMs: number }) {
     <div>
       <button
         onClick={() => setExpanded((v) => !v)}
-        className="w-full flex items-center gap-2 px-4 py-2 hover:bg-slate-50/50 transition-colors text-left group"
+        className="w-full flex items-center gap-2 px-4 py-2 hover:bg-hover transition-colors text-left group"
       >
         <div style={{ width: indent, flexShrink: 0 }} />
         <SpanIcon category={span.category} />
@@ -266,7 +266,7 @@ function OperationRow({ op, lookbackHours }: { op: TraceOperation; lookbackHours
     <div className="border-b border-border-soft last:border-b-0">
       <button
         onClick={handleExpand}
-        className="w-full flex items-center gap-4 px-5 py-3.5 hover:bg-slate-50/50 transition-colors text-left"
+        className="w-full flex items-center gap-4 px-5 py-3.5 hover:bg-hover transition-colors text-left"
       >
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
@@ -294,10 +294,10 @@ function OperationRow({ op, lookbackHours }: { op: TraceOperation; lookbackHours
       </button>
 
       {expanded && (
-        <div className="border-t border-border-soft bg-slate-50/30">
+        <div className="border-t border-border-soft bg-surface-2">
           {loading ? (
             <div className="flex items-center justify-center py-8">
-              <div className="animate-spin rounded-full h-6 w-6 border-2 border-accent border-t-primary-600" />
+              <div className="animate-spin rounded-full h-6 w-6 border-2 border-accent border-t-transparent" />
             </div>
           ) : (
             <>
@@ -342,8 +342,8 @@ function OperationRow({ op, lookbackHours }: { op: TraceOperation; lookbackHours
                       onClick={() => setActiveFilter(null)}
                       className={`text-[10px] px-2 py-1 rounded-full font-medium transition-colors border ${
                         activeFilter === null
-                          ? "bg-primary-50 dark:bg-primary-500/15 text-primary-700 dark:text-primary-300 border-primary-200 dark:border-primary-500/30"
-                          : "bg-white dark:bg-white/[0.04] text-slate-500 dark:text-slate-400 border-slate-200 dark:border-white/[0.08] hover:border-slate-300"
+                          ? "bg-accent-soft text-accent border-accent"
+                          : "bg-surface text-muted border-border-soft hover:border-border"
                       }`}
                     >
                       all · {allSpans.length}
@@ -356,8 +356,8 @@ function OperationRow({ op, lookbackHours }: { op: TraceOperation; lookbackHours
                           onClick={() => setActiveFilter((cur) => (cur === cat ? null : cat))}
                           className={`text-[10px] px-2 py-1 rounded-full font-medium transition-colors flex items-center gap-1 border ${
                             activeFilter === cat
-                              ? "bg-primary-50 dark:bg-primary-500/15 text-primary-700 dark:text-primary-300 border-primary-200 dark:border-primary-500/30"
-                              : "bg-white dark:bg-white/[0.04] text-slate-500 dark:text-slate-400 border-slate-200 dark:border-white/[0.08] hover:border-slate-300"
+                              ? "bg-accent-soft text-accent border-accent"
+                              : "bg-surface text-muted border-border-soft hover:border-border"
                           }`}
                         >
                           <span>{spanCategoryEmoji[cat]}</span>
@@ -506,7 +506,7 @@ export function TracesAdminPanel({ useCase }: Props): JSX.Element {
       {/* Loading */}
       {loading && !traceData && (
         <div className="flex items-center justify-center py-16">
-          <div className="animate-spin rounded-full h-8 w-8 border-2 border-accent border-t-primary-600" />
+          <div className="animate-spin rounded-full h-8 w-8 border-2 border-accent border-t-transparent" />
         </div>
       )}
 
@@ -582,7 +582,7 @@ export function TracesAdminPanel({ useCase }: Props): JSX.Element {
             </div>
 
             {/* Category legend */}
-            <div className="flex flex-wrap gap-3 px-5 py-3 border-b border-border-soft bg-slate-50/30">
+            <div className="flex flex-wrap gap-3 px-5 py-3 border-b border-border-soft bg-surface-2">
               {(Object.entries(spanCategoryColors) as [SpanCategory, string][]).map(([cat, color]) => (
                 <div key={cat} className="flex items-center gap-1.5">
                   <div className={`w-2.5 h-2.5 rounded-sm ${color}`} />


### PR DESCRIPTION
## Problem

Several UI surfaces were near-unreadable, especially in dark mode. Two root causes:

1. **Undefined Tailwind tokens.** The frontend used \`primary-*\` and \`navy-*\` color classes that are **neither defined in \`tailwind.config.js\` nor in Tailwind's default palette**. JIT silently emits no CSS for these, so user message gradients went transparent, sidebar backgrounds vanished, and a lot of text inherited from invisible parents.
2. **Hardcoded light-mode card backgrounds.** Several panels used \`bg-slate-50/70\`, \`bg-slate-50/50\`, \`hover:bg-slate-100/80\`, etc. with **no \`dark:\` variant**. In dark mode these rendered as near-white cards while text adapted to dark theme tokens → white-on-white invisible text. APM was the worst case (37 unreadable elements).

## Fix

Replaced all broken/hardcoded color references with the semantic theme tokens already defined in \`globals.css\` (CSS variables) and bound in \`tailwind.config.js\`:

| Old (broken or hardcoded) | New (theme-aware) |
|---|---|
| \`from-primary-600 to-violet-600 shadow-primary-500/20\` | \`bg-gradient-to-br from-accent to-accent-hover text-accent-fg shadow-md\` |
| \`bg-navy-950\`, \`bg-navy-800\` | \`bg-surface-2\`, \`bg-surface\` |
| \`text-primary-400\`, \`text-primary-500\` | \`text-accent\`, \`text-text-strong\` |
| \`bg-slate-50/70\`, \`bg-slate-50/50\` | \`bg-surface-2\` |
| \`hover:bg-slate-50/50\`, \`hover:bg-slate-100/80\` | \`hover:bg-hover\` |
| \`bg-slate-200/80\` | \`bg-surface-2\` |
| \`border-t-primary-X\` (spinner) | \`border-t-transparent\` |

These tokens drive off CSS variables defined per theme in \`src/app/globals.css\`, so the fix works across all 8 themes in both light and dark mode without further changes.

## Verification

Ran an in-browser WCAG AA contrast auditor (4.5:1 threshold) against the live app with real backend data, walking every text node and checking it against its nearest opaque parent background.

| Surface | Before | After |
|---|---|---|
| Skills tab | many faded items | 0 |
| System Prompt | 0 | 0 |
| MCP Servers | 0 | 0 |
| **APM tab** | **37 invisible items** | **3** (tiny \`*\` markers at 3.95:1, acceptable for icon-sized markers) |
| Consistency | 0 | 0 |
| Evals | 0 | 0 |
| Traces | 0 | 0 |
| Main chat | 0 | 0 |
| BYOK Settings modal | 0 | 0 |
| How It Works modal | 1 (intentional decorative \`·\`) | 1 |

Also verified \`npx next build\` succeeds with no new warnings.

## Files changed

10 files, +61 / −61:
- \`MessageBubble.tsx\` — user/assistant bubble gradients and text colors
- \`ChatWindow.tsx\` — spinner, follow-up icon, focus ring, mobile menu hover
- \`SkillsAdminPanel.tsx\` — sidebar bg, nav items, spinners, skill card states, toggle
- \`TracesAdminPanel.tsx\` — spinners, filter chips, expanded row backgrounds
- \`EvalsAdminPanel.tsx\` — evaluator toggle, spinner, scenario list backgrounds
- \`ApmAdminPanel.tsx\` — spinner, MCP server cards, suggested packages, table row hovers, inline \`<code>\` chip
- \`GenerateScenariosModal.tsx\` — header icon, scenario card backgrounds
- \`ThoughtChain.tsx\` — \`started\` status palette, hover backgrounds, inline pill
- \`SettingsModal.tsx\` — footer bar background
- \`app/page.tsx\` — skip link, focus ring, sample question cards

## Out of scope (intentionally untouched)

Existing \`violet-*\`, \`purple-*\`, \`sky-*\`, \`slate-300+\` references that are valid Tailwind defaults and render legibly even if not theme-coupled (e.g. \`AgentLoop\` harness/plan palette, \`SourceBadge\` palette, \`ThoughtChain\` \`KIND_COLORS\`, hardcoded \`emerald\`/\`red\`/\`amber\` status colors). These don't cause contrast bugs in either mode — leaving them for a future theme-coupling pass.
