### PR TITLE
fix(ci): use builtin TimeoutError to unblock ruff UP041 and resume deploys

### DIFF
--- a/src/backend/app/services/foundry_agent_proxy.py
+++ b/src/backend/app/services/foundry_agent_proxy.py
@@ -155,7 +155,7 @@ class FoundryAgentProxy:
                                 payload.get("loaded_use_cases"),
                             )
                 return (ok, returned, resp.status, elapsed)
-        except (aiohttp.ClientError, asyncio.TimeoutError):
+        except (aiohttp.ClientError, TimeoutError):
             elapsed = loop.time() - t0
             logger.warning("Warm-pool ping failed after %.1fs", elapsed, exc_info=True)
             return (False, None, 0, elapsed)


### PR DESCRIPTION
## Why this PR exists

Every CI/CD Pipeline run on `main` has been failing **Lint & Static Analysis** since commit `5594712` (2026-06-08, *Add warm-pool for fast, isolated hosted-agent sessions*). Because the deploy jobs depend on that stage, every merge for the past 2 days has had **Deploy to Staging** and **Deploy to Production** silently **SKIPPED** rather than failing loudly.

Net effect: the hosted-agent environment is stale. Recently merged work — `#18` retail-banking-csr removal, `#19`–`#22` rebuilds (hr-onboarding, sales-account-review, it-service-desk, clinician-visit-prep), `#23` roadmap doc, `#24` plant-floor-supervisor — is on `main` but not deployed. That's why duplicate retail-banking journeys still show up in the live agent.

## What changes

```diff
-        except (aiohttp.ClientError, asyncio.TimeoutError):
+        except (aiohttp.ClientError, TimeoutError):
```

One line in `src/backend/app/services/foundry_agent_proxy.py:158`. In Python 3.11+ (`target-version = "py311"` in `pyproject.toml`), `asyncio.TimeoutError` is an alias for the builtin `TimeoutError`, so the swap is a no-op at runtime and the `asyncio` import stays (still used 4× elsewhere in the file). Ruff `UP041` is happy.

## How to verify

```bash
cd src/backend
ruff check app/services/foundry_agent_proxy.py   # All checks passed!
ruff check .                                     # All checks passed!
```

Verified locally with `uvx ruff 0.15.16` — both targeted file and full backend tree clean.

## What unblocks once merged

The next merge to `main` will run the full pipeline including **Deploy to Production** for the first time since 2026-06-08, picking up the entire backlog of merged persona work in one go.

## Open question for @kmavrodis

After this lands, does the auto-deploy fire on the merge itself, or does main need another commit (or a workflow_dispatch) to trigger the deploy? Worth a glance just to confirm the stale-environment problem actually clears.