### PR TITLE
Fix exported agent `azd up` on Windows: cross-platform azd hooks

### DIFF
--- a/src/backend/app/exporter_templates/README.md.template
+++ b/src/backend/app/exporter_templates/README.md.template
@@ -57,12 +57,13 @@ azd up
 2. **Builds** the agent container via ACR remoteBuild
 3. **Registers** the hosted agent on the Foundry project via the
    `azure.ai.agents` extension
-4. **Runs `hooks/postdeploy.sh`** to grant the data-plane RBAC roles
-   (`AcrPull`, `Cognitive Services OpenAI User`, `Cognitive Services User`)
-   to the hosted-agent's instance + blueprint managed identities. These
-   identities are created by Foundry **after** Bicep provisioning, so they
-   can't be granted via Bicep — the hook discovers them via
-   `azd ai agent show` and runs `az role assignment create`.
+4. **Runs the post-deploy RBAC hook** (`hooks/postdeploy.sh` on Linux/macOS,
+   `hooks/postdeploy.ps1` on Windows — azd picks the right one) to grant the
+   data-plane roles (`AcrPull`, `Cognitive Services OpenAI User`,
+   `Cognitive Services User`, `Foundry User`) to the hosted-agent's instance +
+   blueprint managed identities. These identities are created by Foundry
+   **after** Bicep provisioning, so they can't be granted via Bicep — the hook
+   discovers them via `azd ai agent show` and runs `az role assignment create`.
 5. **Prints** an Agent Playground URL
 
 > **Note:** If the first invocation reports `agent_version_failed` with

--- a/src/backend/app/exporter_templates/azure.yaml.template
+++ b/src/backend/app/exporter_templates/azure.yaml.template
@@ -47,38 +47,62 @@ services:
 
 hooks:
     predeploy:
-        name: predeploy
-        kind: sh
-        shell: sh
-        run: |
-            BUILD_TS="$$(date +%s)"
-            azd env set KRATOS_BUILD_TS "$$BUILD_TS"
-            echo "KRATOS_BUILD_TS=$$BUILD_TS (forces new hosted-agent version)"
+        posix:
+            shell: sh
+            run: |
+                BUILD_TS="$$(date +%s)"
+                azd env set KRATOS_BUILD_TS "$$BUILD_TS"
+                echo "KRATOS_BUILD_TS=$$BUILD_TS (forces new hosted-agent version)"
+        windows:
+            shell: pwsh
+            run: |
+                $$BuildTs = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+                azd env set KRATOS_BUILD_TS "$$BuildTs"
+                Write-Host "KRATOS_BUILD_TS=$$BuildTs (forces new hosted-agent version)"
     preprovision:
-        name: preprovision
-        kind: sh
-        shell: sh
-        run: echo "Provisioning Azure resources for ${name}..."
+        posix:
+            shell: sh
+            run: echo "Provisioning Azure resources for ${name}..."
+        windows:
+            shell: pwsh
+            run: Write-Host "Provisioning Azure resources for ${name}..."
     postprovision:
-        name: postprovision
-        kind: sh
-        shell: sh
-        run: |
-            # azure.ai.agents extension requires AZURE_TENANT_ID in env to
-            # auto-assign Foundry User to the agent identity. Set it from
-            # the current Azure CLI session if it isn't already set.
-            if [ -z "$${AZURE_TENANT_ID:-}" ]; then
-                TID="$$(az account show --query tenantId -o tsv 2>/dev/null || true)"
-                if [ -n "$$TID" ]; then
-                    azd env set AZURE_TENANT_ID "$$TID"
-                    echo "Set AZURE_TENANT_ID=$$TID"
+        posix:
+            shell: sh
+            run: |
+                # azure.ai.agents extension requires AZURE_TENANT_ID in env to
+                # auto-assign Foundry User to the agent identity. Set it from
+                # the current Azure CLI session if it isn't already set.
+                if [ -z "$${AZURE_TENANT_ID:-}" ]; then
+                    TID="$$(az account show --query tenantId -o tsv 2>/dev/null || true)"
+                    if [ -n "$$TID" ]; then
+                        azd env set AZURE_TENANT_ID "$$TID"
+                        echo "Set AZURE_TENANT_ID=$$TID"
+                    fi
                 fi
-            fi
-            echo "Post-provisioning complete."
-            echo "Run 'azd deploy' to publish the hosted agent."
+                echo "Post-provisioning complete."
+                echo "Run 'azd deploy' to publish the hosted agent."
+        windows:
+            shell: pwsh
+            run: |
+                # azure.ai.agents extension requires AZURE_TENANT_ID in env to
+                # auto-assign Foundry User to the agent identity. Set it from
+                # the current Azure CLI session if it isn't already set.
+                if (-not $$env:AZURE_TENANT_ID) {
+                    $$Tid = (az account show --query tenantId -o tsv 2>$$null)
+                    if ($$Tid) {
+                        azd env set AZURE_TENANT_ID "$$Tid"
+                        Write-Host "Set AZURE_TENANT_ID=$$Tid"
+                    }
+                }
+                Write-Host "Post-provisioning complete."
+                Write-Host "Run 'azd deploy' to publish the hosted agent."
     postdeploy:
-        name: postdeploy
-        kind: sh
-        shell: sh
-        run: ./hooks/postdeploy.sh
-        interactive: true
+        posix:
+            shell: sh
+            run: ./hooks/postdeploy.sh
+            interactive: true
+        windows:
+            shell: pwsh
+            run: ./hooks/postdeploy.ps1
+            interactive: true

--- a/src/backend/app/exporter_templates/hooks/postdeploy.ps1.template
+++ b/src/backend/app/exporter_templates/hooks/postdeploy.ps1.template
@@ -1,0 +1,145 @@
+#!/usr/bin/env pwsh
+# Post-deploy hook for ${name} (Kratos-exported Foundry Hosted Agent).
+#
+# PowerShell port of postdeploy.sh for Windows hosts (azd selects this via the
+# `windows:` hook variant in azure.yaml). Foundry creates two managed
+# identities for each hosted agent — the *instance* identity (used by the
+# running container) and the *blueprint* identity (used by the agent control
+# plane). These identities are created **after** Bicep provisioning, so
+# bicep-based RBAC can't grant them roles directly. This hook runs after
+# `azd deploy` registers the agent, queries the identities from the Foundry
+# control plane, and grants the data-plane roles the Kratos runtime needs.
+#
+# Roles are pinned by GUID (not display name) because Azure rotates the
+# display names — e.g. "Azure AI User" was renamed "Foundry User" in May
+# 2026 while the GUID stayed identical. The GUID call-site survives further
+# rotations.
+#
+# The hook is idempotent — re-running it is safe.
+
+$$ErrorActionPreference = "Stop"
+
+Write-Host ""
+Write-Host "=============================================================="
+Write-Host "       Granting RBAC to hosted-agent identities"
+Write-Host "=============================================================="
+
+# Role definition GUIDs (pin by GUID, not name — survives rename).
+# Source: foundry-hosted-agents SKILL.md section Identity & RBAC
+$$AcrPullRole             = "7f951dda-4ed3-4680-a7ca-43fe172d538d"  # AcrPull
+$$CognitiveOpenAiUserRole = "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd"  # Cognitive Services OpenAI User
+$$CognitiveUserRole       = "a97b65f3-24c7-4388-baec-2e87135dc908"  # Cognitive Services User
+$$FoundryUserRole         = "53ca6127-db72-4b80-b1b0-d745d6d5456d"  # Foundry User (formerly Azure AI User)
+
+# Discover the identities from `azd ai agent show` (JSON output).
+$$AgentRaw = (azd ai agent show 2>$$null | Out-String)
+$$AgentJson = $$null
+$$JsonStart = $$AgentRaw.IndexOf("{")
+$$JsonEnd = $$AgentRaw.LastIndexOf("}")
+if ($$JsonStart -ge 0 -and $$JsonEnd -gt $$JsonStart) {
+    try {
+        $$AgentJson = $$AgentRaw.Substring($$JsonStart, $$JsonEnd - $$JsonStart + 1) | ConvertFrom-Json
+    } catch {
+        $$AgentJson = $$null
+    }
+}
+if ($$null -eq $$AgentJson) {
+    Write-Host "WARNING: Couldn't read agent state from 'azd ai agent show'. Skipping RBAC."
+    exit 0
+}
+
+$$InstancePrincipal = $$AgentJson.instance_identity.principal_id
+$$BlueprintPrincipal = $$AgentJson.blueprint.principal_id
+
+if (-not $$InstancePrincipal) {
+    Write-Host "WARNING: Couldn't extract instance_identity.principal_id. Skipping RBAC."
+    exit 0
+}
+
+Write-Host "Instance identity:  $$InstancePrincipal"
+if ($$BlueprintPrincipal) {
+    Write-Host "Blueprint identity: $$BlueprintPrincipal"
+} else {
+    Write-Host "Blueprint identity: (none)"
+}
+Write-Host ""
+
+# Resolve scopes from the azd environment.
+$$Sub = $$env:AZURE_SUBSCRIPTION_ID
+$$Rg = $$env:AZURE_RESOURCE_GROUP
+$$AcrName = $$env:AZURE_CONTAINER_REGISTRY_NAME
+$$AiProjectId = $$env:AZURE_AI_PROJECT_ID
+$$AiAccountName = $$env:AZURE_AI_ACCOUNT_NAME
+
+# Derive parent Foundry account ID from the project ID if not already known.
+$$AiAccountId = $$AiProjectId -replace "/projects/[^/]*$$", ""
+if (-not $$AiAccountName) {
+    $$AiAccountName = ($$AiAccountId -split "/")[-1]
+}
+$$AcrId = "/subscriptions/$$Sub/resourceGroups/$$Rg/providers/Microsoft.ContainerRegistry/registries/$$AcrName"
+
+function Invoke-RoleGrant {
+    param(
+        [string] $$PrincipalId,
+        [string] $$Role,
+        [string] $$Scope,
+        [string] $$Label
+    )
+    if (-not $$PrincipalId -or -not $$Scope) { return }
+    az role assignment create `
+        --assignee-object-id $$PrincipalId `
+        --assignee-principal-type ServicePrincipal `
+        --role $$Role `
+        --scope $$Scope `
+        --output none 2>$$null
+    $$Short = $$PrincipalId.Substring(0, [Math]::Min(8, $$PrincipalId.Length))
+    if ($$LASTEXITCODE -eq 0) {
+        Write-Host "  [ok]   $$Short... -> $$Label"
+    } else {
+        Write-Host "  [skip] $$Short... -> $$Label (exists / skip)"
+    }
+}
+
+# -- 1. Grant AcrPull to the Foundry PROJECT MI (the actual image-puller). --
+# Per foundry-hosted-agents skill: the project system MI is what pulls the
+# hosted-agent container image, NOT the account MI. Bicep already grants both
+# AcrPull at provision time, but we re-grant here as belt-and-braces in case
+# the project MI was recreated between provision and deploy.
+$$ProjectMi = (az resource show --ids $$AiProjectId --api-version 2025-04-01-preview --query identity.principalId -o tsv 2>$$null)
+if ($$ProjectMi) {
+    Write-Host "Foundry project MI: $$ProjectMi"
+    Invoke-RoleGrant -PrincipalId $$ProjectMi -Role $$AcrPullRole -Scope $$AcrId -Label "AcrPull"
+}
+
+# -- 2. Grant data-plane roles to BOTH instance + blueprint identities. --
+# Kratos calls AOAI directly via CopilotClient -> needs Cognitive Services
+# OpenAI User on the account. We also grant Foundry User on both scopes in
+# case the runtime needs project-scoped data-plane access (e.g. for session
+# storage, tool discovery via the Foundry control plane).
+foreach ($$Principal in @($$InstancePrincipal, $$BlueprintPrincipal)) {
+    if (-not $$Principal) { continue }
+
+    # Container image pull (Foundry pulls the hosted-agent image from ACR).
+    Invoke-RoleGrant -PrincipalId $$Principal -Role $$AcrPullRole -Scope $$AcrId -Label "AcrPull"
+
+    # Direct AOAI invocations (Kratos's CopilotClient path).
+    Invoke-RoleGrant -PrincipalId $$Principal -Role $$CognitiveOpenAiUserRole -Scope $$AiAccountId -Label "Cognitive Services OpenAI User"
+    Invoke-RoleGrant -PrincipalId $$Principal -Role $$CognitiveOpenAiUserRole -Scope $$AiProjectId -Label "Cognitive Services OpenAI User"
+
+    # Cognitive Services basic data-plane (token issuance, model listing).
+    Invoke-RoleGrant -PrincipalId $$Principal -Role $$CognitiveUserRole -Scope $$AiAccountId -Label "Cognitive Services User"
+    Invoke-RoleGrant -PrincipalId $$Principal -Role $$CognitiveUserRole -Scope $$AiProjectId -Label "Cognitive Services User"
+
+    # Foundry-mediated data-plane (required by post-rename data plane,
+    # surfaces as 401 if missing — see foundry-hosted-agents SKILL.md).
+    Invoke-RoleGrant -PrincipalId $$Principal -Role $$FoundryUserRole -Scope $$AiAccountId -Label "Foundry User"
+    Invoke-RoleGrant -PrincipalId $$Principal -Role $$FoundryUserRole -Scope $$AiProjectId -Label "Foundry User"
+}
+
+Write-Host ""
+Write-Host "RBAC complete."
+Write-Host ""
+Write-Host "Note: RBAC propagation takes 5-15 minutes for newly-created"
+Write-Host "service principals. If 'azd ai agent invoke' returns 401/403,"
+Write-Host "wait ~10 minutes, then retry. If still failing after 15 minutes,"
+Write-Host "run 'azd deploy' again to publish a new agent version."

--- a/src/backend/app/services/project_exporter.py
+++ b/src/backend/app/services/project_exporter.py
@@ -102,8 +102,13 @@ _HOSTED_AGENT_TEMPLATE_FILES: tuple[tuple[str, str], ...] = (
 )
 
 # Templates rendered into ``hooks/`` at the project root. These are azd
-# lifecycle hooks (currently just ``postdeploy.sh``) and need exec bit set.
-_HOOKS_TEMPLATE_FILES: tuple[tuple[str, str], ...] = (("hooks/postdeploy.sh.template", "postdeploy.sh"),)
+# lifecycle hooks (``postdeploy``) and need the exec bit set on the POSIX
+# variant. A PowerShell sibling ships alongside so ``azd up`` also works on
+# Windows (azd picks the OS-specific variant declared in ``azure.yaml``).
+_HOOKS_TEMPLATE_FILES: tuple[tuple[str, str], ...] = (
+    ("hooks/postdeploy.sh.template", "postdeploy.sh"),
+    ("hooks/postdeploy.ps1.template", "postdeploy.ps1"),
+)
 
 # Subset of templates that need ``${placeholder}`` substitution.
 _PARAMETERIZED: frozenset[str] = frozenset(
@@ -114,6 +119,7 @@ _PARAMETERIZED: frozenset[str] = frozenset(
         "agent.yaml.template",
         "agent.manifest.yaml.template",
         "hooks/postdeploy.sh.template",
+        "hooks/postdeploy.ps1.template",
     }
 )
 

--- a/src/backend/tests/test_project_exporter.py
+++ b/src/backend/tests/test_project_exporter.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+import yaml
 from fastapi.testclient import TestClient
 
 from app.services.project_exporter import ProjectExporter, _slugify
@@ -296,6 +297,57 @@ def test_assemble_writes_postdeploy_hook_with_exec_bit(exporter: ProjectExporter
     assert "./hooks/postdeploy.sh" in azyaml
 
 
+def test_assemble_azure_yaml_hooks_are_cross_platform(exporter: ProjectExporter, tmp_path: Path):
+    """Every azd hook must ship POSIX *and* Windows variants.
+
+    Regression test for the Windows ``azd up`` failure: the exported hooks
+    used to be ``shell: sh`` only, so on Windows (no bash/sh) azd could not
+    run them. Each hook now declares a ``posix:`` (sh) and ``windows:``
+    (pwsh) configuration.
+    """
+    out = tmp_path / "out"
+    out.mkdir()
+    exporter.assemble("finance-close", out)
+
+    doc = yaml.safe_load((out / "azure.yaml").read_text())
+    hooks = doc["hooks"]
+    for event in ("predeploy", "preprovision", "postprovision", "postdeploy"):
+        assert event in hooks, f"missing hook: {event}"
+        assert "posix" in hooks[event], f"{event} missing posix variant"
+        assert "windows" in hooks[event], f"{event} missing windows variant"
+        assert hooks[event]["posix"]["shell"] == "sh"
+        assert hooks[event]["windows"]["shell"] == "pwsh"
+
+    # postdeploy points at the matching script per OS.
+    assert hooks["postdeploy"]["posix"]["run"] == "./hooks/postdeploy.sh"
+    assert hooks["postdeploy"]["windows"]["run"] == "./hooks/postdeploy.ps1"
+    # Non-schema ``name:`` key must be gone (azure.yaml schema forbids it).
+    assert "name:" not in (out / "azure.yaml").read_text().split("hooks:", 1)[1]
+
+
+def test_assemble_writes_windows_postdeploy_hook(exporter: ProjectExporter, tmp_path: Path):
+    """A PowerShell RBAC hook must ship so ``azd up`` works on Windows."""
+    out = tmp_path / "out"
+    out.mkdir()
+    exporter.assemble("finance-close", out)
+
+    hook = out / "hooks" / "postdeploy.ps1"
+    assert hook.is_file(), "hooks/postdeploy.ps1 must be rendered for Windows"
+    content = hook.read_text()
+
+    # Same RBAC behaviour as the bash hook: discover identities + grant roles.
+    assert "azd ai agent show" in content
+    assert "az role assignment create" in content
+    # Role GUIDs are pinned identically to the bash hook.
+    assert "7f951dda-4ed3-4680-a7ca-43fe172d538d" in content  # AcrPull
+    assert "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd" in content  # Cognitive Services OpenAI User
+    assert "53ca6127-db72-4b80-b1b0-d745d6d5456d" in content  # Foundry User
+
+    # Persona name substituted; no leftover azure.yaml ``$$`` escapes.
+    assert "Finance Close Controller" in content
+    assert "$$" not in content, "ps1 should be plain PowerShell (no $$ azure.yaml escapes)"
+
+
 def test_assemble_unknown_use_case_raises(exporter: ProjectExporter, tmp_path: Path):
     out = tmp_path / "out"
     out.mkdir()
@@ -347,6 +399,18 @@ def test_build_zip_includes_all_expected_paths(exporter: ProjectExporter, tmp_pa
     assert not any("__pycache__" in n for n in names)
     assert not any("evals/" in n for n in names)
     assert not any("exporter_templates" in n for n in names)
+
+
+def test_build_zip_includes_windows_hook(exporter: ProjectExporter, tmp_path: Path):
+    """Both the POSIX and Windows postdeploy hooks must land in the zip."""
+    out = tmp_path / "out"
+    out.mkdir()
+    exporter.assemble("finance-close", out)
+    blob = ProjectExporter.build_zip(out)
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        names = set(zf.namelist())
+    assert "hooks/postdeploy.sh" in names
+    assert "hooks/postdeploy.ps1" in names
 
 
 def test_build_zip_skips_other_use_cases(exporter: ProjectExporter, tmp_path: Path):


### PR DESCRIPTION
## What & why

Fixes #28.

The per-use-case **"Download as Foundry Agent"** export shipped azd hooks that were POSIX/bash-only, so `azd up` on the exported project failed on Windows:

- Every hook in `azure.yaml` used `kind: sh` / `shell: sh` with **no Windows variant**. On Windows, `azd` has no `sh`/bash and falls back to `pwsh`, so the inline hooks (`date +%s`, `[ -z ... ]`, `az ... -o tsv`) couldn't run.
- `hooks/postdeploy.sh` is hard bash (`#!/usr/bin/env bash`, `set -euo pipefail`, `sed`, `python3`).

## Changes

- **`azure.yaml.template`** — restructure all four hooks (`predeploy`, `preprovision`, `postprovision`, `postdeploy`) into OS-specific `posix:` (sh) and `windows:` (pwsh) variants, per the [azd hooks schema](https://learn.microsoft.com/azure/developer/azure-developer-cli/azd-extensibility). Also drops the non-schema `name:`/`kind:` keys (the `hook` schema is `additionalProperties: false`).
- **`hooks/postdeploy.ps1.template`** (new) — PowerShell port of the RBAC fixup hook: same role GUIDs, same `azd ai agent show` discovery, same `az role assignment create` grants to the instance + blueprint identities.
- **`project_exporter.py`** — render `postdeploy.ps1` alongside `postdeploy.sh` (`_HOOKS_TEMPLATE_FILES` + `_PARAMETERIZED`).
- **`README.md.template`** — note the OS-specific post-deploy hook.

azd automatically picks the matching variant per OS, so Linux/macOS behaviour is unchanged.

## Tests (TDD)

Added 3 tests (written first, watched fail, then implemented):

- `test_assemble_azure_yaml_hooks_are_cross_platform` — every hook has `posix:` + `windows:` variants with the right shells; `postdeploy` points at the matching `.sh`/`.ps1`; no `name:` key.
- `test_assemble_writes_windows_postdeploy_hook` — `hooks/postdeploy.ps1` renders with the pinned role GUIDs, `azd ai agent show`, `az role assignment create`, persona substituted, no leftover `$$` template escapes.
- `test_build_zip_includes_windows_hook` — the zip bundles both hook scripts.

All **36 backend tests pass**; `ruff check` clean.

> Note: `pwsh` wasn't available in the dev env to parse the script, so the `.ps1` was validated structurally (balanced braces/quotes, no reserved `$PID` assignment, no leftover template escapes) and by careful review against the proven bash original.