### PR TITLE
fix(ci): apply ruff format to app/main.py — second blocker after PR #25

### DIFF
--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -174,9 +174,7 @@ async def lifespan(application: FastAPI) -> AsyncGenerator[None, None]:
     if settings.keep_warm_enabled and not settings.is_local_mode:
         import asyncio
 
-        keep_warm_task = asyncio.create_task(
-            _keep_warm_loop(foundry_proxy, settings.keep_warm_interval_s)
-        )
+        keep_warm_task = asyncio.create_task(_keep_warm_loop(foundry_proxy, settings.keep_warm_interval_s))
         logger.info(
             "Warm-pool task started — maintaining %d pre-warmed sandboxes, refresh every %ds",
             settings.warm_pool_size,


### PR DESCRIPTION
## Why this PR exists

PR #25 cleared the `UP041` lint error, so I expected the next merge to main to run the full pipeline. It didn't — the `Lint & Static Analysis` job ran further this time but failed at the **format-check** step, on the same warm-pool commit (`5594712`).

```
Would reformat: app/main.py
1 file would be reformatted, 37 files already formatted
```

## What changes

```diff
-        keep_warm_task = asyncio.create_task(
-            _keep_warm_loop(foundry_proxy, settings.keep_warm_interval_s)
-        )
+        keep_warm_task = asyncio.create_task(_keep_warm_loop(foundry_proxy, settings.keep_warm_interval_s))
```

One line in `src/backend/app/main.py`. The two-line form is 106 chars when joined, well under the project's `line-length = 120`, so `ruff format` wants it on a single line. Purely cosmetic, zero runtime impact.

## How to verify

```bash
cd src/backend
ruff check .                    # All checks passed!
ruff format --check .           # 38 files already formatted
```

Verified locally with `uvx ruff 0.15.16` — both clean.

## Context: this is the second of N blockers

Worth flagging for @kmavrodis: looking at the run history, **the CI/CD Pipeline has never had a successful run on main** going back to 2026-05-20. Every commit fails the same job. Recent merges (#18 csr removal, #19–#22 rebuilds, #23 roadmap, #24 plant-floor-supervisor, #25 my UP041 fix) all merged green-ish but with `Deploy to Staging`/`Deploy to Production` silently **SKIPPED** because lint failed before them.

That's why the live env still shows the pre-#18 set of journeys (with the duplicate `retail-banking-csr`, missing `plant-floor-supervisor`, etc.) — none of the recent merges have been deployed.

This PR is one more step toward a clean pipeline run. Once it lands, the next push to main should be the first one to actually reach **Deploy to Production**. If anything else fails after this in Unit Tests / Build / Deploy stages, I'll keep iterating, but it's worth a glance whether a manual `azd up` or workflow_dispatch is faster to bridge the gap.