### PR TITLE
Persona import API + sub-path/embed hosting for Kratos

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -50,6 +50,20 @@ services:
                       echo "{\"apiUrl\":\"${AGENT_SERVICE_URL}\"}" > out/config.json
                       echo "Injected config.json with apiUrl=${AGENT_SERVICE_URL}"
                     fi
+                    # Emit a basePath-aware staticwebapp.config.json into out/ so the
+                    # SWA EasyAuth 401 redirect + /api/* gating stay inside the mount
+                    # path (e.g. /kratos) when hosted behind Front Door. Empty base
+                    # path → straight copy (standalone root deployment).
+                    BP="$(printf '%s' "${NEXT_PUBLIC_BASE_PATH:-}" | sed 's#/*$##')"
+                    if [ -f staticwebapp.config.json ]; then
+                      if [ -n "$BP" ]; then
+                        sed "s#/.auth/login/aad#${BP}/.auth/login/aad#g; s#\"/api/\*\"#\"${BP}/api/*\"#g" \
+                          staticwebapp.config.json > out/staticwebapp.config.json
+                        echo "Wrote basePath-aware staticwebapp.config.json (basePath=${BP})"
+                      else
+                        cp staticwebapp.config.json out/staticwebapp.config.json
+                      fi
+                    fi
 hooks:
     postdeploy:
         name: postdeploy

--- a/azure.yaml
+++ b/azure.yaml
@@ -46,7 +46,18 @@ services:
                 kind: sh
                 shell: sh
                 run: |
-                    if [ -n "${AGENT_SERVICE_URL}" ]; then
+                    # config.json tells the static frontend where the backend API is.
+                    # When hosted behind Front Door under a sub-path (NEXT_PUBLIC_BASE_PATH,
+                    # e.g. /kratos), the embedded UI calls the backend SAME-ORIGIN at
+                    # <basePath>/api/* — Front Door routes /kratos/api/* to the Container
+                    # App (stripping the /kratos prefix). This avoids CORS entirely.
+                    # In standalone (root) deployments there is no sub-path, so we point
+                    # config.json at the backend's own URL (AGENT_SERVICE_URL).
+                    BP="$(printf '%s' "${NEXT_PUBLIC_BASE_PATH:-}" | sed 's#/*$##')"
+                    if [ -n "$BP" ]; then
+                      echo "{\"apiUrl\":\"${BP}\"}" > out/config.json
+                      echo "Injected same-origin config.json with apiUrl=${BP} (behind Front Door)"
+                    elif [ -n "${AGENT_SERVICE_URL}" ]; then
                       echo "{\"apiUrl\":\"${AGENT_SERVICE_URL}\"}" > out/config.json
                       echo "Injected config.json with apiUrl=${AGENT_SERVICE_URL}"
                     fi
@@ -54,7 +65,6 @@ services:
                     # SWA EasyAuth 401 redirect + /api/* gating stay inside the mount
                     # path (e.g. /kratos) when hosted behind Front Door. Empty base
                     # path → straight copy (standalone root deployment).
-                    BP="$(printf '%s' "${NEXT_PUBLIC_BASE_PATH:-}" | sed 's#/*$##')"
                     if [ -f staticwebapp.config.json ]; then
                       if [ -n "$BP" ]; then
                         sed "s#/.auth/login/aad#${BP}/.auth/login/aad#g; s#\"/api/\*\"#\"${BP}/api/*\"#g" \

--- a/docs/superpowers/specs/2026-06-17-kratos-persona-import-embed-design.md
+++ b/docs/superpowers/specs/2026-06-17-kratos-persona-import-embed-design.md
@@ -314,21 +314,83 @@ site could `POST` import directly and arrive with just `?persona=<name>` — "Va
 
 ---
 
-## 8. Secondary PR — agentic-loop-site (separate session)
+## 8. Secondary PR — agentic-loop-site (full plan)
 
-Captured here for completeness; **implemented in a separate session/worktree**, not this one.
+Lands in the **`agentic-loop-site` repo** (`~/Repos/agentic-loop-site`) on its **own
+branch/PR** — it is a different repository from this Kratos worktree, so it cannot be
+committed here, but it is fully planned below and tracked alongside the Kratos PR.
 
-- Replace the **mock** Kratos integration (`src/pages/Kratos.tsx`,
-  `src/components/KratosChatMock.tsx`, `src/data/kratos.ts` `mockKratosReply`) with:
-  - a **"Describe your agent" generate box** that **builds the threadlight-compatible
-    manifest** in the site (reusing the `GreenfieldBuilder` / `advisor.ts` "Make it real"
-    pattern, repurposed to persona intent), and
-  - the **import-then-settle** handoff (§10.1 Variant B / D9): the site writes the manifest
-    to `sessionStorage['kratos.import']` (§7.1) and navigates to `/kratos/?embed=1&theme=<t>&import=1`;
-    Kratos imports on entry (after its own EasyAuth) and settles on `?persona=<name>`.
-- Add the **Front Door** profile + routes that path-mount Kratos under `/kratos/*`
-  (per §6.3–6.4), including `/kratos/.auth/*` and `/kratos/api/*`.
-- No Kratos files are copied — the mount serves the live Kratos SWA.
+**Repo facts (verified):** Vite + React 19 SPA, `BrowserRouter` (`src/main.tsx`), deployed to
+Azure **Static Web App** `agentic-loop` (`rg-agentic-loop`) via `deploy.ps1` (SWA CLI). **No
+IaC and no `staticwebapp.config.json` today.** The "generate" surface today is
+`src/components/GreenfieldBuilder.tsx` → `src/data/advisor.ts` (`buildAdvisorPackage` →
+`AdvisorPackage`) → `src/components/MakeItRealModal.tsx` (a *copy-a-Copilot-prompt* handoff —
+**no manifest, no backend call**). The Kratos surface is **fully mocked**:
+`src/pages/Kratos.tsx`, `src/components/KratosLauncher.tsx`, `src/components/KratosChatMock.tsx`,
+`src/data/kratos.ts` (`KRATOS_PERSONAS`, `mockKratosReply`).
+
+### 8.1 Workstream S-A — Persona manifest builder (NL → threadlight manifest)
+
+- **New `src/data/manifest.ts`** — `buildPersonaManifest({ intent, requirementIds, name? })`
+  that maps the free-text intent + `inferRequirementsFromSelections(...)` (reuse `advisor.ts`)
+  → a **threadlight-design-compatible manifest object** (the §9 contract: `name`,
+  `description`, `instructions`, `skills[]`, `mcpServers`/`tools`, `traits[]`,
+  `workflow_model:'agent'`). The TS type mirrors the Kratos Pydantic import model field-for-field.
+- **NL→manifest is the site's job (D2).** Primary mapping is **deterministic** (regex/intent
+  hints already in `advisor.ts`), matching Kratos's deterministic import. The site **may**
+  optionally call its own advisor/LLM to enrich `instructions`/`description` — that choice is
+  the site's, and the manifest it emits is the contract Kratos consumes.
+- **New `src/components/PersonaBuilder.tsx`** (or a persona mode added to `GreenfieldBuilder`):
+  a "Describe your agent" box + a **"Create in Kratos"** CTA that produces the manifest and
+  triggers the handoff (S-B). The existing `MakeItRealModal` "copy a Copilot prompt" path stays
+  for the app-scaffolding use case; persona creation is a distinct, shorter path.
+
+### 8.2 Workstream S-B — Generate → import handoff (Variant B / §10.1)
+
+- **New `src/lib/kratosHandoff.ts`** — `relayAndOpen(manifest, { theme })`:
+  1. `sessionStorage.setItem('kratos.import', JSON.stringify(manifest))` (§7.1 relay key),
+  2. `window.location.assign(`${KRATOS_BASE}/?embed=1&import=1&theme=${theme}`)`.
+- **Full-page navigation, not `react-router`** — `/kratos/*` is served by the **Kratos** app
+  via Front Door, so the handoff must leave the SPA (`window.location.assign`), never
+  `navigate('/kratos')`. `KRATOS_BASE` comes from `import.meta.env.VITE_KRATOS_BASE`
+  (default `/kratos`).
+- Kratos imports on entry after its own EasyAuth, then settles on `?persona=<name>` (§7.1).
+
+### 8.3 Workstream S-C — Replace the mock with the embedded real Kratos
+
+- **Route-collision fix (required).** The site's `react-router` route `path="kratos"`
+  (`src/main.tsx`) **collides** with the Front Door `/kratos/*` mount (the edge routes
+  `/kratos/*` to the Kratos SWA, so the site SPA never renders its own `/kratos`). **Rename the
+  site's Kratos *marketing* route** (e.g. `/reference/kratos` or `/kratos-about`) and update the
+  `Sidebar` link. The bare `/kratos/*` namespace is reserved for the embedded app.
+- **`KratosLauncher.tsx`** — replace `navigate('/kratos', { state })` with a **deep-link into
+  the embedded app**: `window.location.assign(`${KRATOS_BASE}/?embed=1&persona=${personaId}&prompt=${encodeURIComponent(prompt)}&theme=${theme}`)`.
+- **`Kratos.tsx`** (now at the renamed marketing path) — keep the marketing/"why this
+  architecture" content; route its "try it" CTAs into the embedded app. Remove the
+  `KratosChatMock` render branch.
+- **Retire the mock** — delete `KratosChatMock.tsx` and `mockKratosReply` from `kratos.ts`.
+  Keep a static `KRATOS_PERSONAS` list for the launcher dropdown (or, optional enhancement,
+  fetch live personas from `${KRATOS_BASE}/api/use-cases`).
+
+### 8.4 Workstream S-D — Front Door infra + site deploy
+
+- **New `infra/frontdoor.bicep`** (the site has no IaC today) provisioning an **Azure Front
+  Door** profile + endpoint with two origins (site SWA, Kratos SWA) and routes, in priority
+  order: `/kratos/.auth/*` and `/kratos/api/*` and `/kratos/*` → **Kratos** origin (caching
+  off); default `/*` → **site** origin. (Per §6.3–6.4.)
+- **Entra app #2** (Kratos) redirect URIs must include the Front Door origin under
+  `/kratos/.auth/login/aad/callback` — documented as a deploy step.
+- **Add `staticwebapp.config.json`** to the site only if needed for SPA fallback; `/kratos/*`
+  is handled at the Front Door edge and never reaches the site SWA.
+- **Update `deploy.ps1`** (or add an `azd`/CLI step) to provision/refresh Front Door alongside
+  the existing SWA deploy. No Kratos files are copied — the mount serves the live Kratos SWA.
+
+### 8.5 Workstream S-E — Config & local dev
+
+- **`VITE_KRATOS_BASE`** (default `/kratos`) — handoff/deep-link target, configurable per env.
+- **Local dev fallback** — without Front Door, `/kratos` isn't mounted; if
+  `VITE_KRATOS_STANDALONE_URL` is set, the handoff opens that absolute Kratos URL instead so the
+  flow is testable locally.
 
 ---
 
@@ -421,11 +483,17 @@ import-on-entry → settle on `?persona=<name>`.
 - Tests for the import mapping + endpoint.
 - This spec; session `plan.md`.
 
-**agentic-loop-site PR (separate session):**
-- Replace mock Kratos with a generate box that **builds the manifest**, relays it via
-  `sessionStorage['kratos.import']`, and enters `/kratos/?embed=1&import=1` so Kratos imports
-  on entry and settles on `?persona=<name>` (§10.1 Variant B / D9).
-- Front Door profile + routes (`/kratos/*`, `/kratos/.auth/*`, `/kratos/api/*`, default → site).
+**agentic-loop-site PR (separate repo `~/Repos/agentic-loop-site`, own branch):**
+- `src/data/manifest.ts` — **new** `buildPersonaManifest(...)` → threadlight-compatible manifest (§9 contract; reuses `advisor.ts` requirement inference).
+- `src/components/PersonaBuilder.tsx` — **new** (or persona mode in `GreenfieldBuilder.tsx`): "Describe your agent" box + "Create in Kratos" CTA.
+- `src/lib/kratosHandoff.ts` — **new** `relayAndOpen(manifest,{theme})`: `sessionStorage['kratos.import']` + full-page `window.location.assign('/kratos/?embed=1&import=1&theme=…')` (Variant B).
+- `src/components/KratosLauncher.tsx` — replace `navigate('/kratos',{state})` with deep-link `…/kratos/?embed=1&persona=&prompt=&theme=`.
+- `src/main.tsx` + `src/components/Sidebar.tsx` — **rename the marketing `/kratos` route** (e.g. `/reference/kratos`) to free the `/kratos/*` namespace for the Front Door mount.
+- `src/pages/Kratos.tsx` — keep marketing content at the renamed path; remove the mock render branch.
+- `src/components/KratosChatMock.tsx` — **delete**; `src/data/kratos.ts` — drop `mockKratosReply` (keep `KRATOS_PERSONAS` for the picker).
+- `infra/frontdoor.bicep` — **new** AFD profile/endpoint/origins/routes (`/kratos/.auth/*`, `/kratos/api/*`, `/kratos/*` → Kratos; `/*` → site).
+- `deploy.ps1` (+ optional `staticwebapp.config.json`) — provision/refresh Front Door alongside SWA deploy; document Entra app #2 redirect URI under `/kratos/.auth/login/aad/callback`.
+- `.env`/build — `VITE_KRATOS_BASE` (default `/kratos`), `VITE_KRATOS_STANDALONE_URL` (local-dev fallback).
 
 ---
 

--- a/docs/superpowers/specs/2026-06-17-kratos-persona-import-embed-design.md
+++ b/docs/superpowers/specs/2026-06-17-kratos-persona-import-embed-design.md
@@ -11,8 +11,10 @@
 ## 1. Problem & Goal
 
 `agentic-loop-site` should let an (authenticated) user **describe an agent in natural
-language** and get a **real, working Kratos persona** generated for them — instead of
-hand-authoring the three persona files. The site should also **host the Kratos UI as if
+language** and get a **real, working Kratos persona** created for them — instead of
+hand-authoring the three persona files. **The site turns the description into a
+threadlight-compatible manifest; Kratos imports that manifest** to create the persona (the
+site owns generation; Kratos owns import). The site should also **host the Kratos UI as if
 it were part of the site** (same origin, same "included" feel), **without copying any
 Kratos files**, so that deploying the site always uses the latest Kratos code (no
 duplication, no drift).
@@ -25,7 +27,7 @@ Two deliverables (two PRs):
    **embedded mount** of Kratos + the **Front Door route** that path-mounts Kratos under
    the site origin.
 
-The generated persona **contract must be compatible with `threadlight-design`** (its
+The persona **manifest the site builds must be compatible with `threadlight-design`** (its
 `manifest.json` + `AGENTS.md` + skills shape) so the two ecosystems interoperate.
 
 ---
@@ -35,13 +37,13 @@ The generated persona **contract must be compatible with `threadlight-design`** 
 | # | Decision | Rationale |
 |---|----------|-----------|
 | D1 | **Two PRs**, Kratos primary (this worktree); site secondary (separate session — `~/Repos/agentic-loop-site` is a plain clone, not a worktree). | User directive. |
-| D2 | **Generate box (UI) lives in the site**; **LLM generation runs in the Kratos backend** (the Import API), reusing Kratos's Foundry credentials. | Site has no backend/LLM; Kratos already has the Foundry wiring. |
+| D2 | **The site builds the manifest.** agentic-loop-site owns NL→manifest generation (its advisor / its own LLM / deterministic builder). Kratos does **not** generate personas from NL — it **imports a ready manifest**. | User directive: "agentic-loop-site creates the manifest and Kratos imports it." Site already has the contract/advisor concept (`advisor.ts`). |
 | D3 | **Embedding = reverse-proxy / path-mount at deploy (Front Door)** under `site.com/kratos/*`. **Not** iframe, **not** module federation. | User picked §2; wants same-origin "included" feel + URL args; called federation "clumsy". |
 | D4 | **No public/anonymous access.** Both the site SWA and Kratos SWA sit behind **Entra EasyAuth**. No demo mode, no ephemeral personas. | User directive. |
 | D5 | **Different Entra app registrations** for site vs Kratos → entering `/kratos/*` triggers a **second EasyAuth round-trip** (silent if the browser already has an Entra IdP session; otherwise interactive). | User directive. Drives the basePath-aware `/.auth` work. |
 | D6 | **Import endpoint is authenticated** (`require_authenticated_user`), consistent with all existing Kratos admin/export routes. | Security parity. |
-| D7 | The site's generate box **hands NL into the embedded Kratos**, which performs the authenticated import — rather than the site calling the Kratos backend cross-origin. | Keeps every Kratos backend call inside Kratos's own auth/CORS/session context; lets EasyAuth do the work; survives D5. |
-| D8 | Import contract is **threadlight-`manifest.json`-compatible** and **hybrid**: accepts a structured contract and/or a raw NL `prompt`; the LLM expands NL → contract → Kratos's 3 files. | User NOTE about threadlight compatibility. |
+| D7 | **Import-first, then redirect.** Sequence: site builds manifest → `POST /api/use-cases/import` (manifest-in) creates the persona → **only on success** the UX deep-links into the embedded Kratos at the new persona (`?embed=1&persona=<name>`). | User directive: "Kratos imports it first (new API) then UX redirects." |
+| D8 | Import contract input is **the threadlight-`manifest.json`-compatible manifest** (structured, primary path). Optional NL `prompt` expansion in Kratos is a **secondary convenience**, off the main flow. | User NOTE about threadlight compatibility; D2 moves generation to the site. |
 
 ---
 
@@ -104,71 +106,72 @@ flowchart TB
     direction LR
     R1["/ , /about, ... → site SWA"]
     R2["/kratos/* → Kratos SWA (basePath=/kratos)"]
-    R3["/kratos/.auth/* → Kratos SWA EasyAuth (rewrite)"]
+    R3["/kratos/.auth/* → Kratos EasyAuth (rewrite)"]
     R4["/kratos/api/* → Kratos backend (Container App)"]
   end
 
   U["Authenticated user"] --> FD
-  R1 --> SITE["agentic-loop-site SWA<br/>EasyAuth app #1<br/>+ 'Describe your agent' box"]
-  R2 --> KFE["Kratos frontend SWA<br/>EasyAuth app #2<br/>embed mode"]
-  R3 --> KAUTH["Kratos EasyAuth"]
-  R4 --> KBE["Kratos backend<br/>POST /api/use-cases/import"]
-  KBE --> LLM["Foundry LLM (_call_llm)"]
-  KBE --> STORE["Blob / local use-cases/<name>/<br/>(SYSTEM_PROMPT.md + .mcp.json + apm.yml)"]
+  R1 --> SITE["agentic-loop-site SWA · EasyAuth app #1<br/>'Describe your agent' box<br/><b>builds threadlight manifest</b>"]
+  SITE -->|"1 · POST manifest (authenticated)"| R4
+  R4 --> KBE["Kratos <b>import API</b><br/>POST /api/use-cases/import (manifest-in)"]
+  KBE --> STORE["use-cases/&lt;name&gt;/<br/>SYSTEM_PROMPT.md + .mcp.json + apm.yml"]
   KBE --> REG["app.state.registries[name]"]
+  KBE -->|"201 {name}"| SITE
+  SITE -->|"2 · redirect /kratos/?embed=1&persona=&lt;name&gt;"| R2
+  R2 --> KFE["Kratos frontend · EasyAuth app #2<br/>embed mode → opens the new persona"]
 ```
 
-**End-to-end flow (generate a persona):**
+**End-to-end flow (import-first, then redirect — per D2/D7):**
 
-1. User is on `site.com` (already authenticated to site EasyAuth app #1).
-2. User types a description into the **generate box** and submits. The site **stashes the
-   NL prompt in `sessionStorage['kratos.generate']`** (see §7.1) and navigates (top-level)
-   to `site.com/kratos/?embed=1&theme=<t>&generate=1`.
-3. Front Door routes `/kratos/*` → Kratos SWA. Kratos EasyAuth (app #2) authenticates —
-   **silent** if the Entra IdP session already exists in the browser, otherwise a prompt.
-   The handoff payload **survives this redirect** because `sessionStorage` is shared across
-   the single `site.com` origin (storage is per-origin, not per-path — both backend SWAs are
-   invisible to the browser).
-4. Embedded Kratos (chromeless) sees `?generate=1`, **reads-and-clears** the handoff payload
-   from `sessionStorage` (so a refresh won't regenerate), then calls
-   `POST /kratos/api/use-cases/import` with the NL — authenticated by the EasyAuth cookie,
-   **same-origin** (no CORS), API base resolved by `config.ts`'s same-origin proxy fallback.
-5. Import API: LLM expands NL → threadlight-compatible **contract** → maps to the three
-   Kratos files → persists (blob/local) → registers `app.state.registries[name]` →
-   `201 {name, displayName}`. On the NL path the slug is **auto-deduped** (`-2`, `-3`, …) so
-   generation never dead-ends on a name clash; an explicit `contract.name` clash returns
-   `409` (unless `overwrite`).
-6. Kratos sets `selectedUseCase = name`, surfaces the persona's `sampleQuestions`, and opens
-   the chat — the user is now talking to their generated agent, visually "inside" the site.
-   On `422`/`409`/network error, embed mode shows an inline "couldn't generate — try again /
-   edit" affordance instead of the chat.
+1. User is on `site.com` (authenticated to site EasyAuth app #1), types a description into the
+   **generate box**.
+2. **The site builds the threadlight-compatible manifest** from the description (its
+   advisor / its own LLM / deterministic builder — Kratos is not involved in generation).
+3. The site **POSTs the manifest** to `site.com/kratos/api/use-cases/import` (the new Kratos
+   import API). *(Auth-context note: this endpoint is gated by Kratos EasyAuth app #2 — see
+   §10.1 for exactly which page issues this authenticated call; that's the one open
+   decision below.)*
+4. Kratos import API: validate manifest → map to the three persona files → persist
+   (blob/local) → register `app.state.registries[name]` → return `201 {name, displayName}`.
+   Slug is **auto-deduped** (`name-2`, `name-3`, …) so a name clash never dead-ends (explicit
+   collisions can opt into `409`/`overwrite`).
+5. **Only on success**, the UX **redirects** into the embedded Kratos at the new persona:
+   `site.com/kratos/?embed=1&theme=<t>&persona=<name>`.
+6. Front Door routes `/kratos/*` → Kratos SWA; EasyAuth (app #2) is satisfied (already
+   established in step 3 / silent via IdP session). Embed mode (chromeless) **preselects the
+   persona**, surfaces its `sampleQuestions`, and opens the chat — the user is now talking to
+   their agent, visually "inside" the site. Import errors are surfaced **on the site** (step 4
+   response) *before* any redirect, so the embedded view only ever opens on success.
 
 ---
 
 ## 5. Workstream A — Persona Import API (Kratos backend, net-new)
+
+**Primary input = a ready manifest (built by the site, D2/D8).** The endpoint validates the
+manifest, maps it to Kratos's three persona files, persists, and registers the persona live —
+**no LLM on the main path**. An optional NL `prompt` expansion is kept only as a secondary
+convenience (§5.3).
 
 ### 5.1 Endpoint
 - `POST /api/use-cases/import` — new router `src/backend/app/routers/import_persona.py`,
   mounted in `main.py` under the `/api/use-cases` prefix (alongside `use_cases` / `export`).
 - **Auth-gated** with the same `require_authenticated_user` dependency used by `export.py`.
 - Returns `201` with `{ name, displayName, files: {...}, created: true }`. Name-collision
-  policy: on the **NL path** (no explicit `contract.name`) the derived slug is
-  **auto-deduped** (`name-2`, `name-3`, …) so generation never dead-ends; with an **explicit
-  `contract.name`** a clash returns `409` unless `?overwrite=true`. `422` on invalid
-  contract or malformed LLM output.
+  policy: when the manifest omits `name` (or on the secondary NL path) the derived slug is
+  **auto-deduped** (`name-2`, `name-3`, …) so import never dead-ends; with an **explicit
+  `manifest.name`** a clash returns `409` unless `options.overwrite` / `?overwrite=true`.
+  `422` on invalid manifest (or malformed LLM output on the NL convenience path).
 
-### 5.2 Request contract (hybrid; threadlight-compatible)
-Accepts **either** a structured contract, **or** a raw `prompt`, **or** both (the contract
-provides hints, the LLM fills the gaps):
+### 5.2 Request body (manifest-in; threadlight-compatible)
+The **primary input is the manifest** (built by the site). The body is the manifest, plus
+import options. An optional `prompt` is accepted only as a **secondary convenience** (off
+the main flow) for callers that want Kratos to expand NL itself.
 
 ```jsonc
 {
-  // --- Option 1: natural language (LLM expands) ---
-  "prompt": "An assistant for retail-bank dispute handling that ...",
-
-  // --- Option 2 / hints: threadlight-manifest-compatible structured contract ---
-  "contract": {
-    "name": "dispute-handler",                 // optional; LLM/slug derives if absent
+  // --- PRIMARY: the threadlight-manifest.json-compatible manifest (built by the site) ---
+  "manifest": {
+    "name": "dispute-handler",                 // ↔ folder + SYSTEM_PROMPT frontmatter.name
     "description": "...",                       // ↔ SYSTEM_PROMPT frontmatter.description
     "sampleQuestions": ["...", "..."],          // ↔ SYSTEM_PROMPT frontmatter.sampleQuestions
     "instructions": "## Role ...",              // ↔ SYSTEM_PROMPT.md markdown body (AGENTS.md-like)
@@ -178,20 +181,28 @@ provides hints, the LLM fills the gaps):
     "traits": ["..."],                          // carried as metadata (round-trip)
     "workflow_model": "agent"                   // Kratos personas are agent-shaped
   },
+
+  // --- SECONDARY (optional): let Kratos expand NL instead of sending a manifest ---
+  "prompt": "An assistant for retail-bank dispute handling that ...",
+
   "options": { "curated": false, "overwrite": false }
 }
 ```
 
-### 5.3 LLM behavior (reuse `admin_analysis._call_llm`)
-- If `prompt` is present, call the Foundry LLM in **JSON mode** with a system prompt that
-  instructs it to emit the **threadlight-compatible contract** above (validated against a
-  Pydantic model). Merge any caller-supplied `contract` hints (caller hints win on
-  conflicts; LLM fills the rest).
-- Deterministic, non-LLM fallback: if no `prompt` and a complete `contract` is supplied,
-  skip the LLM and map directly.
+- **Exactly one of `manifest` / `prompt` is required.** The main flow (D2/D7) always sends
+  `manifest`. If only `prompt` is sent, Kratos expands it (§5.3) — a convenience path, not
+  used by the site's generate box.
 
-### 5.4 Mapping: contract → Kratos's 3 files
-| Contract field | Kratos file |
+### 5.3 Optional NL expansion (secondary path; reuse `admin_analysis._call_llm`)
+- Only when `prompt` is supplied **and** `manifest` is absent: call the Foundry LLM in
+  **JSON mode** to emit a manifest (validated against the same Pydantic model), then proceed
+  as if a manifest had been posted.
+- The **primary path is fully deterministic** — a posted `manifest` is validated and mapped
+  directly with **no LLM call**. (Kratos keeps the LLM capability for the convenience path,
+  but generation ownership lives in the site per D2.)
+
+### 5.4 Mapping: manifest → Kratos's 3 files
+| Manifest field | Kratos file |
 |---|---|
 | `name` | folder name `use-cases/<name>/` (slugified, validated `^[a-z0-9][a-z0-9-]{0,63}$`) |
 | `description`, `sampleQuestions`, `curated` | `SYSTEM_PROMPT.md` **frontmatter** |
@@ -210,8 +221,8 @@ provides hints, the LLM fills the gaps):
   (`GET /api/use-cases`) and selectable without a restart.
 
 ### 5.6 Tests
-- Unit: contract→files mapping (golden), slug/validation, overwrite/409, auth 401.
-- Unit: LLM path mocked (assert `_call_llm` called with JSON mode; malformed JSON → 422).
+- Unit: manifest→files mapping (golden), slug/validation, overwrite/409, auth 401.
+- Unit: secondary NL path mocked (assert `_call_llm` called with JSON mode; malformed JSON → 422).
 - Integration: import → `GET /api/use-cases` includes the new persona → chat selectable.
 
 ---
@@ -260,9 +271,9 @@ URL arguments (read in `page.tsx` via `useSearchParams`):
 |---|---|
 | `embed=1` | **Chromeless** layout: hide the standalone sidebar/header chrome so the site's own chrome wraps Kratos; tighten paddings to blend in. |
 | `theme=light\|dark` | Apply theme to match the host site (Tailwind `dark` class / data-attr). |
-| `persona=<name>` | Preselect `selectedUseCase` (skip if not found). |
-| `prompt=<text>` | Prefill `landingInput`. |
-| `generate=1` (or `generate=<short NL>`) | After auth, read the NL handoff (§7.1), **read-and-clear** it, **auto-invoke** `POST /kratos/api/use-cases/import`, then select + open the created persona. |
+| `persona=<name>` | **Primary handoff (D7).** Preselect `selectedUseCase`, surface its `sampleQuestions`, open the chat. This is the post-import landing target — import already happened on the site, so embed just *opens* the persona. (Skip gracefully if not found yet — show landing.) |
+| `prompt=<text>` | Prefill `landingInput` (optional, e.g. seed the first question). |
+| `import=1` | **Only used by auth-variant B (§10.1).** Read the manifest handoff (§7.1), **read-and-clear** it, **POST it to `/kratos/api/use-cases/import`** from inside Kratos (after its own EasyAuth), then settle on the created persona. Absent in variant A. |
 
 - Add a small `useEmbed()` hook + an `embed`-aware wrapper around the existing layout; no
   changes to standalone behavior when params are absent.
@@ -271,26 +282,35 @@ URL arguments (read in `page.tsx` via `useSearchParams`):
   that would be heavy and brittle; chromeless + theme sync is the pragmatic "included"
   feel the user asked for.)
 
-### 7.1 The `generate=` handoff (same-origin sessionStorage relay)
+### 7.1 The handoff (depends on the §10.1 auth decision)
 
-The NL prompt is **not** stuffed into the query string (URL length limits, prompt leaking
-into browser history/edge logs, fragility across the EasyAuth redirect). Instead:
+**Variant A (default/recommended) — the site imports, then redirects with `persona`.**
+The site posts the manifest to the import API itself and, on `201`, navigates to
+`/kratos/?embed=1&theme=<t>&persona=<name>`. Embed mode does **no importing** — it only
+*opens* the named persona. Nothing is relayed through storage; the persona name is a short,
+safe value to carry in the URL. This is the cleanest expression of D7 ("import first, then
+redirect").
+
+**Variant B (fallback) — Kratos imports on entry via a same-origin manifest relay.**
+Used only if the site cannot make an authenticated cross-app import call (§10.1):
 
 - Under Front Door, `/` and `/kratos/*` are **one browser origin** (`site.com`), so
-  `sessionStorage` is **shared** (web storage is keyed by origin, not path; the two backend
-  SWAs are invisible to the browser). The site writes
-  `sessionStorage.setItem('kratos.generate', JSON.stringify({ nl, theme?, persona?, prompt?, nonce }))`
-  and navigates to `/kratos/?embed=1&generate=1`.
-- The payload **survives the second EasyAuth round-trip** (same origin), so the design no
-  longer depends on EasyAuth preserving the `post_login_redirect_uri` query string.
-- Kratos embed mode **reads the payload once and removes it** (`removeItem`) before invoking
-  import, so a page refresh cannot re-trigger generation.
-- **Fallback for short prompts / no-relay contexts:** `generate=<url-encoded NL>` is still
-  accepted; if `generate` is a non-`1` value, treat it as the literal NL. If `generate=1`
-  but the relay payload is missing (e.g. opened directly), embed mode shows the normal
-  landing input instead of erroring.
+  `sessionStorage` is **shared** (web storage is keyed by origin, not path). The site writes
+  `sessionStorage.setItem('kratos.import', JSON.stringify({ manifest, theme?, nonce }))` and
+  navigates to `/kratos/?embed=1&import=1`.
+- The manifest **survives the second EasyAuth round-trip** (same origin), so the design does
+  not depend on EasyAuth preserving any query string.
+- Kratos embed mode **reads the payload once and removes it** (`removeItem`) before calling
+  import, so a refresh cannot re-import; on `201` it settles on `?persona=<name>` (replacing
+  history so the manifest never re-runs).
+- The manifest itself is **never** placed in the URL (size limits, history/edge-log leakage).
 - This relay lives in the **site PR**; the Kratos PR only **consumes** `sessionStorage`
-  `['kratos.generate']` + the `generate` param. Standalone Kratos ignores both.
+  `['kratos.import']` + the `import` param. Standalone Kratos ignores both.
+
+Both variants converge on the same end state: an embedded, chromeless Kratos opened at the
+newly-created persona. On import/registration error, the user is kept **on the site** with a
+retry affordance (variant A surfaces the error before any redirect; variant B shows an inline
+"couldn't import — try again" panel in embed mode instead of the chat).
 
 ---
 
@@ -300,10 +320,15 @@ Captured here for completeness; **implemented in a separate session/worktree**, 
 
 - Replace the **mock** Kratos integration (`src/pages/Kratos.tsx`,
   `src/components/KratosChatMock.tsx`, `src/data/kratos.ts` `mockKratosReply`) with:
-  - a **"Describe your agent" generate box** (can reuse the `GreenfieldBuilder` /
-    `advisor.ts` "Make it real" pattern, repurposed to persona intent), and
-  - an **embedded mount** that writes the NL to `sessionStorage['kratos.generate']` (§7.1)
-    and navigates to `/kratos/?embed=1&theme=<t>&generate=1`.
+  - a **"Describe your agent" generate box** that **builds the threadlight-compatible
+    manifest** in the site (reusing the `GreenfieldBuilder` / `advisor.ts` "Make it real"
+    pattern, repurposed to persona intent), and
+  - the **import-then-redirect** handoff per the §10.1 auth decision:
+    - **Variant A:** site `POST`s the manifest to `/kratos/api/use-cases/import`, then on
+      `201` navigates to `/kratos/?embed=1&theme=<t>&persona=<name>`.
+    - **Variant B:** site writes the manifest to `sessionStorage['kratos.import']` (§7.1)
+      and navigates to `/kratos/?embed=1&import=1` (Kratos imports on entry after its own
+      EasyAuth).
 - Add the **Front Door** profile + routes that path-mount Kratos under `/kratos/*`
   (per §6.3–6.4), including `/kratos/.auth/*` and `/kratos/api/*`.
 - No Kratos files are copied — the mount serves the live Kratos SWA.
@@ -312,10 +337,10 @@ Captured here for completeness; **implemented in a separate session/worktree**, 
 
 ## 9. threadlight-design contract compatibility
 
-The Import API's `contract` is a **subset/superset of threadlight's machine-readable
-contract** so personas round-trip between ecosystems:
+The Import API's `manifest` is a **subset/superset of threadlight's machine-readable
+manifest** so personas round-trip between ecosystems:
 
-| threadlight artifact | threadlight field | Kratos Import `contract` | Kratos file |
+| threadlight artifact | threadlight field | Kratos Import `manifest` | Kratos file |
 |---|---|---|---|
 | `specs/manifest.json` | `name`, `description` | `name`, `description` | `SYSTEM_PROMPT.md` frontmatter |
 | `AGENTS.md` | agent identity / behavior body | `instructions` | `SYSTEM_PROMPT.md` body |
@@ -325,11 +350,13 @@ contract** so personas round-trip between ecosystems:
 | SPEC §11e | `workflow_model: agent\|workflow` | `workflow_model` (Kratos supports `agent`) | `apm.yml` metadata |
 | SKILL.md frontmatter | `name`, `description` (USE FOR / DO NOT USE FOR) | per-skill `name`/`description` | (future) Kratos skill files |
 
+- Because the **site builds this manifest** (D2), the field names above are the contract the
+  site must emit — keeping them threadlight-shaped means the same builder can target either
+  ecosystem.
 - Kratos personas map to threadlight's **`agent`** workflow shape; `workflow` is recorded
   as metadata but not executed by Kratos (out of scope).
-- A future enhancement (not this PR) could accept a threadlight `manifest.json` directly
-  and/or have Kratos `export.py` emit a threadlight-compatible `manifest.json` for full
-  round-trip.
+- A future enhancement (not this PR) could have Kratos `export.py` emit a threadlight
+  `manifest.json` for full bidirectional round-trip.
 
 ---
 
@@ -345,6 +372,24 @@ contract** so personas round-trip between ecosystems:
 - The Import API trusts the Kratos SWA EasyAuth principal (existing
   `require_authenticated_user`); no new auth surface is introduced.
 
+### 10.1 OPEN DECISION — which page issues the authenticated import call?
+
+Because the import endpoint is gated by **Kratos** EasyAuth (app #2) but the generate box
+lives on the **site** (app #1), the cross-app `POST` needs a Kratos auth context. Two ways:
+
+| | **Variant A — site calls import directly** | **Variant B — Kratos entry page imports after its own login** |
+|---|---|---|
+| Who POSTs the manifest | The site page (`fetch('/kratos/api/use-cases/import')`) | The embedded Kratos page, on entry |
+| Auth needed | A **Kratos (app #2) session must already exist** in the browser; if not, the cross-app `fetch` hits a `401`→login redirect a `fetch` can't follow | Kratos does its **own** EasyAuth round-trip first (silent if IdP session exists), *then* imports — always has a valid context |
+| Handoff | None — persona name carried in the redirect URL (`?persona=<name>`) | Manifest relayed via same-origin `sessionStorage['kratos.import']` (§7.1), `?import=1` |
+| Pros | Simplest; truest "import-first, then redirect"; no storage relay | Robust to a missing Kratos session; no cross-app `fetch`/CORS/401-follow problem |
+| Cons | Fragile if the user has no Kratos session yet (needs a priming top-level visit to `/kratos/.auth` first) | Import happens *inside* Kratos on entry, so the "redirect only after success" ordering is realized as "enter → import → settle on persona" |
+
+**Recommendation: Variant B** — it survives the two-app EasyAuth split with no reliance on a
+pre-existing Kratos session and no un-followable `fetch` redirect, at the cost of moving the
+import call one hop into Kratos. (Variant A can be offered as a fast path when a Kratos
+session is already present.) **This is the one decision to confirm before implementation.**
+
 ---
 
 ## 11. Risks & open questions
@@ -353,9 +398,9 @@ contract** so personas round-trip between ecosystems:
 |---|---|
 | Front Door `/kratos/.auth/*` rewrite correctness (EasyAuth redirect URIs must resolve under the mount) | Validate during site-PR infra work; the Entra app #2 redirect URIs must include the Front Door origin under `/kratos/.auth/login/aad/callback`. |
 | Next.js `basePath` + `trailingSlash` + static export edge cases for `_next/*` and `config.json` placement | Verify `out/` layout after `next build`; add a smoke check. |
-| Second login could drop the `generate` payload if it relied on EasyAuth query preservation | **Mitigated** by the same-origin `sessionStorage` relay (§7.1) — the payload is independent of the redirect URL; read-and-cleared after use. |
-| CORS: under the mount, frontend calls `/kratos/api/*` **same-origin** (no CORS); direct cross-origin calls avoided by D7. | Keep Kratos `_cors_origins` unchanged for standalone use. |
-| `GreenfieldBuilder`/`advisor.ts` is app-scaffolding-shaped, not persona-shaped | Site PR repurposes the box to persona intent; deterministic contract optional, NL is primary. |
+| Second login could drop the handoff if it relied on EasyAuth query preservation | **Mitigated** in variant B by the same-origin `sessionStorage['kratos.import']` relay (§7.1) — the manifest is independent of the redirect URL, read-and-cleared after use. Variant A carries only a short `persona=<name>` in the URL. |
+| CORS / cross-app `fetch` for the import call (two EasyAuth apps) | Resolved by the §10.1 decision: variant B keeps the import call **inside Kratos** (same-origin, own EasyAuth); variant A relies on a pre-existing Kratos session. **Confirm before build.** |
+| `GreenfieldBuilder`/`advisor.ts` is app-scaffolding-shaped, not persona-shaped | Site PR repurposes the box to build a **persona manifest**; the manifest shape (§9) is the site's output contract. |
 | Cost/complexity of Front Door | Accepted (D3); the lower-effort iframe alt was rejected as "clumsy". |
 
 ---
@@ -370,13 +415,15 @@ contract** so personas round-trip between ecosystems:
 - `src/frontend/next.config.js` — `NEXT_PUBLIC_BASE_PATH` → `basePath`/`assetPrefix`.
 - `src/frontend/src/lib/config.ts` — basePath-aware `/config.json` fetch.
 - `src/frontend/staticwebapp.config.json` — basePath-aware `401` redirect.
-- `src/frontend/src/app/page.tsx` (+ small `useEmbed`/`useSearchParams` hook + chromeless wrapper) — embed/theme/persona/prompt/generate URL args.
+- `src/frontend/src/app/page.tsx` (+ small `useEmbed`/`useSearchParams` hook + chromeless wrapper) — embed/theme/persona/prompt URL args (+ `import=1` for §10.1 variant B).
 - `azure.yaml` — confirm `config.json` injection path under basePath.
 - Tests for the import mapping + endpoint.
 - This spec; session `plan.md`.
 
 **agentic-loop-site PR (separate session):**
-- Replace mock Kratos with generate box + embedded mount (`?embed=1&generate=…`).
+- Replace mock Kratos with a generate box that **builds the manifest**, imports it, then
+  opens the embedded persona (`?embed=1&persona=<name>` for variant A, or
+  `?embed=1&import=1` + `sessionStorage['kratos.import']` for variant B).
 - Front Door profile + routes (`/kratos/*`, `/kratos/.auth/*`, `/kratos/api/*`, default → site).
 
 ---

--- a/docs/superpowers/specs/2026-06-17-kratos-persona-import-embed-design.md
+++ b/docs/superpowers/specs/2026-06-17-kratos-persona-import-embed-design.md
@@ -1,0 +1,354 @@
+# Design Spec — Kratos Persona Import API + Embedded Hosting in agentic-loop-site
+
+- **Date:** 2026-06-17
+- **Status:** Design (approved direction, pre-implementation)
+- **Primary repo:** `kmavrodis/kratos-agent` (this worktree) — implemented here
+- **Secondary repo:** `aiappsgbb/agentic-loop-site` — separate PR / separate session
+- **Related skill (contract compatibility only):** `aiappsgbb/threadlight-skills → threadlight-design`
+
+---
+
+## 1. Problem & Goal
+
+`agentic-loop-site` should let an (authenticated) user **describe an agent in natural
+language** and get a **real, working Kratos persona** generated for them — instead of
+hand-authoring the three persona files. The site should also **host the Kratos UI as if
+it were part of the site** (same origin, same "included" feel), **without copying any
+Kratos files**, so that deploying the site always uses the latest Kratos code (no
+duplication, no drift).
+
+Two deliverables (two PRs):
+
+1. **Kratos PR (this repo, primary):** a persona **Import API** + the frontend changes
+   that make Kratos **mountable under a sub-path** and **embeddable** ("included" mode).
+2. **agentic-loop-site PR (secondary):** a **"Describe your agent" generate box** + the
+   **embedded mount** of Kratos + the **Front Door route** that path-mounts Kratos under
+   the site origin.
+
+The generated persona **contract must be compatible with `threadlight-design`** (its
+`manifest.json` + `AGENTS.md` + skills shape) so the two ecosystems interoperate.
+
+---
+
+## 2. Locked-in Decisions (from clarification)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | **Two PRs**, Kratos primary (this worktree); site secondary (separate session — `~/Repos/agentic-loop-site` is a plain clone, not a worktree). | User directive. |
+| D2 | **Generate box (UI) lives in the site**; **LLM generation runs in the Kratos backend** (the Import API), reusing Kratos's Foundry credentials. | Site has no backend/LLM; Kratos already has the Foundry wiring. |
+| D3 | **Embedding = reverse-proxy / path-mount at deploy (Front Door)** under `site.com/kratos/*`. **Not** iframe, **not** module federation. | User picked §2; wants same-origin "included" feel + URL args; called federation "clumsy". |
+| D4 | **No public/anonymous access.** Both the site SWA and Kratos SWA sit behind **Entra EasyAuth**. No demo mode, no ephemeral personas. | User directive. |
+| D5 | **Different Entra app registrations** for site vs Kratos → entering `/kratos/*` triggers a **second EasyAuth round-trip** (silent if the browser already has an Entra IdP session; otherwise interactive). | User directive. Drives the basePath-aware `/.auth` work. |
+| D6 | **Import endpoint is authenticated** (`require_authenticated_user`), consistent with all existing Kratos admin/export routes. | Security parity. |
+| D7 | The site's generate box **hands NL into the embedded Kratos**, which performs the authenticated import — rather than the site calling the Kratos backend cross-origin. | Keeps every Kratos backend call inside Kratos's own auth/CORS/session context; lets EasyAuth do the work; survives D5. |
+| D8 | Import contract is **threadlight-`manifest.json`-compatible** and **hybrid**: accepts a structured contract and/or a raw NL `prompt`; the LLM expands NL → contract → Kratos's 3 files. | User NOTE about threadlight compatibility. |
+
+---
+
+## 3. Background: how Kratos works today (verified)
+
+**Persona = "use-case" = a folder** `use-cases/<name>/` containing:
+- `SYSTEM_PROMPT.md` — YAML frontmatter (`name`, `description`, `sampleQuestions[]`,
+  `curated`) + markdown body (the system prompt / agent instructions).
+- `.mcp.json` — MCP server config (often `{}`).
+- `apm.yml` — Agent Package Manager manifest (`dependencies.apm[]`, `dependencies.mcp[]`).
+
+Personas are loaded at startup into `app.state.registries: dict[str, SkillRegistry]`
+(keyed by use-case name); `app.state.skill_registry` defaults to `generic`. Stored in
+Azure Blob Storage (prod) or local `use-cases/` (dev) via `BlobSkillService`.
+
+**Backend** (FastAPI, `src/backend/app/`): routers mounted in `main.py`. All existing
+admin routers operate on **existing** use-cases (404 if missing). **There is no
+"create new persona" endpoint** — that is the net-new Import API.
+- `routers/admin_analysis.py` has the reusable Foundry LLM helper
+  `_call_llm(system_prompt, user_content, json_mode=)` — `DefaultAzureCredential` token
+  for `https://cognitiveservices.azure.com/.default`, URL from `FOUNDRY_ENDPOINT` +
+  `FOUNDRY_MODEL_DEPLOYMENT`, api-version `2024-12-01-preview`, supports
+  `response_format={"type":"json_object"}`.
+- `routers/export.py` is the existing **reverse** of import (use-case → deployable ZIP);
+  source of the use-case **name regex** `^[a-z0-9][a-z0-9-]{0,63}$` and the auth pattern.
+- `services/blob_skill_service.py` has `upload_file`, `upload_mcp_config`,
+  `upload_apm_manifest`, `local_dir`, `seed_from_local`, `list_use_cases`,
+  `is_available` — but **no atomic "create use-case + register"** method.
+
+**Frontend** (`src/frontend/`, Next.js 14 static export):
+- `next.config.js`: `output: "export"`, `trailingSlash: true`. **No client-side MSAL is
+  actually used** — the `NEXT_PUBLIC_MSAL_*` env vars are declared but unreferenced.
+- Auth is **Azure Static Web Apps EasyAuth**: `staticwebapp.config.json` gates `/api/*`
+  to role `authenticated` and redirects `401 → /.auth/login/aad`; global headers set
+  `X-Frame-Options: DENY` + a CSP (`frame-src 'self' …`).
+- `src/lib/config.ts` resolves the backend URL at runtime: build env → `/config.json`
+  (`window.__KRATOS_CONFIG__`) → **same-origin `""` fallback "behind a proxy"** → dev.
+  `loadRuntimeConfig()` fetches the **absolute** path `/config.json`.
+- `page.tsx` already holds the state we need for deep-linking: `selectedUseCase`,
+  `landingInput`, `pendingMessage`.
+
+**Deploy** (`azure.yaml`): `agent-service` = Container App (backend `/api/*`);
+`kratos-agent` = Foundry hosted agent; `web` = **Azure Static Web App** (Free tier,
+`dist: out`). A `web.predeploy` hook injects `out/config.json` with `apiUrl`. The
+frontend's same-origin fallback means it works behind a proxy without a hardcoded URL.
+
+> **Implication for embedding:** because both the site and Kratos frontends are SWAs and
+> SWA cannot reverse-proxy another SWA for non-`/api` routes, a true path-mount needs a
+> proxy in front → **Azure Front Door** (D3). The Next.js static export must serve under a
+> sub-path → **`basePath`/`assetPrefix`** (Workstream B). EasyAuth `/.auth/*` must also be
+> reachable under the sub-path (D5).
+
+---
+
+## 4. Architecture Overview
+
+```mermaid
+flowchart TB
+  subgraph FD["Azure Front Door — origin: site.com (single browser origin)"]
+    direction LR
+    R1["/ , /about, ... → site SWA"]
+    R2["/kratos/* → Kratos SWA (basePath=/kratos)"]
+    R3["/kratos/.auth/* → Kratos SWA EasyAuth (rewrite)"]
+    R4["/kratos/api/* → Kratos backend (Container App)"]
+  end
+
+  U["Authenticated user"] --> FD
+  R1 --> SITE["agentic-loop-site SWA<br/>EasyAuth app #1<br/>+ 'Describe your agent' box"]
+  R2 --> KFE["Kratos frontend SWA<br/>EasyAuth app #2<br/>embed mode"]
+  R3 --> KAUTH["Kratos EasyAuth"]
+  R4 --> KBE["Kratos backend<br/>POST /api/use-cases/import"]
+  KBE --> LLM["Foundry LLM (_call_llm)"]
+  KBE --> STORE["Blob / local use-cases/<name>/<br/>(SYSTEM_PROMPT.md + .mcp.json + apm.yml)"]
+  KBE --> REG["app.state.registries[name]"]
+```
+
+**End-to-end flow (generate a persona):**
+
+1. User is on `site.com` (already authenticated to site EasyAuth app #1).
+2. User types a description into the **generate box** and submits.
+3. Site navigates to the embedded Kratos:
+   `site.com/kratos/?embed=1&theme=<t>&generate=<url-encoded NL>`.
+4. Front Door routes `/kratos/*` → Kratos SWA. Kratos EasyAuth (app #2) authenticates —
+   **silent** if the Entra IdP session already exists in the browser, otherwise a prompt.
+5. Embedded Kratos (chromeless) reads `?generate=`, calls
+   `POST /kratos/api/use-cases/import` (authenticated, same Kratos origin context).
+6. Import API: LLM expands NL → threadlight-compatible **contract** → maps to the three
+   Kratos files → persists (blob/local) → registers `app.state.registries[name]`.
+7. Kratos selects the new persona and opens the chat — the user is now talking to their
+   generated agent, visually "inside" the site.
+
+---
+
+## 5. Workstream A — Persona Import API (Kratos backend, net-new)
+
+### 5.1 Endpoint
+- `POST /api/use-cases/import` — new router `src/backend/app/routers/import_persona.py`,
+  mounted in `main.py` under the `/api/use-cases` prefix (alongside `use_cases` / `export`).
+- **Auth-gated** with the same `require_authenticated_user` dependency used by `export.py`.
+- Returns `201` with `{ name, displayName, files: {...}, created: true }`; `409` if the
+  use-case already exists (unless `?overwrite=true`); `422` on invalid contract.
+
+### 5.2 Request contract (hybrid; threadlight-compatible)
+Accepts **either** a structured contract, **or** a raw `prompt`, **or** both (the contract
+provides hints, the LLM fills the gaps):
+
+```jsonc
+{
+  // --- Option 1: natural language (LLM expands) ---
+  "prompt": "An assistant for retail-bank dispute handling that ...",
+
+  // --- Option 2 / hints: threadlight-manifest-compatible structured contract ---
+  "contract": {
+    "name": "dispute-handler",                 // optional; LLM/slug derives if absent
+    "description": "...",                       // ↔ SYSTEM_PROMPT frontmatter.description
+    "sampleQuestions": ["...", "..."],          // ↔ SYSTEM_PROMPT frontmatter.sampleQuestions
+    "instructions": "## Role ...",              // ↔ SYSTEM_PROMPT.md markdown body (AGENTS.md-like)
+    "skills": [ { "name": "...", "description": "..." } ], // ↔ apm.yml dependencies.apm[]
+    "mcpServers": { /* MCP contract */ },       // ↔ .mcp.json
+    "tools": [ /* abstract tool contracts */ ], // ↔ apm.yml dependencies.mcp[] / .mcp.json
+    "traits": ["..."],                          // carried as metadata (round-trip)
+    "workflow_model": "agent"                   // Kratos personas are agent-shaped
+  },
+  "options": { "curated": false, "overwrite": false }
+}
+```
+
+### 5.3 LLM behavior (reuse `admin_analysis._call_llm`)
+- If `prompt` is present, call the Foundry LLM in **JSON mode** with a system prompt that
+  instructs it to emit the **threadlight-compatible contract** above (validated against a
+  Pydantic model). Merge any caller-supplied `contract` hints (caller hints win on
+  conflicts; LLM fills the rest).
+- Deterministic, non-LLM fallback: if no `prompt` and a complete `contract` is supplied,
+  skip the LLM and map directly.
+
+### 5.4 Mapping: contract → Kratos's 3 files
+| Contract field | Kratos file |
+|---|---|
+| `name` | folder name `use-cases/<name>/` (slugified, validated `^[a-z0-9][a-z0-9-]{0,63}$`) |
+| `description`, `sampleQuestions`, `curated` | `SYSTEM_PROMPT.md` **frontmatter** |
+| `instructions` | `SYSTEM_PROMPT.md` **markdown body** |
+| `mcpServers` / `tools` | `.mcp.json` (default `{}` when none) |
+| `skills`, `tools` | `apm.yml` (`dependencies.apm[]`, `dependencies.mcp[]`) |
+| `traits`, `workflow_model`, source metadata | `apm.yml` metadata block (for round-trip) |
+
+### 5.5 Persistence + registration (new service method)
+- Add `BlobSkillService.create_use_case(name, system_prompt_md, mcp_json, apm_yml,
+  *, overwrite=False) -> CreatedUseCase` that writes all three files **atomically**
+  (blob if `is_available`, else local `use-cases/<name>/…`, mirroring `admin_prompt.py`'s
+  blob-vs-local pattern) and refuses to clobber unless `overwrite`.
+- After write, **register in the live registry**: build a `SkillRegistry` for the new
+  use-case and insert into `app.state.registries[name]` so it is immediately listable
+  (`GET /api/use-cases`) and selectable without a restart.
+
+### 5.6 Tests
+- Unit: contract→files mapping (golden), slug/validation, overwrite/409, auth 401.
+- Unit: LLM path mocked (assert `_call_llm` called with JSON mode; malformed JSON → 422).
+- Integration: import → `GET /api/use-cases` includes the new persona → chat selectable.
+
+---
+
+## 6. Workstream B — Sub-path hosting (Kratos frontend + infra)
+
+### 6.1 Next.js basePath / assetPrefix (env-driven, default off)
+- `next.config.js`: read `NEXT_PUBLIC_BASE_PATH` (default `""`); when set (e.g. `/kratos`),
+  set `basePath` and `assetPrefix` so all routes + `_next/*` assets live under the prefix.
+  Local/standalone Kratos deploy stays unchanged (empty basePath).
+
+### 6.2 basePath-aware runtime config
+- `src/lib/config.ts`: `loadRuntimeConfig()` must fetch `${basePath}/config.json` (not the
+  absolute `/config.json`), so the runtime API config resolves under the mount.
+- `azure.yaml` `web.predeploy` hook writes `out/config.json` — confirm it lands at the
+  basePath location in the export (Next emits under `out/` honoring basePath; verify path).
+- The existing **same-origin `""` API fallback** is retained: under the mount, the
+  frontend calls `/kratos/api/*` same-origin (no hardcoded backend host needed), which
+  Front Door routes to the Kratos backend.
+
+### 6.3 EasyAuth under the sub-path (D5)
+- `staticwebapp.config.json`: make the `401` redirect **basePath-aware**
+  (`${basePath}/.auth/login/aad`) and ensure `/api/*` (→ `/kratos/api/*` at the edge) keeps
+  `allowedRoles: ["authenticated"]`.
+- `X-Frame-Options: DENY` and the CSP **stay as-is** — path-mount is top-level navigation,
+  not framing, so no relaxation is needed (a security win vs the iframe alternative).
+- Front Door must route **`/kratos/.auth/*` → Kratos SWA `/.auth/*`** (prefix rewrite) so
+  the second EasyAuth round-trip completes under the mounted origin.
+
+### 6.4 Front Door (where it lives)
+- The Front Door profile + routes (`/kratos/*`, `/kratos/.auth/*`, `/kratos/api/*`, default
+  `/* → site`) are **infra that fronts both apps**. Primary placement: the **site PR**
+  (it owns the composed origin), with this spec documenting the exact route/rewrite rules.
+  Kratos's repo contributes only the basePath-aware SWA config + the `NEXT_PUBLIC_BASE_PATH`
+  build wiring so the Kratos SWA is *mountable*. (If we later want Kratos to be
+  self-mounting, an optional `infra/modules/front-door.bicep` can be added to Kratos — out
+  of scope for this PR.)
+
+---
+
+## 7. Workstream C — Embed / "included" mode (Kratos frontend)
+
+URL arguments (read in `page.tsx` via `useSearchParams`):
+
+| Param | Effect |
+|---|---|
+| `embed=1` | **Chromeless** layout: hide the standalone sidebar/header chrome so the site's own chrome wraps Kratos; tighten paddings to blend in. |
+| `theme=light\|dark` | Apply theme to match the host site (Tailwind `dark` class / data-attr). |
+| `persona=<name>` | Preselect `selectedUseCase` (skip if not found). |
+| `prompt=<text>` | Prefill `landingInput`. |
+| `generate=<NL>` | After auth, **auto-invoke** `POST /kratos/api/use-cases/import` with the NL, then select + open the created persona. |
+
+- Add a small `useEmbed()` hook + an `embed`-aware wrapper around the existing layout; no
+  changes to standalone behavior when params are absent.
+- "Same look and feel": embed mode is chromeless and theme-synced; the site provides the
+  surrounding frame/nav. (We are **not** restyling Kratos to the site's design system —
+  that would be heavy and brittle; chromeless + theme sync is the pragmatic "included"
+  feel the user asked for.)
+
+---
+
+## 8. Secondary PR — agentic-loop-site (separate session)
+
+Captured here for completeness; **implemented in a separate session/worktree**, not this one.
+
+- Replace the **mock** Kratos integration (`src/pages/Kratos.tsx`,
+  `src/components/KratosChatMock.tsx`, `src/data/kratos.ts` `mockKratosReply`) with:
+  - a **"Describe your agent" generate box** (can reuse the `GreenfieldBuilder` /
+    `advisor.ts` "Make it real" pattern, repurposed to persona intent), and
+  - an **embedded mount** that navigates to `/kratos/?embed=1&theme=<t>&generate=<NL>`.
+- Add the **Front Door** profile + routes that path-mount Kratos under `/kratos/*`
+  (per §6.3–6.4), including `/kratos/.auth/*` and `/kratos/api/*`.
+- No Kratos files are copied — the mount serves the live Kratos SWA.
+
+---
+
+## 9. threadlight-design contract compatibility
+
+The Import API's `contract` is a **subset/superset of threadlight's machine-readable
+contract** so personas round-trip between ecosystems:
+
+| threadlight artifact | threadlight field | Kratos Import `contract` | Kratos file |
+|---|---|---|---|
+| `specs/manifest.json` | `name`, `description` | `name`, `description` | `SYSTEM_PROMPT.md` frontmatter |
+| `AGENTS.md` | agent identity / behavior body | `instructions` | `SYSTEM_PROMPT.md` body |
+| `specs/manifest.json` | `skills[]` (`name`, `implements`) | `skills[]` | `apm.yml` `dependencies.apm[]` |
+| SPEC §5b / §6 | MCP contract / tool contracts | `mcpServers`, `tools` | `.mcp.json`, `apm.yml` `dependencies.mcp[]` |
+| `specs/manifest.json` | `traits[]` | `traits[]` | `apm.yml` metadata |
+| SPEC §11e | `workflow_model: agent\|workflow` | `workflow_model` (Kratos supports `agent`) | `apm.yml` metadata |
+| SKILL.md frontmatter | `name`, `description` (USE FOR / DO NOT USE FOR) | per-skill `name`/`description` | (future) Kratos skill files |
+
+- Kratos personas map to threadlight's **`agent`** workflow shape; `workflow` is recorded
+  as metadata but not executed by Kratos (out of scope).
+- A future enhancement (not this PR) could accept a threadlight `manifest.json` directly
+  and/or have Kratos `export.py` emit a threadlight-compatible `manifest.json` for full
+  round-trip.
+
+---
+
+## 10. Auth & SSO topology (consequences of D4 + D5)
+
+- One **browser origin** (`site.com`) via Front Door; **two SWAs**, each with its **own**
+  EasyAuth/Entra app registration.
+- EasyAuth cookies are host-scoped; with path-routing, `/.auth/*` can only point at one
+  backend per path — hence the dedicated **`/kratos/.auth/*` → Kratos SWA** rewrite.
+- The second login at `/kratos/*` is a redirect round-trip; **silent** when the user
+  already has an Entra IdP session in the browser (common, since they just logged into the
+  site), otherwise interactive. Documented as expected behavior, not a bug.
+- The Import API trusts the Kratos SWA EasyAuth principal (existing
+  `require_authenticated_user`); no new auth surface is introduced.
+
+---
+
+## 11. Risks & open questions
+
+| Risk / question | Disposition |
+|---|---|
+| Front Door `/kratos/.auth/*` rewrite correctness (EasyAuth redirect URIs must resolve under the mount) | Validate during site-PR infra work; the Entra app #2 redirect URIs must include the Front Door origin under `/kratos/.auth/login/aad/callback`. |
+| Next.js `basePath` + `trailingSlash` + static export edge cases for `_next/*` and `config.json` placement | Verify `out/` layout after `next build`; add a smoke check. |
+| Second login UX (interactive prompt if no IdP session) | Accepted per D5; document in site UX. |
+| CORS: under the mount, frontend calls `/kratos/api/*` **same-origin** (no CORS); direct cross-origin calls avoided by D7. | Keep Kratos `_cors_origins` unchanged for standalone use. |
+| `GreenfieldBuilder`/`advisor.ts` is app-scaffolding-shaped, not persona-shaped | Site PR repurposes the box to persona intent; deterministic contract optional, NL is primary. |
+| Cost/complexity of Front Door | Accepted (D3); the lower-effort iframe alt was rejected as "clumsy". |
+
+---
+
+## 12. Change inventory
+
+**Kratos PR (this repo):**
+- `src/backend/app/routers/import_persona.py` — **new** router (`POST /api/use-cases/import`).
+- `src/backend/app/main.py` — mount the new router.
+- `src/backend/app/services/blob_skill_service.py` — **new** `create_use_case(...)` (atomic write + registry registration helper).
+- `src/backend/app/models/…` — Pydantic models for the import contract.
+- `src/frontend/next.config.js` — `NEXT_PUBLIC_BASE_PATH` → `basePath`/`assetPrefix`.
+- `src/frontend/src/lib/config.ts` — basePath-aware `/config.json` fetch.
+- `src/frontend/staticwebapp.config.json` — basePath-aware `401` redirect.
+- `src/frontend/src/app/page.tsx` (+ small `useEmbed`/`useSearchParams` hook + chromeless wrapper) — embed/theme/persona/prompt/generate URL args.
+- `azure.yaml` — confirm `config.json` injection path under basePath.
+- Tests for the import mapping + endpoint.
+- This spec; session `plan.md`.
+
+**agentic-loop-site PR (separate session):**
+- Replace mock Kratos with generate box + embedded mount (`?embed=1&generate=…`).
+- Front Door profile + routes (`/kratos/*`, `/kratos/.auth/*`, `/kratos/api/*`, default → site).
+
+---
+
+## 13. Out of scope (this iteration)
+- Restyling Kratos to the site's full design system (we do chromeless + theme sync only).
+- threadlight `workflow`-shaped personas (Kratos runs `agent`-shaped only).
+- Full bidirectional round-trip (Kratos `export.py` emitting threadlight `manifest.json`).
+- Anonymous/demo mode, ephemeral personas (explicitly rejected by D4).
+- A self-mounting Front Door module inside the Kratos repo (lives in the site PR).

--- a/docs/superpowers/specs/2026-06-17-kratos-persona-import-embed-design.md
+++ b/docs/superpowers/specs/2026-06-17-kratos-persona-import-embed-design.md
@@ -1,7 +1,7 @@
 # Design Spec — Kratos Persona Import API + Embedded Hosting in agentic-loop-site
 
 - **Date:** 2026-06-17
-- **Status:** Design (approved direction, pre-implementation)
+- **Status:** Design — locked direction (manifest-first + §10.1 Variant B), pre-implementation
 - **Primary repo:** `kmavrodis/kratos-agent` (this worktree) — implemented here
 - **Secondary repo:** `aiappsgbb/agentic-loop-site` — separate PR / separate session
 - **Related skill (contract compatibility only):** `aiappsgbb/threadlight-skills → threadlight-design`
@@ -44,6 +44,7 @@ The persona **manifest the site builds must be compatible with `threadlight-desi
 | D6 | **Import endpoint is authenticated** (`require_authenticated_user`), consistent with all existing Kratos admin/export routes. | Security parity. |
 | D7 | **Import-first, then redirect.** Sequence: site builds manifest → `POST /api/use-cases/import` (manifest-in) creates the persona → **only on success** the UX deep-links into the embedded Kratos at the new persona (`?embed=1&persona=<name>`). | User directive: "Kratos imports it first (new API) then UX redirects." |
 | D8 | Import contract input is **the threadlight-`manifest.json`-compatible manifest** (structured, primary path). Optional NL `prompt` expansion in Kratos is a **secondary convenience**, off the main flow. | User NOTE about threadlight compatibility; D2 moves generation to the site. |
+| D9 | **The authenticated import call is issued from inside Kratos** (after its own EasyAuth), not cross-app from the site. The site relays the manifest via same-origin `sessionStorage['kratos.import']` → `/kratos/?embed=1&import=1` → Kratos imports on entry → settles on `?persona=<name>`. (§10.1 "Variant B".) | User-confirmed. Survives the two-EasyAuth-app split without a pre-existing Kratos session or an un-followable cross-app `fetch` redirect. |
 
 ---
 
@@ -112,36 +113,41 @@ flowchart TB
 
   U["Authenticated user"] --> FD
   R1 --> SITE["agentic-loop-site SWA · EasyAuth app #1<br/>'Describe your agent' box<br/><b>builds threadlight manifest</b>"]
-  SITE -->|"1 · POST manifest (authenticated)"| R4
+  SITE -->|"1 · relay manifest → sessionStorage['kratos.import']<br/>navigate /kratos/?embed=1&import=1"| R2
+  R2 --> KFE["Kratos frontend · EasyAuth app #2<br/>embed mode (import-on-entry)"]
+  KFE -->|"2 · EasyAuth login (silent if IdP session)"| R3
+  KFE -->|"3 · POST manifest (same-origin, Kratos cookie)"| R4
   R4 --> KBE["Kratos <b>import API</b><br/>POST /api/use-cases/import (manifest-in)"]
   KBE --> STORE["use-cases/&lt;name&gt;/<br/>SYSTEM_PROMPT.md + .mcp.json + apm.yml"]
   KBE --> REG["app.state.registries[name]"]
-  KBE -->|"201 {name}"| SITE
-  SITE -->|"2 · redirect /kratos/?embed=1&persona=&lt;name&gt;"| R2
-  R2 --> KFE["Kratos frontend · EasyAuth app #2<br/>embed mode → opens the new persona"]
+  KBE -->|"201 {name}"| KFE
+  KFE -->|"4 · settle on ?embed=1&persona=&lt;name&gt;"| KFE
 ```
 
-**End-to-end flow (import-first, then redirect — per D2/D7):**
+**End-to-end flow (Variant B — import-on-entry, then settle; per D2/D7/D9):**
 
 1. User is on `site.com` (authenticated to site EasyAuth app #1), types a description into the
    **generate box**.
 2. **The site builds the threadlight-compatible manifest** from the description (its
    advisor / its own LLM / deterministic builder — Kratos is not involved in generation).
-3. The site **POSTs the manifest** to `site.com/kratos/api/use-cases/import` (the new Kratos
-   import API). *(Auth-context note: this endpoint is gated by Kratos EasyAuth app #2 — see
-   §10.1 for exactly which page issues this authenticated call; that's the one open
-   decision below.)*
-4. Kratos import API: validate manifest → map to the three persona files → persist
+3. The site **relays the manifest** into same-origin `sessionStorage['kratos.import']`
+   (§7.1) and navigates (top-level) to `site.com/kratos/?embed=1&theme=<t>&import=1`.
+4. Front Door routes `/kratos/*` → Kratos SWA; **Kratos EasyAuth (app #2)** authenticates —
+   silent if the browser already has an Entra IdP session, otherwise an interactive prompt.
+   The manifest **survives this redirect** because storage is per-origin (the single
+   `site.com` origin), not per-path.
+5. Embed mode (chromeless) sees `import=1`, **reads-and-clears** the manifest from
+   `sessionStorage`, and **POSTs it same-origin** to `/kratos/api/use-cases/import` —
+   authenticated by the Kratos EasyAuth cookie (no cross-app `fetch`, no CORS).
+6. Kratos import API: validate manifest → map to the three persona files → persist
    (blob/local) → register `app.state.registries[name]` → return `201 {name, displayName}`.
    Slug is **auto-deduped** (`name-2`, `name-3`, …) so a name clash never dead-ends (explicit
    collisions can opt into `409`/`overwrite`).
-5. **Only on success**, the UX **redirects** into the embedded Kratos at the new persona:
-   `site.com/kratos/?embed=1&theme=<t>&persona=<name>`.
-6. Front Door routes `/kratos/*` → Kratos SWA; EasyAuth (app #2) is satisfied (already
-   established in step 3 / silent via IdP session). Embed mode (chromeless) **preselects the
-   persona**, surfaces its `sampleQuestions`, and opens the chat — the user is now talking to
-   their agent, visually "inside" the site. Import errors are surfaced **on the site** (step 4
-   response) *before* any redirect, so the embedded view only ever opens on success.
+7. **On success**, embed mode **settles on the new persona** — `history.replaceState` to
+   `?embed=1&theme=<t>&persona=<name>` (so a refresh won't re-import), preselects it,
+   surfaces its `sampleQuestions`, and opens the chat — the user is now talking to their
+   agent, visually "inside" the site. On import/registration error, embed mode shows an
+   inline "couldn't import — try again" affordance instead of the chat.
 
 ---
 
@@ -271,9 +277,9 @@ URL arguments (read in `page.tsx` via `useSearchParams`):
 |---|---|
 | `embed=1` | **Chromeless** layout: hide the standalone sidebar/header chrome so the site's own chrome wraps Kratos; tighten paddings to blend in. |
 | `theme=light\|dark` | Apply theme to match the host site (Tailwind `dark` class / data-attr). |
-| `persona=<name>` | **Primary handoff (D7).** Preselect `selectedUseCase`, surface its `sampleQuestions`, open the chat. This is the post-import landing target — import already happened on the site, so embed just *opens* the persona. (Skip gracefully if not found yet — show landing.) |
+| `persona=<name>` | **Post-import landing target (D7/D9).** Preselect `selectedUseCase`, surface its `sampleQuestions`, open the chat. Embed settles here via `history.replaceState` after a successful import. (Skip gracefully if not found yet — show landing.) |
 | `prompt=<text>` | Prefill `landingInput` (optional, e.g. seed the first question). |
-| `import=1` | **Only used by auth-variant B (§10.1).** Read the manifest handoff (§7.1), **read-and-clear** it, **POST it to `/kratos/api/use-cases/import`** from inside Kratos (after its own EasyAuth), then settle on the created persona. Absent in variant A. |
+| `import=1` | **The chosen handoff (§10.1 Variant B / D9).** Read the manifest handoff (§7.1), **read-and-clear** it, **POST it to `/kratos/api/use-cases/import`** from inside Kratos (after its own EasyAuth), then settle on `?persona=<name>`. |
 
 - Add a small `useEmbed()` hook + an `embed`-aware wrapper around the existing layout; no
   changes to standalone behavior when params are absent.
@@ -282,17 +288,9 @@ URL arguments (read in `page.tsx` via `useSearchParams`):
   that would be heavy and brittle; chromeless + theme sync is the pragmatic "included"
   feel the user asked for.)
 
-### 7.1 The handoff (depends on the §10.1 auth decision)
+### 7.1 The handoff (Variant B — locked, §10.1 / D9)
 
-**Variant A (default/recommended) — the site imports, then redirects with `persona`.**
-The site posts the manifest to the import API itself and, on `201`, navigates to
-`/kratos/?embed=1&theme=<t>&persona=<name>`. Embed mode does **no importing** — it only
-*opens* the named persona. Nothing is relayed through storage; the persona name is a short,
-safe value to carry in the URL. This is the cleanest expression of D7 ("import first, then
-redirect").
-
-**Variant B (fallback) — Kratos imports on entry via a same-origin manifest relay.**
-Used only if the site cannot make an authenticated cross-app import call (§10.1):
+Kratos imports on entry via a same-origin manifest relay:
 
 - Under Front Door, `/` and `/kratos/*` are **one browser origin** (`site.com`), so
   `sessionStorage` is **shared** (web storage is keyed by origin, not path). The site writes
@@ -303,14 +301,16 @@ Used only if the site cannot make an authenticated cross-app import call (§10.1
 - Kratos embed mode **reads the payload once and removes it** (`removeItem`) before calling
   import, so a refresh cannot re-import; on `201` it settles on `?persona=<name>` (replacing
   history so the manifest never re-runs).
+- The import call is **same-origin** (`/kratos/api/...`), carried by Kratos's own EasyAuth
+  cookie — no cross-app `fetch`, no CORS, no un-followable `401` redirect.
 - The manifest itself is **never** placed in the URL (size limits, history/edge-log leakage).
 - This relay lives in the **site PR**; the Kratos PR only **consumes** `sessionStorage`
   `['kratos.import']` + the `import` param. Standalone Kratos ignores both.
 
-Both variants converge on the same end state: an embedded, chromeless Kratos opened at the
-newly-created persona. On import/registration error, the user is kept **on the site** with a
-retry affordance (variant A surfaces the error before any redirect; variant B shows an inline
-"couldn't import — try again" panel in embed mode instead of the chat).
+On import/registration error, embed mode shows an inline "couldn't import — try again" panel
+instead of the chat. *(Optional future fast path: when a Kratos session already exists, the
+site could `POST` import directly and arrive with just `?persona=<name>` — "Variant A" in
+§10.1, not built in this PR.)*
 
 ---
 
@@ -323,12 +323,9 @@ Captured here for completeness; **implemented in a separate session/worktree**, 
   - a **"Describe your agent" generate box** that **builds the threadlight-compatible
     manifest** in the site (reusing the `GreenfieldBuilder` / `advisor.ts` "Make it real"
     pattern, repurposed to persona intent), and
-  - the **import-then-redirect** handoff per the §10.1 auth decision:
-    - **Variant A:** site `POST`s the manifest to `/kratos/api/use-cases/import`, then on
-      `201` navigates to `/kratos/?embed=1&theme=<t>&persona=<name>`.
-    - **Variant B:** site writes the manifest to `sessionStorage['kratos.import']` (§7.1)
-      and navigates to `/kratos/?embed=1&import=1` (Kratos imports on entry after its own
-      EasyAuth).
+  - the **import-then-settle** handoff (§10.1 Variant B / D9): the site writes the manifest
+    to `sessionStorage['kratos.import']` (§7.1) and navigates to `/kratos/?embed=1&theme=<t>&import=1`;
+    Kratos imports on entry (after its own EasyAuth) and settles on `?persona=<name>`.
 - Add the **Front Door** profile + routes that path-mount Kratos under `/kratos/*`
   (per §6.3–6.4), including `/kratos/.auth/*` and `/kratos/api/*`.
 - No Kratos files are copied — the mount serves the live Kratos SWA.
@@ -372,23 +369,27 @@ manifest** so personas round-trip between ecosystems:
 - The Import API trusts the Kratos SWA EasyAuth principal (existing
   `require_authenticated_user`); no new auth surface is introduced.
 
-### 10.1 OPEN DECISION — which page issues the authenticated import call?
+### 10.1 DECISION (locked) — Kratos imports on entry after its own login (Variant B)
 
 Because the import endpoint is gated by **Kratos** EasyAuth (app #2) but the generate box
-lives on the **site** (app #1), the cross-app `POST` needs a Kratos auth context. Two ways:
+lives on the **site** (app #1), the authenticated import call is issued **from inside
+Kratos**, not cross-app from the site:
 
-| | **Variant A — site calls import directly** | **Variant B — Kratos entry page imports after its own login** |
+| | **Variant A — site calls import directly** | **✅ Variant B (CHOSEN) — Kratos entry page imports after its own login** |
 |---|---|---|
 | Who POSTs the manifest | The site page (`fetch('/kratos/api/use-cases/import')`) | The embedded Kratos page, on entry |
 | Auth needed | A **Kratos (app #2) session must already exist** in the browser; if not, the cross-app `fetch` hits a `401`→login redirect a `fetch` can't follow | Kratos does its **own** EasyAuth round-trip first (silent if IdP session exists), *then* imports — always has a valid context |
 | Handoff | None — persona name carried in the redirect URL (`?persona=<name>`) | Manifest relayed via same-origin `sessionStorage['kratos.import']` (§7.1), `?import=1` |
-| Pros | Simplest; truest "import-first, then redirect"; no storage relay | Robust to a missing Kratos session; no cross-app `fetch`/CORS/401-follow problem |
-| Cons | Fragile if the user has no Kratos session yet (needs a priming top-level visit to `/kratos/.auth` first) | Import happens *inside* Kratos on entry, so the "redirect only after success" ordering is realized as "enter → import → settle on persona" |
+| Pros | Simplest; no storage relay | Robust to a missing Kratos session; no cross-app `fetch`/CORS/401-follow problem |
+| Cons | Fragile if the user has no Kratos session yet (needs a priming top-level visit to `/kratos/.auth` first) | Import happens *inside* Kratos on entry, so "redirect only after success" is realized as "enter → import → settle on persona" |
 
-**Recommendation: Variant B** — it survives the two-app EasyAuth split with no reliance on a
+**Chosen: Variant B.** It survives the two-app EasyAuth split with no reliance on a
 pre-existing Kratos session and no un-followable `fetch` redirect, at the cost of moving the
-import call one hop into Kratos. (Variant A can be offered as a fast path when a Kratos
-session is already present.) **This is the one decision to confirm before implementation.**
+import call one hop into Kratos. Variant A **may** be offered later as an optional fast path
+when a Kratos session is already present, but it is **not required** for this PR. The
+realized end-to-end sequence is therefore: site builds manifest → relay via
+`sessionStorage['kratos.import']` → enter `/kratos/?embed=1&import=1` → Kratos EasyAuth →
+import-on-entry → settle on `?persona=<name>`.
 
 ---
 
@@ -398,8 +399,8 @@ session is already present.) **This is the one decision to confirm before implem
 |---|---|
 | Front Door `/kratos/.auth/*` rewrite correctness (EasyAuth redirect URIs must resolve under the mount) | Validate during site-PR infra work; the Entra app #2 redirect URIs must include the Front Door origin under `/kratos/.auth/login/aad/callback`. |
 | Next.js `basePath` + `trailingSlash` + static export edge cases for `_next/*` and `config.json` placement | Verify `out/` layout after `next build`; add a smoke check. |
-| Second login could drop the handoff if it relied on EasyAuth query preservation | **Mitigated** in variant B by the same-origin `sessionStorage['kratos.import']` relay (§7.1) — the manifest is independent of the redirect URL, read-and-cleared after use. Variant A carries only a short `persona=<name>` in the URL. |
-| CORS / cross-app `fetch` for the import call (two EasyAuth apps) | Resolved by the §10.1 decision: variant B keeps the import call **inside Kratos** (same-origin, own EasyAuth); variant A relies on a pre-existing Kratos session. **Confirm before build.** |
+| Second login could drop the handoff if it relied on EasyAuth query preservation | **Mitigated** by the same-origin `sessionStorage['kratos.import']` relay (§7.1) — the manifest is independent of the redirect URL, read-and-cleared after use. Only a short `persona=<name>` ever appears in the URL (post-import). |
+| CORS / cross-app `fetch` for the import call (two EasyAuth apps) | **Resolved by D9 / §10.1 Variant B**: the import call runs **inside Kratos** (same-origin, Kratos's own EasyAuth cookie) — no cross-app `fetch`, no CORS, no un-followable `401`. |
 | `GreenfieldBuilder`/`advisor.ts` is app-scaffolding-shaped, not persona-shaped | Site PR repurposes the box to build a **persona manifest**; the manifest shape (§9) is the site's output contract. |
 | Cost/complexity of Front Door | Accepted (D3); the lower-effort iframe alt was rejected as "clumsy". |
 
@@ -411,19 +412,19 @@ session is already present.) **This is the one decision to confirm before implem
 - `src/backend/app/routers/import_persona.py` — **new** router (`POST /api/use-cases/import`).
 - `src/backend/app/main.py` — mount the new router.
 - `src/backend/app/services/blob_skill_service.py` — **new** `create_use_case(...)` (atomic write + registry registration helper).
-- `src/backend/app/models/…` — Pydantic models for the import contract.
+- `src/backend/app/models/…` — Pydantic models for the import **manifest** (exactly-one-of manifest/prompt).
 - `src/frontend/next.config.js` — `NEXT_PUBLIC_BASE_PATH` → `basePath`/`assetPrefix`.
 - `src/frontend/src/lib/config.ts` — basePath-aware `/config.json` fetch.
 - `src/frontend/staticwebapp.config.json` — basePath-aware `401` redirect.
-- `src/frontend/src/app/page.tsx` (+ small `useEmbed`/`useSearchParams` hook + chromeless wrapper) — embed/theme/persona/prompt URL args (+ `import=1` for §10.1 variant B).
+- `src/frontend/src/app/page.tsx` (+ small `useEmbed`/`useSearchParams` hook + chromeless wrapper) — embed/theme/persona/prompt URL args + `import=1` import-on-entry (§10.1 Variant B).
 - `azure.yaml` — confirm `config.json` injection path under basePath.
 - Tests for the import mapping + endpoint.
 - This spec; session `plan.md`.
 
 **agentic-loop-site PR (separate session):**
-- Replace mock Kratos with a generate box that **builds the manifest**, imports it, then
-  opens the embedded persona (`?embed=1&persona=<name>` for variant A, or
-  `?embed=1&import=1` + `sessionStorage['kratos.import']` for variant B).
+- Replace mock Kratos with a generate box that **builds the manifest**, relays it via
+  `sessionStorage['kratos.import']`, and enters `/kratos/?embed=1&import=1` so Kratos imports
+  on entry and settles on `?persona=<name>` (§10.1 Variant B / D9).
 - Front Door profile + routes (`/kratos/*`, `/kratos/.auth/*`, `/kratos/api/*`, default → site).
 
 ---

--- a/docs/superpowers/specs/2026-06-17-kratos-persona-import-embed-design.md
+++ b/docs/superpowers/specs/2026-06-17-kratos-persona-import-embed-design.md
@@ -121,17 +121,27 @@ flowchart TB
 **End-to-end flow (generate a persona):**
 
 1. User is on `site.com` (already authenticated to site EasyAuth app #1).
-2. User types a description into the **generate box** and submits.
-3. Site navigates to the embedded Kratos:
-   `site.com/kratos/?embed=1&theme=<t>&generate=<url-encoded NL>`.
-4. Front Door routes `/kratos/*` → Kratos SWA. Kratos EasyAuth (app #2) authenticates —
+2. User types a description into the **generate box** and submits. The site **stashes the
+   NL prompt in `sessionStorage['kratos.generate']`** (see §7.1) and navigates (top-level)
+   to `site.com/kratos/?embed=1&theme=<t>&generate=1`.
+3. Front Door routes `/kratos/*` → Kratos SWA. Kratos EasyAuth (app #2) authenticates —
    **silent** if the Entra IdP session already exists in the browser, otherwise a prompt.
-5. Embedded Kratos (chromeless) reads `?generate=`, calls
-   `POST /kratos/api/use-cases/import` (authenticated, same Kratos origin context).
-6. Import API: LLM expands NL → threadlight-compatible **contract** → maps to the three
-   Kratos files → persists (blob/local) → registers `app.state.registries[name]`.
-7. Kratos selects the new persona and opens the chat — the user is now talking to their
-   generated agent, visually "inside" the site.
+   The handoff payload **survives this redirect** because `sessionStorage` is shared across
+   the single `site.com` origin (storage is per-origin, not per-path — both backend SWAs are
+   invisible to the browser).
+4. Embedded Kratos (chromeless) sees `?generate=1`, **reads-and-clears** the handoff payload
+   from `sessionStorage` (so a refresh won't regenerate), then calls
+   `POST /kratos/api/use-cases/import` with the NL — authenticated by the EasyAuth cookie,
+   **same-origin** (no CORS), API base resolved by `config.ts`'s same-origin proxy fallback.
+5. Import API: LLM expands NL → threadlight-compatible **contract** → maps to the three
+   Kratos files → persists (blob/local) → registers `app.state.registries[name]` →
+   `201 {name, displayName}`. On the NL path the slug is **auto-deduped** (`-2`, `-3`, …) so
+   generation never dead-ends on a name clash; an explicit `contract.name` clash returns
+   `409` (unless `overwrite`).
+6. Kratos sets `selectedUseCase = name`, surfaces the persona's `sampleQuestions`, and opens
+   the chat — the user is now talking to their generated agent, visually "inside" the site.
+   On `422`/`409`/network error, embed mode shows an inline "couldn't generate — try again /
+   edit" affordance instead of the chat.
 
 ---
 
@@ -141,8 +151,11 @@ flowchart TB
 - `POST /api/use-cases/import` — new router `src/backend/app/routers/import_persona.py`,
   mounted in `main.py` under the `/api/use-cases` prefix (alongside `use_cases` / `export`).
 - **Auth-gated** with the same `require_authenticated_user` dependency used by `export.py`.
-- Returns `201` with `{ name, displayName, files: {...}, created: true }`; `409` if the
-  use-case already exists (unless `?overwrite=true`); `422` on invalid contract.
+- Returns `201` with `{ name, displayName, files: {...}, created: true }`. Name-collision
+  policy: on the **NL path** (no explicit `contract.name`) the derived slug is
+  **auto-deduped** (`name-2`, `name-3`, …) so generation never dead-ends; with an **explicit
+  `contract.name`** a clash returns `409` unless `?overwrite=true`. `422` on invalid
+  contract or malformed LLM output.
 
 ### 5.2 Request contract (hybrid; threadlight-compatible)
 Accepts **either** a structured contract, **or** a raw `prompt`, **or** both (the contract
@@ -249,7 +262,7 @@ URL arguments (read in `page.tsx` via `useSearchParams`):
 | `theme=light\|dark` | Apply theme to match the host site (Tailwind `dark` class / data-attr). |
 | `persona=<name>` | Preselect `selectedUseCase` (skip if not found). |
 | `prompt=<text>` | Prefill `landingInput`. |
-| `generate=<NL>` | After auth, **auto-invoke** `POST /kratos/api/use-cases/import` with the NL, then select + open the created persona. |
+| `generate=1` (or `generate=<short NL>`) | After auth, read the NL handoff (§7.1), **read-and-clear** it, **auto-invoke** `POST /kratos/api/use-cases/import`, then select + open the created persona. |
 
 - Add a small `useEmbed()` hook + an `embed`-aware wrapper around the existing layout; no
   changes to standalone behavior when params are absent.
@@ -257,6 +270,27 @@ URL arguments (read in `page.tsx` via `useSearchParams`):
   surrounding frame/nav. (We are **not** restyling Kratos to the site's design system —
   that would be heavy and brittle; chromeless + theme sync is the pragmatic "included"
   feel the user asked for.)
+
+### 7.1 The `generate=` handoff (same-origin sessionStorage relay)
+
+The NL prompt is **not** stuffed into the query string (URL length limits, prompt leaking
+into browser history/edge logs, fragility across the EasyAuth redirect). Instead:
+
+- Under Front Door, `/` and `/kratos/*` are **one browser origin** (`site.com`), so
+  `sessionStorage` is **shared** (web storage is keyed by origin, not path; the two backend
+  SWAs are invisible to the browser). The site writes
+  `sessionStorage.setItem('kratos.generate', JSON.stringify({ nl, theme?, persona?, prompt?, nonce }))`
+  and navigates to `/kratos/?embed=1&generate=1`.
+- The payload **survives the second EasyAuth round-trip** (same origin), so the design no
+  longer depends on EasyAuth preserving the `post_login_redirect_uri` query string.
+- Kratos embed mode **reads the payload once and removes it** (`removeItem`) before invoking
+  import, so a page refresh cannot re-trigger generation.
+- **Fallback for short prompts / no-relay contexts:** `generate=<url-encoded NL>` is still
+  accepted; if `generate` is a non-`1` value, treat it as the literal NL. If `generate=1`
+  but the relay payload is missing (e.g. opened directly), embed mode shows the normal
+  landing input instead of erroring.
+- This relay lives in the **site PR**; the Kratos PR only **consumes** `sessionStorage`
+  `['kratos.generate']` + the `generate` param. Standalone Kratos ignores both.
 
 ---
 
@@ -268,7 +302,8 @@ Captured here for completeness; **implemented in a separate session/worktree**, 
   `src/components/KratosChatMock.tsx`, `src/data/kratos.ts` `mockKratosReply`) with:
   - a **"Describe your agent" generate box** (can reuse the `GreenfieldBuilder` /
     `advisor.ts` "Make it real" pattern, repurposed to persona intent), and
-  - an **embedded mount** that navigates to `/kratos/?embed=1&theme=<t>&generate=<NL>`.
+  - an **embedded mount** that writes the NL to `sessionStorage['kratos.generate']` (§7.1)
+    and navigates to `/kratos/?embed=1&theme=<t>&generate=1`.
 - Add the **Front Door** profile + routes that path-mount Kratos under `/kratos/*`
   (per §6.3–6.4), including `/kratos/.auth/*` and `/kratos/api/*`.
 - No Kratos files are copied — the mount serves the live Kratos SWA.
@@ -318,7 +353,7 @@ contract** so personas round-trip between ecosystems:
 |---|---|
 | Front Door `/kratos/.auth/*` rewrite correctness (EasyAuth redirect URIs must resolve under the mount) | Validate during site-PR infra work; the Entra app #2 redirect URIs must include the Front Door origin under `/kratos/.auth/login/aad/callback`. |
 | Next.js `basePath` + `trailingSlash` + static export edge cases for `_next/*` and `config.json` placement | Verify `out/` layout after `next build`; add a smoke check. |
-| Second login UX (interactive prompt if no IdP session) | Accepted per D5; document in site UX. |
+| Second login could drop the `generate` payload if it relied on EasyAuth query preservation | **Mitigated** by the same-origin `sessionStorage` relay (§7.1) — the payload is independent of the redirect URL; read-and-cleared after use. |
 | CORS: under the mount, frontend calls `/kratos/api/*` **same-origin** (no CORS); direct cross-origin calls avoided by D7. | Keep Kratos `_cors_origins` unchanged for standalone use. |
 | `GreenfieldBuilder`/`advisor.ts` is app-scaffolding-shaped, not persona-shaped | Site PR repurposes the box to persona intent; deterministic contract optional, NL is primary. |
 | Cost/complexity of Front Door | Accepted (D3); the lower-effort iframe alt was rejected as "clumsy". |

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -23,6 +23,7 @@ from app.routers import (
     export,
     files,
     health,
+    import_persona,
     settings,
     traces,
     use_cases,
@@ -245,6 +246,7 @@ app.include_router(admin_mcp.router, prefix="/api/admin/mcp-servers", tags=["adm
 app.include_router(admin_apm.router, prefix="/api/admin/use-cases/{use_case}/apm", tags=["admin"])
 app.include_router(admin_analysis.router, prefix="/api/admin/analysis", tags=["admin"])
 app.include_router(use_cases.router, prefix="/api/use-cases", tags=["use-cases"])
+app.include_router(import_persona.router, prefix="/api/use-cases", tags=["import"])
 app.include_router(export.router, prefix="/api/use-cases", tags=["export"])
 app.include_router(evals.router, prefix="/api/use-cases", tags=["evals"])
 app.include_router(traces.router, prefix="/api/traces", tags=["traces"])

--- a/src/backend/app/models.py
+++ b/src/backend/app/models.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 # ─── Enums ───
 
@@ -297,6 +297,83 @@ class UseCaseList(BaseModel):
     """List of available use-cases."""
 
     useCases: list[UseCaseInfo]
+
+
+# ─── Persona Import (threadlight-design-compatible manifest) ─────────────────
+
+
+class ImportSkill(BaseModel):
+    """A skill reference in the import manifest.
+
+    Maps to ``apm.yml`` ``dependencies.apm[]`` when ``package`` is given.
+    ``implements`` carries threadlight ``BR-XXX`` traceability (metadata only).
+    """
+
+    name: str
+    description: str = ""
+    package: str | None = None
+    implements: list[str] = Field(default_factory=list)
+
+
+class ImportMcpServer(BaseModel):
+    """An MCP server reference → ``.mcp.json`` + ``apm.yml`` ``dependencies.mcp[]``."""
+
+    name: str
+    transport: str = "http"
+    url: str | None = None
+    registry: bool = False
+
+
+class PersonaManifest(BaseModel):
+    """threadlight-design-compatible persona manifest consumed by the import API.
+
+    Field names mirror threadlight's ``specs/manifest.json`` / ``AGENTS.md`` so
+    personas round-trip between ecosystems (see design spec §9).
+    """
+
+    name: str
+    description: str = ""
+    instructions: str = ""
+    displayName: str | None = None
+    sampleQuestions: list[str] = Field(default_factory=list)
+    skills: list[ImportSkill] = Field(default_factory=list)
+    mcpServers: list[ImportMcpServer] = Field(default_factory=list)
+    traits: list[str] = Field(default_factory=list)
+    workflow_model: Literal["agent", "workflow"] = "agent"
+
+
+class PersonaImportRequest(BaseModel):
+    """Import request body — exactly one of ``manifest`` or ``prompt``.
+
+    ``manifest`` is the primary, deterministic path (no LLM). ``prompt`` is a
+    secondary natural-language convenience that is expanded into a manifest via
+    the Foundry model before the same deterministic mapping runs.
+    """
+
+    manifest: PersonaManifest | None = None
+    prompt: str | None = None
+    name: str | None = None
+    overwrite: bool = False
+    dedupe: bool = True
+
+    @model_validator(mode="after")
+    def _exactly_one_source(self) -> "PersonaImportRequest":
+        if (self.manifest is None) == (self.prompt is None):
+            raise ValueError("Provide exactly one of 'manifest' or 'prompt'")
+        if self.prompt is not None and not self.prompt.strip():
+            raise ValueError("'prompt' must not be empty")
+        return self
+
+
+class PersonaImportResponse(BaseModel):
+    """Result of a persona import."""
+
+    name: str
+    displayName: str
+    description: str
+    skillCount: int
+    created: bool
+    files: list[str]
 
 
 class SystemPromptResponse(BaseModel):

--- a/src/backend/app/routers/import_persona.py
+++ b/src/backend/app/routers/import_persona.py
@@ -1,0 +1,276 @@
+"""Persona import API — create a Kratos use-case from a threadlight manifest.
+
+``POST /api/use-cases/import`` accepts a threadlight-design-compatible persona
+manifest (the primary, deterministic path — no LLM) and maps it onto the three
+core persona files Kratos already understands:
+
+* ``SYSTEM_PROMPT.md`` — frontmatter (name/description/sampleQuestions/curated)
+  plus the manifest ``instructions`` as the body.
+* ``.mcp.json``        — Copilot MCP config built from ``mcpServers``.
+* ``apm.yml``          — APM manifest carrying ``skills`` (→ ``dependencies.apm``)
+  and ``mcpServers`` (→ ``dependencies.mcp``), with ``traits``/``workflow_model``
+  recorded under ``metadata.kratos``.
+
+The persona is persisted (blob + local mirror) and registered live in
+``app.state.registries`` so it is immediately selectable in the UI.
+
+A secondary natural-language ``prompt`` path is supported: the prompt is
+expanded into a manifest via the Foundry model and then runs through the exact
+same deterministic mapping. See design spec §5.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+
+import yaml
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from app.auth import require_authenticated_user
+from app.models import (
+    ImportMcpServer,
+    PersonaImportRequest,
+    PersonaImportResponse,
+    PersonaManifest,
+)
+from app.services.blob_skill_service import BlobSkillService
+from app.services.skill_registry import SkillRegistry
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_USE_CASE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+
+_auth_dep = Depends(require_authenticated_user)
+
+
+# ─── Slug helpers ────────────────────────────────────────────────────────────
+
+
+def _slugify(value: str) -> str:
+    """Normalise an arbitrary string into a valid use-case slug.
+
+    Produces a value matching ``^[a-z0-9][a-z0-9-]{0,63}$`` or ``"persona"``
+    when nothing usable remains.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", value.strip().lower())
+    slug = re.sub(r"-+", "-", slug).strip("-")[:64].strip("-")
+    if not slug or not slug[0].isalnum():
+        slug = f"persona-{slug}".strip("-")[:64] if slug else "persona"
+    return slug or "persona"
+
+
+async def _resolve_slug(
+    base: str,
+    *,
+    registries: dict[str, SkillRegistry],
+    blob_service: BlobSkillService,
+    overwrite: bool,
+    dedupe: bool,
+) -> str:
+    """Resolve the final slug, honouring overwrite / dedupe semantics.
+
+    * ``overwrite`` → return ``base`` unchanged (existing persona replaced).
+    * ``dedupe``    → return the first free ``base``, ``base-2``, ``base-3`` …
+    * otherwise     → return ``base``; the caller raises 409 if it exists.
+    """
+    if overwrite:
+        return base
+
+    async def _taken(name: str) -> bool:
+        return name in registries or await blob_service.use_case_exists(name)
+
+    if not dedupe:
+        return base
+
+    if not await _taken(base):
+        return base
+    for n in range(2, 1000):
+        candidate = f"{base}-{n}"[:64].strip("-")
+        if not await _taken(candidate):
+            return candidate
+    raise HTTPException(status_code=409, detail="Unable to allocate a unique persona slug")
+
+
+# ─── Manifest → persona files mapping ────────────────────────────────────────
+
+
+def _build_system_prompt(manifest: PersonaManifest, slug: str) -> str:
+    """Render SYSTEM_PROMPT.md (frontmatter + instructions body)."""
+    display = manifest.displayName or manifest.name or slug.replace("-", " ").title()
+    frontmatter: dict = {
+        "name": display,
+        "description": manifest.description,
+        "sampleQuestions": list(manifest.sampleQuestions),
+        "curated": True,
+    }
+    fm_yaml = yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True).strip()
+    body = manifest.instructions.strip() or f"You are {display}, an enterprise AI assistant."
+    return f"---\n{fm_yaml}\n---\n\n{body}\n"
+
+
+def _build_mcp_json(servers: list[ImportMcpServer]) -> str:
+    """Render .mcp.json (Copilot MCP config) from the manifest MCP servers."""
+    config: dict[str, dict] = {}
+    for server in servers:
+        entry: dict = {"type": server.transport}
+        if server.url:
+            entry["url"] = server.url
+        config[server.name] = entry
+    return json.dumps(config, indent=2) + "\n"
+
+
+def _build_apm_yml(manifest: PersonaManifest, slug: str) -> str:
+    """Render apm.yml carrying skill + MCP dependencies and Kratos metadata."""
+    apm_packages = [s.package for s in manifest.skills if s.package]
+    mcp_deps = [
+        {
+            "name": s.name,
+            "registry": s.registry,
+            "transport": s.transport,
+            **({"url": s.url} if s.url else {}),
+        }
+        for s in manifest.mcpServers
+    ]
+
+    dependencies: dict = {}
+    if apm_packages:
+        dependencies["apm"] = apm_packages
+    if mcp_deps:
+        dependencies["mcp"] = mcp_deps
+
+    data: dict = {
+        "name": f"kratos-{slug}",
+        "version": "1.0.0",
+        "description": manifest.description or f"Kratos persona — {slug}",
+        "author": "kratos-import",
+        "license": "MIT",
+        "target": "copilot",
+        "dependencies": dependencies,
+        "metadata": {
+            "kratos": {
+                "traits": list(manifest.traits),
+                "workflow_model": manifest.workflow_model,
+                "skills": [s.name for s in manifest.skills],
+            }
+        },
+    }
+    return yaml.safe_dump(data, sort_keys=False, allow_unicode=True)
+
+
+# ─── Natural-language (secondary) path ───────────────────────────────────────
+
+_NL_SYSTEM_PROMPT = """\
+You convert a short natural-language description of an AI agent persona into a
+strict JSON manifest. Respond with ONLY a JSON object, no prose, matching:
+
+{
+  "name": "short human name",
+  "description": "one sentence",
+  "instructions": "the system prompt body — how the agent should behave",
+  "sampleQuestions": ["3-5 example user questions"],
+  "skills": [{"name": "kebab-name", "description": "what it does"}],
+  "mcpServers": [],
+  "traits": ["optional descriptive traits"],
+  "workflow_model": "agent"
+}
+
+Keep instructions concise and actionable. Do not invent MCP servers or skill
+packages the user did not ask for.\
+"""
+
+
+async def _expand_prompt_to_manifest(prompt: str) -> PersonaManifest:
+    """Expand a natural-language prompt into a PersonaManifest via the model."""
+    from app.routers.admin_analysis import _call_llm
+
+    raw = await _call_llm(_NL_SYSTEM_PROMPT, prompt, json_mode=True)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.error("NL manifest expansion returned invalid JSON: %s", raw[:500])
+        raise HTTPException(status_code=502, detail="Model returned invalid manifest JSON") from exc
+    try:
+        return PersonaManifest.model_validate(data)
+    except Exception as exc:  # noqa: BLE001 — surface validation as 502 (model output)
+        logger.error("NL manifest failed validation: %s", exc)
+        raise HTTPException(status_code=502, detail=f"Model manifest failed validation: {exc}") from exc
+
+
+# ─── Endpoint ────────────────────────────────────────────────────────────────
+
+
+@router.post("/import", response_model=PersonaImportResponse, status_code=201)
+async def import_persona(
+    request: Request,
+    body: PersonaImportRequest,
+    _principal: dict = _auth_dep,
+) -> PersonaImportResponse:
+    """Create a Kratos persona from a threadlight manifest (or NL prompt).
+
+    Returns ``201`` with the created persona summary. ``409`` when the slug is
+    taken and neither ``overwrite`` nor ``dedupe`` apply. ``422`` for an invalid
+    request body. ``502`` when the optional NL expansion fails.
+    """
+    blob_service: BlobSkillService | None = getattr(request.app.state, "blob_skill_service", None)
+    registries: dict[str, SkillRegistry] | None = getattr(request.app.state, "registries", None)
+    if blob_service is None or registries is None:
+        raise HTTPException(status_code=503, detail="Persona storage is not initialised")
+
+    manifest = body.manifest or await _expand_prompt_to_manifest(body.prompt or "")
+
+    base_slug = _slugify(body.name or manifest.name)
+    if not _USE_CASE_NAME_RE.match(base_slug):
+        raise HTTPException(status_code=422, detail="Could not derive a valid persona name")
+
+    already_exists = base_slug in registries or await blob_service.use_case_exists(base_slug)
+    if already_exists and not body.overwrite and not body.dedupe:
+        raise HTTPException(status_code=409, detail=f"Persona '{base_slug}' already exists")
+
+    slug = await _resolve_slug(
+        base_slug,
+        registries=registries,
+        blob_service=blob_service,
+        overwrite=body.overwrite,
+        dedupe=body.dedupe,
+    )
+    replaced = body.overwrite and (slug in registries or await blob_service.use_case_exists(slug))
+
+    system_prompt_md = _build_system_prompt(manifest, slug)
+    mcp_json = _build_mcp_json(manifest.mcpServers)
+    apm_yml = _build_apm_yml(manifest, slug)
+
+    try:
+        files = await blob_service.create_use_case(
+            slug,
+            system_prompt_md=system_prompt_md,
+            mcp_json=mcp_json,
+            apm_yml=apm_yml,
+            overwrite=body.overwrite,
+        )
+    except FileExistsError as exc:
+        raise HTTPException(status_code=409, detail=f"Persona '{slug}' already exists") from exc
+
+    apm_service = getattr(request.app.state, "apm_service", None)
+    registry = SkillRegistry()
+    await registry.load(
+        slug,
+        blob_service,
+        apm_service=apm_service,
+        local_root=str(blob_service.local_base_dir),
+    )
+    registries[slug] = registry
+
+    display = manifest.displayName or manifest.name or slug.replace("-", " ").title()
+    logger.info("Imported persona '%s' (replaced=%s, skills=%d)", slug, replaced, len(registry.skills))
+    return PersonaImportResponse(
+        name=slug,
+        displayName=display,
+        description=manifest.description,
+        skillCount=len(registry.skills),
+        created=not replaced,
+        files=files,
+    )

--- a/src/backend/app/routers/import_persona.py
+++ b/src/backend/app/routers/import_persona.py
@@ -113,13 +113,27 @@ def _build_system_prompt(manifest: PersonaManifest, slug: str) -> str:
 
 
 def _build_mcp_json(servers: list[ImportMcpServer]) -> str:
-    """Render .mcp.json (Copilot MCP config) from the manifest MCP servers."""
+    """Render .mcp.json (Copilot MCP config) from the manifest MCP servers.
+
+    ``.mcp.json`` is loaded verbatim into the Copilot SDK session config, so every
+    entry must be runnable. A remote (http/sse) server needs a ``url``; a registry
+    reference without one cannot be expressed here deterministically (it would need
+    ``apm install`` to resolve a command/url). Such entries are therefore skipped —
+    they remain recorded in ``apm.yml`` ``dependencies.mcp`` for later resolution —
+    so the imported persona never carries a non-startable MCP server.
+    """
     config: dict[str, dict] = {}
     for server in servers:
-        entry: dict = {"type": server.transport}
-        if server.url:
-            entry["url"] = server.url
-        config[server.name] = entry
+        if not server.url:
+            logger.info(
+                "Skipping MCP server '%s' in .mcp.json: no url (registry=%s, transport=%s); "
+                "kept in apm.yml dependencies.mcp for later resolution",
+                server.name,
+                server.registry,
+                server.transport,
+            )
+            continue
+        config[server.name] = {"type": server.transport, "url": server.url}
     return json.dumps(config, indent=2) + "\n"
 
 

--- a/src/backend/app/services/blob_skill_service.py
+++ b/src/backend/app/services/blob_skill_service.py
@@ -263,6 +263,62 @@ class BlobSkillService:
         blob_path = f"{_USE_CASES_PREFIX}{use_case}/{filename}"
         await self.upload_file(blob_path, content)
 
+    async def use_case_exists(self, use_case: str) -> bool:
+        """Return True if a use-case already exists in blob or on local disk."""
+        if self._container_client and use_case in await self.list_use_cases():
+            return True
+        local = self.local_dir(use_case)
+        return local.is_dir() and (local / "SYSTEM_PROMPT.md").exists()
+
+    async def create_use_case(
+        self,
+        use_case: str,
+        *,
+        system_prompt_md: str,
+        mcp_json: str,
+        apm_yml: str,
+        overwrite: bool = False,
+    ) -> list[str]:
+        """Create a new use-case from its three core persona files.
+
+        Writes ``SYSTEM_PROMPT.md``, ``.mcp.json`` and ``apm.yml`` to blob
+        storage (when configured) and always mirrors them to the local
+        filesystem so a freshly constructed :class:`SkillRegistry` can read
+        them immediately — both via the blob→local sync path and the
+        local-fallback path.
+
+        Args:
+            use_case: The (already validated) use-case slug.
+            system_prompt_md: Full SYSTEM_PROMPT.md content incl. frontmatter.
+            mcp_json: Serialized ``.mcp.json`` (Copilot MCP config shape).
+            apm_yml: Serialized ``apm.yml`` APM manifest.
+            overwrite: When False and the use-case exists, raise FileExistsError.
+
+        Returns:
+            The list of relative file paths that were written.
+        """
+        if not overwrite and await self.use_case_exists(use_case):
+            raise FileExistsError(use_case)
+
+        files: dict[str, bytes] = {
+            "SYSTEM_PROMPT.md": system_prompt_md.encode("utf-8"),
+            ".mcp.json": mcp_json.encode("utf-8"),
+            "apm.yml": apm_yml.encode("utf-8"),
+        }
+
+        local_dir = self.local_dir(use_case)
+        local_dir.mkdir(parents=True, exist_ok=True)
+        for name, content in files.items():
+            (local_dir / name).write_bytes(content)
+
+        if self._container_client:
+            await self.upload_file(f"{_USE_CASES_PREFIX}{use_case}/SYSTEM_PROMPT.md", files["SYSTEM_PROMPT.md"])
+            await self.upload_mcp_config(use_case, files[".mcp.json"])
+            await self.upload_apm_manifest(use_case, "apm.yml", files["apm.yml"])
+
+        logger.info("Created use-case '%s' (%d files, blob=%s)", use_case, len(files), self.is_available)
+        return [f"{_USE_CASES_PREFIX}{use_case}/{name}" for name in files]
+
     # ─── Internal helpers ─────────────────────────────────────────────────
 
     async def download_blob(self, blob_path: str) -> bytes | None:

--- a/src/backend/tests/test_import_persona.py
+++ b/src/backend/tests/test_import_persona.py
@@ -1,0 +1,143 @@
+"""Tests for the persona import API (``POST /api/use-cases/import``)."""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(tmp_path: Path):
+    """TestClient with a local-only BlobSkillService and an empty registry map."""
+    from app.config import Settings
+    from app.main import app
+    from app.services.blob_skill_service import BlobSkillService
+
+    blob_service = BlobSkillService(Settings(), local_base_dir=str(tmp_path / "use-cases"))
+    app.state.blob_skill_service = blob_service
+    app.state.registries = {}
+    app.state.apm_service = None
+
+    yield TestClient(app, raise_server_exceptions=False)
+
+    app.dependency_overrides.clear()
+
+
+def _manifest(**overrides) -> dict:
+    base = {
+        "name": "Claims Triage Bot",
+        "description": "Triages insurance claims and flags fraud signals.",
+        "instructions": "You are a claims triage assistant. Be precise and cite policy rules.",
+        "sampleQuestions": ["Triage claim 12345", "What is the fraud score for claim 999?"],
+        "skills": [
+            {"name": "fraud-check", "description": "Score fraud risk", "package": "acme/skills/skills/fraud-check"},
+            {"name": "no-package-skill", "description": "metadata only"},
+        ],
+        "mcpServers": [
+            {"name": "microsoft-learn", "transport": "http", "url": "https://learn.microsoft.com/api/mcp"}
+        ],
+        "traits": ["analysis", "validation"],
+        "workflow_model": "agent",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_import_manifest_creates_persona(client, tmp_path):
+    resp = client.post("/api/use-cases/import", json={"manifest": _manifest()})
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["name"] == "claims-triage-bot"
+    assert data["displayName"] == "Claims Triage Bot"
+    assert data["created"] is True
+    assert data["files"]
+
+    # Persona registered live
+    from app.main import app
+
+    assert "claims-triage-bot" in app.state.registries
+
+    # Files written to the local mirror
+    uc_dir = tmp_path / "use-cases" / "claims-triage-bot"
+    assert (uc_dir / "SYSTEM_PROMPT.md").exists()
+    assert (uc_dir / ".mcp.json").exists()
+    assert (uc_dir / "apm.yml").exists()
+
+
+def test_system_prompt_frontmatter_mapping(client, tmp_path):
+    client.post("/api/use-cases/import", json={"manifest": _manifest()})
+    text = (tmp_path / "use-cases" / "claims-triage-bot" / "SYSTEM_PROMPT.md").read_text()
+    assert text.startswith("---\n")
+    fm_block = text.split("---\n", 2)[1]
+    fm = yaml.safe_load(fm_block)
+    assert fm["name"] == "Claims Triage Bot"
+    assert fm["description"].startswith("Triages insurance claims")
+    assert fm["curated"] is True
+    assert "Triage claim 12345" in fm["sampleQuestions"]
+    # Instructions become the body
+    assert "claims triage assistant" in text.split("---\n", 2)[2]
+
+
+def test_apm_and_mcp_mapping(client, tmp_path):
+    client.post("/api/use-cases/import", json={"manifest": _manifest()})
+    uc_dir = tmp_path / "use-cases" / "claims-triage-bot"
+
+    apm = yaml.safe_load((uc_dir / "apm.yml").read_text())
+    assert apm["name"] == "kratos-claims-triage-bot"
+    assert apm["dependencies"]["apm"] == ["acme/skills/skills/fraud-check"]
+    assert apm["dependencies"]["mcp"][0]["name"] == "microsoft-learn"
+    assert apm["metadata"]["kratos"]["traits"] == ["analysis", "validation"]
+    assert apm["metadata"]["kratos"]["workflow_model"] == "agent"
+
+    mcp = json.loads((uc_dir / ".mcp.json").read_text())
+    assert mcp["microsoft-learn"]["url"] == "https://learn.microsoft.com/api/mcp"
+    assert mcp["microsoft-learn"]["type"] == "http"
+
+
+def test_import_dedupes_slug(client):
+    first = client.post("/api/use-cases/import", json={"manifest": _manifest()})
+    second = client.post("/api/use-cases/import", json={"manifest": _manifest()})
+    assert first.json()["name"] == "claims-triage-bot"
+    assert second.status_code == 201
+    assert second.json()["name"] == "claims-triage-bot-2"
+
+
+def test_import_overwrite_replaces(client):
+    client.post("/api/use-cases/import", json={"manifest": _manifest()})
+    resp = client.post(
+        "/api/use-cases/import",
+        json={"manifest": _manifest(description="updated"), "overwrite": True},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["name"] == "claims-triage-bot"
+    assert resp.json()["created"] is False
+
+
+def test_conflict_when_no_dedupe_no_overwrite(client):
+    client.post("/api/use-cases/import", json={"manifest": _manifest()})
+    resp = client.post(
+        "/api/use-cases/import",
+        json={"manifest": _manifest(), "dedupe": False},
+    )
+    assert resp.status_code == 409
+
+
+def test_requires_exactly_one_source(client):
+    both = client.post(
+        "/api/use-cases/import",
+        json={"manifest": _manifest(), "prompt": "make a bot"},
+    )
+    assert both.status_code == 422
+    neither = client.post("/api/use-cases/import", json={})
+    assert neither.status_code == 422
+
+
+def test_auth_enforced_when_enabled(client):
+    from app.config import Settings, get_settings
+    from app.main import app
+
+    app.dependency_overrides[get_settings] = lambda: Settings(admin_auth_enabled="true")
+    resp = client.post("/api/use-cases/import", json={"manifest": _manifest()})
+    assert resp.status_code == 401

--- a/src/backend/tests/test_import_persona.py
+++ b/src/backend/tests/test_import_persona.py
@@ -96,6 +96,31 @@ def test_apm_and_mcp_mapping(client, tmp_path):
     assert mcp["microsoft-learn"]["type"] == "http"
 
 
+def test_url_less_mcp_server_skipped_in_mcp_json(client, tmp_path):
+    # A registry reference with no url cannot be a runnable Copilot MCP entry, so
+    # it must be skipped in .mcp.json (kept only in apm.yml) — never written as a
+    # non-startable {"type": "http"} entry. This is exactly what the host site
+    # emits for its `mcp-tools` / `m365-graph` requirements.
+    manifest = _manifest(
+        mcpServers=[
+            {"name": "tools", "transport": "http", "registry": True},
+            {"name": "microsoft-learn", "transport": "http", "url": "https://learn.microsoft.com/api/mcp"},
+        ]
+    )
+    resp = client.post("/api/use-cases/import", json={"manifest": manifest})
+    assert resp.status_code == 201, resp.text
+    uc_dir = tmp_path / "use-cases" / "claims-triage-bot"
+
+    mcp = json.loads((uc_dir / ".mcp.json").read_text())
+    assert "tools" not in mcp  # url-less → skipped, no broken entry
+    assert mcp["microsoft-learn"]["url"] == "https://learn.microsoft.com/api/mcp"
+
+    # The dependency is still recorded in apm.yml for later resolution.
+    apm = yaml.safe_load((uc_dir / "apm.yml").read_text())
+    mcp_dep_names = {d["name"] for d in apm["dependencies"]["mcp"]}
+    assert {"tools", "microsoft-learn"} <= mcp_dep_names
+
+
 def test_import_dedupes_slug(client):
     first = client.post("/api/use-cases/import", json={"manifest": _manifest()})
     second = client.post("/api/use-cases/import", json={"manifest": _manifest()})

--- a/src/frontend/next.config.js
+++ b/src/frontend/next.config.js
@@ -1,12 +1,21 @@
 /** @type {import('next').NextConfig} */
+
+// Optional sub-path mount (e.g. "/kratos") so the static export can be hosted
+// under a path of another origin (Front Door) without copying Kratos files.
+// Empty/unset → mounted at the origin root (standalone deployment).
+const rawBasePath = (process.env.NEXT_PUBLIC_BASE_PATH || "").replace(/\/+$/, "");
+const basePath = rawBasePath.startsWith("/") ? rawBasePath : rawBasePath ? `/${rawBasePath}` : "";
+
 const nextConfig = {
   output: "export",
   trailingSlash: true,
+  ...(basePath ? { basePath, assetPrefix: basePath } : {}),
   images: {
     unoptimized: true,
   },
   env: {
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || "",
+    NEXT_PUBLIC_BASE_PATH: basePath,
     NEXT_PUBLIC_MSAL_CLIENT_ID: process.env.NEXT_PUBLIC_MSAL_CLIENT_ID || "",
     NEXT_PUBLIC_MSAL_AUTHORITY: process.env.NEXT_PUBLIC_MSAL_AUTHORITY || "",
   },

--- a/src/frontend/src/app/globals.css
+++ b/src/frontend/src/app/globals.css
@@ -38,6 +38,60 @@
   color-scheme: light;
 }
 
+/* Agentic Loop — branded palette so Kratos matches the agentic-loop-site host
+   when embedded under /kratos (aurora purple + cyan on near-black). Light and
+   dark variants mirror the host's :root[data-theme] tokens. */
+[data-theme="agentic-loop"] {
+  --bg:           #f6f7fb;
+  --surface:      #ffffff;
+  --surface-2:    #f0f2f8;
+  --border:       #dfe3ee;
+  --border-soft:  #e7ebf3;
+  --hover:        #eceff6;
+  --text:         #0e1422;
+  --text-strong:  #000000;
+  --muted:        #4a546a;
+  --muted-strong: #2f3748;
+  --accent:       #6b46ff;
+  --accent-hover: #5a37e6;
+  --accent-fg:    #ffffff;
+  --accent-soft:  rgba(107, 70, 255, 0.10);
+  --ask-accent:   #0ea5e9;
+  --ask-accent-fg:#ffffff;
+  --ask-border:   rgba(14, 165, 233, 0.30);
+  --ask-bg:       rgba(14, 165, 233, 0.08);
+  --code-fg:      #ec4899;
+  --shadow-card:  0 1px 2px rgba(15,23,42,0.06), 0 2px 8px rgba(15,23,42,0.05);
+  --font-display: 'Inter';
+  --font-mono:    'JetBrains Mono';
+  color-scheme: light;
+}
+[data-theme="agentic-loop"].dark {
+  --bg:           #07080c;
+  --surface:      #0c0f16;
+  --surface-2:    #121622;
+  --border:       #222838;
+  --border-soft:  #161b28;
+  --hover:        #161b28;
+  --text:         #e8ecf4;
+  --text-strong:  #ffffff;
+  --muted:        #9aa4b8;
+  --muted-strong: #b6bfd0;
+  --accent:       #7c5cff;
+  --accent-hover: #9579ff;
+  --accent-fg:    #ffffff;
+  --accent-soft:  rgba(124, 92, 255, 0.16);
+  --ask-accent:   #34d2ff;
+  --ask-accent-fg:#07080c;
+  --ask-border:   rgba(52, 210, 255, 0.32);
+  --ask-bg:       rgba(52, 210, 255, 0.10);
+  --code-fg:      #ff5ca8;
+  --shadow-card:  0 1px 2px rgba(0,0,0,0.5), 0 2px 8px rgba(0,0,0,0.4);
+  --font-display: 'Inter';
+  --font-mono:    'JetBrains Mono';
+  color-scheme: dark;
+}
+
 [data-theme="tokyo-night"] {
   --bg:           #e1e2e7;
   --surface:      #eaebef;

--- a/src/frontend/src/app/page.tsx
+++ b/src/frontend/src/app/page.tsx
@@ -7,8 +7,14 @@ import { SettingsModal } from "@/components/SettingsModal";
 import { SkillsAdminPanel } from "@/components/SkillsAdminPanel";
 import AgentLoop from "@/components/AgentLoop";
 import { Conversation, UseCase, Skill } from "@/types";
-import { listUseCases, listConversations, createConversation, deleteConversation, listSkills } from "@/lib/api";
+import { listUseCases, listConversations, createConversation, deleteConversation, listSkills, importPersona } from "@/lib/api";
 import { loadRuntimeConfig } from "@/lib/config";
+import { readEmbedParams, takeImportManifest, settlePersonaUrl, type EmbedParams } from "@/lib/embed";
+import { useTheme, THEMES, type ThemeName, type Mode } from "@/components/ThemeProvider";
+
+type ImportStatus = "idle" | "importing" | "error" | "done";
+
+const THEME_NAMES = new Set(THEMES.map((t) => t.id));
 
 export default function Home() {
   const [conversations, setConversations] = useState<Conversation[]>([]);
@@ -25,6 +31,21 @@ export default function Home() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [agenticLoopOpen, setAgenticLoopOpen] = useState(false);
   const [configReady, setConfigReady] = useState(false);
+
+  // Embed mode (chromeless hosting under another origin — design spec §C)
+  const [embed, setEmbed] = useState<EmbedParams>({
+    embed: false, theme: null, persona: null, prompt: null, doImport: false,
+  });
+  const [importStatus, setImportStatus] = useState<ImportStatus>("idle");
+  const [importError, setImportError] = useState<string | null>(null);
+  const importManifestRef = useRef<unknown>(null);
+  const bootstrappedRef = useRef(false);
+  const { setTheme, setMode } = useTheme();
+
+  // Read embed args from the URL once on mount (client-only static export).
+  useEffect(() => {
+    setEmbed(readEmbedParams());
+  }, []);
 
   useEffect(() => {
     // Load runtime config (resolves API URL from /config.json if present)
@@ -71,12 +92,13 @@ export default function Home() {
   };
 
   // Create a conversation and optionally pre-fill a message
-  const startConversation = async (message?: string) => {
+  const startConversation = async (message?: string, useCaseOverride?: string) => {
+    const useCase = useCaseOverride ?? selectedUseCase;
     const tempId = crypto.randomUUID();
     const optimistic: Conversation = {
       id: tempId,
       title: "New Conversation",
-      useCase: selectedUseCase,
+      useCase,
       status: "active",
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -86,7 +108,7 @@ export default function Home() {
     setLandingInput("");
 
     try {
-      const saved = await createConversation("New Conversation", selectedUseCase) as Conversation;
+      const saved = await createConversation("New Conversation", useCase) as Conversation;
       const real = { ...optimistic, id: saved.id };
       setConversations((prev) =>
         prev.map((c) => (c.id === tempId ? real : c))
@@ -134,6 +156,78 @@ export default function Home() {
 
   const closeSidebar = useCallback(() => setSidebarOpen(false), []);
 
+  // Run the relayed manifest import (separated so the error UI can retry it).
+  const runImport = useCallback(async () => {
+    const manifest = importManifestRef.current;
+    if (!manifest) {
+      setImportStatus("error");
+      setImportError("No persona manifest was found to import. Please start again from the host.");
+      return;
+    }
+    setImportStatus("importing");
+    setImportError(null);
+    const promptText = readEmbedParams().prompt;
+    try {
+      const result = await importPersona(manifest);
+      // Make the freshly-imported persona selectable and refresh the catalog.
+      setUseCases((prev) =>
+        prev.find((uc) => uc.name === result.name)
+          ? prev
+          : [...prev, {
+              name: result.name,
+              displayName: result.displayName,
+              description: result.description,
+              skillCount: result.skillCount,
+              sampleQuestions: [],
+            }],
+      );
+      listUseCases().then(setUseCases).catch(() => {});
+      setSelectedUseCase(result.name);
+      settlePersonaUrl(result.name);
+      setImportStatus("done");
+      if (promptText) {
+        startConversation(promptText, result.name);
+      }
+    } catch (err) {
+      setImportStatus("error");
+      setImportError(err instanceof Error ? err.message : "Import failed. Please try again.");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Embed bootstrap: apply theme, then import / open persona / auto-prompt.
+  // Runs once after runtime config + use-cases are ready.
+  useEffect(() => {
+    if (!configReady || bootstrappedRef.current) return;
+    const params = readEmbedParams();
+    if (!params.embed) return;
+    bootstrappedRef.current = true;
+
+    // Sync theme: accept a light/dark mode or a named Kratos theme.
+    if (params.theme) {
+      if (params.theme === "light" || params.theme === "dark") {
+        setMode(params.theme as Mode);
+      } else if (THEME_NAMES.has(params.theme as ThemeName)) {
+        setTheme(params.theme as ThemeName);
+      }
+    }
+
+    if (params.doImport) {
+      importManifestRef.current = takeImportManifest();
+      runImport();
+      return;
+    }
+    if (params.persona) {
+      setSelectedUseCase(params.persona);
+      if (params.prompt) startConversation(params.prompt, params.persona);
+      return;
+    }
+    if (params.prompt) {
+      startConversation(params.prompt);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [configReady, runImport, setMode, setTheme]);
+
   return (
     <div className="flex h-screen overflow-hidden">
       {/* Skip to content link for accessibility */}
@@ -145,14 +239,15 @@ export default function Home() {
       </a>
 
       {/* Mobile sidebar overlay */}
-      {sidebarOpen && (
+      {!embed.embed && sidebarOpen && (
         <div
           className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 lg:hidden animate-fade-in"
           onClick={closeSidebar}
         />
       )}
 
-      {/* Sidebar */}
+      {/* Sidebar — hidden in embed mode (chromeless hosting) */}
+      {!embed.embed && (
       <div className={`
         fixed inset-y-0 left-0 z-50 w-[300px] transform transition-transform duration-300 ease-out
         lg:relative lg:translate-x-0 lg:z-auto
@@ -173,6 +268,7 @@ export default function Home() {
           onCloseMobile={closeSidebar}
         />
       </div>
+      )}
 
       {/* Settings modal */}
       <SettingsModal open={settingsOpen} onClose={() => setSettingsOpen(false)} />
@@ -192,7 +288,8 @@ export default function Home() {
           />
         ) : (
           <div className="flex-1 flex flex-col">
-            {/* Mobile top bar */}
+            {/* Mobile top bar — hidden in embed mode (no sidebar to open) */}
+            {!embed.embed && (
             <div className="lg:hidden flex items-center px-4 py-3 border-b border-border-soft bg-surface backdrop-blur">
               <button
                 onClick={() => setSidebarOpen(true)}
@@ -204,6 +301,7 @@ export default function Home() {
               </button>
               <span className="ml-2 text-sm font-semibold text-text">Kratos Agent</span>
             </div>
+            )}
 
             {/* Landing page */}
             <div className="flex-1 flex flex-col items-center justify-center px-4 py-8">
@@ -309,6 +407,38 @@ export default function Home() {
           </div>
         )}
       </main>
+
+      {/* Persona-import overlay (embed Variant B): shows while the relayed
+          manifest is being imported, with an inline retry on failure. */}
+      {embed.embed && (importStatus === "importing" || importStatus === "error") && (
+        <div className="fixed inset-0 z-[70] flex items-center justify-center bg-bg/80 backdrop-blur-sm animate-fade-in">
+          <div className="w-full max-w-sm mx-4 p-6 rounded-2xl border border-border-soft bg-surface shadow-xl text-center">
+            {importStatus === "importing" ? (
+              <>
+                <div className="mx-auto mb-4 w-10 h-10 rounded-full border-2 border-accent border-t-transparent animate-spin" />
+                <h2 className="text-base font-semibold text-text mb-1">Creating your persona…</h2>
+                <p className="text-sm text-muted">Importing the agent definition into Kratos.</p>
+              </>
+            ) : (
+              <>
+                <div className="mx-auto mb-4 w-10 h-10 rounded-full bg-red-500/10 flex items-center justify-center">
+                  <svg className="w-5 h-5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m0 3.75h.008M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                </div>
+                <h2 className="text-base font-semibold text-text mb-1">Couldn&apos;t create the persona</h2>
+                <p className="text-sm text-muted mb-4 break-words">{importError}</p>
+                <button
+                  onClick={runImport}
+                  className="px-4 py-2 rounded-xl bg-accent text-accent-fg text-sm font-medium shadow-md hover:shadow-lg active:scale-95 transition-all"
+                >
+                  Try again
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Full-screen Agent Manager overlay — rendered on top so the active
           ChatWindow stays mounted and any in-flight stream keeps running. */}

--- a/src/frontend/src/app/page.tsx
+++ b/src/frontend/src/app/page.tsx
@@ -34,7 +34,7 @@ export default function Home() {
 
   // Embed mode (chromeless hosting under another origin — design spec §C)
   const [embed, setEmbed] = useState<EmbedParams>({
-    embed: false, theme: null, mode: null, persona: null, prompt: null, doImport: false,
+    embed: false, theme: null, mode: null, persona: null, prompt: null, doImport: false, back: null,
   });
   const [importStatus, setImportStatus] = useState<ImportStatus>("idle");
   const [importError, setImportError] = useState<string | null>(null);
@@ -244,15 +244,15 @@ export default function Home() {
       </a>
 
       {/* Mobile sidebar overlay */}
-      {!embed.embed && sidebarOpen && (
+      {sidebarOpen && (
         <div
           className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 lg:hidden animate-fade-in"
           onClick={closeSidebar}
         />
       )}
 
-      {/* Sidebar — hidden in embed mode (chromeless hosting) */}
-      {!embed.embed && (
+      {/* Sidebar — full original UX, also shown in embed mode (with a
+          "Back to Agentic Loop" button at the top when embedded). */}
       <div className={`
         fixed inset-y-0 left-0 z-50 w-[300px] transform transition-transform duration-300 ease-out
         lg:relative lg:translate-x-0 lg:z-auto
@@ -271,9 +271,9 @@ export default function Home() {
           selectedUseCase={selectedUseCase}
           onSelectUseCase={setSelectedUseCase}
           onCloseMobile={closeSidebar}
+          embedBackHref={embed.embed ? (embed.back || "/reference/kratos") : null}
         />
       </div>
-      )}
 
       {/* Settings modal */}
       <SettingsModal open={settingsOpen} onClose={() => setSettingsOpen(false)} />
@@ -293,8 +293,7 @@ export default function Home() {
           />
         ) : (
           <div className="flex-1 flex flex-col">
-            {/* Mobile top bar — hidden in embed mode (no sidebar to open) */}
-            {!embed.embed && (
+            {/* Mobile top bar */}
             <div className="lg:hidden flex items-center px-4 py-3 border-b border-border-soft bg-surface backdrop-blur">
               <button
                 onClick={() => setSidebarOpen(true)}
@@ -306,7 +305,6 @@ export default function Home() {
               </button>
               <span className="ml-2 text-sm font-semibold text-text">Kratos Agent</span>
             </div>
-            )}
 
             {/* Landing page */}
             <div className="flex-1 flex flex-col items-center justify-center px-4 py-8">

--- a/src/frontend/src/app/page.tsx
+++ b/src/frontend/src/app/page.tsx
@@ -34,7 +34,7 @@ export default function Home() {
 
   // Embed mode (chromeless hosting under another origin — design spec §C)
   const [embed, setEmbed] = useState<EmbedParams>({
-    embed: false, theme: null, persona: null, prompt: null, doImport: false,
+    embed: false, theme: null, mode: null, persona: null, prompt: null, doImport: false,
   });
   const [importStatus, setImportStatus] = useState<ImportStatus>("idle");
   const [importError, setImportError] = useState<string | null>(null);
@@ -203,13 +203,18 @@ export default function Home() {
     if (!params.embed) return;
     bootstrappedRef.current = true;
 
-    // Sync theme: accept a light/dark mode or a named Kratos theme.
+    // Sync theme: accept a light/dark mode or a named Kratos theme, plus an
+    // optional explicit &mode= so the host can pass a named theme AND a mode
+    // together (e.g. &theme=agentic-loop&mode=dark for a branded dark match).
     if (params.theme) {
       if (params.theme === "light" || params.theme === "dark") {
         setMode(params.theme as Mode);
       } else if (THEME_NAMES.has(params.theme as ThemeName)) {
         setTheme(params.theme as ThemeName);
       }
+    }
+    if (params.mode === "light" || params.mode === "dark") {
+      setMode(params.mode as Mode);
     }
 
     if (params.doImport) {

--- a/src/frontend/src/components/Sidebar.tsx
+++ b/src/frontend/src/components/Sidebar.tsx
@@ -45,9 +45,12 @@ interface Props {
   selectedUseCase: string;
   onSelectUseCase: (name: string) => void;
   onCloseMobile?: () => void;
+  /** When embedded under a host (agentic-loop-site), the same-origin path to
+   *  return to. Null when not embedded — hides the "Back to Agentic Loop" button. */
+  embedBackHref?: string | null;
 }
 
-export function Sidebar({ conversations, activeId, onNew, onSelect, onDelete, onOpenSettings, onOpenSkills, onOpenAgenticLoop, useCases, selectedUseCase, onSelectUseCase, onCloseMobile }: Props) {
+export function Sidebar({ conversations, activeId, onNew, onSelect, onDelete, onOpenSettings, onOpenSkills, onOpenAgenticLoop, useCases, selectedUseCase, onSelectUseCase, onCloseMobile, embedBackHref }: Props) {
   const [searchQuery, setSearchQuery] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<Conversation | null>(null);
   const [personaFilter, setPersonaFilter] = useState<"curated" | "all">("curated");
@@ -91,6 +94,17 @@ export function Sidebar({ conversations, activeId, onNew, onSelect, onDelete, on
 
   return (
     <aside className="w-[300px] bg-surface-2 flex flex-col h-full border-r border-border" aria-label="Conversation sidebar">
+      {embedBackHref && (
+        <a
+          href={embedBackHref}
+          className="flex items-center gap-2 px-5 py-2.5 text-xs font-medium text-muted hover:text-text bg-surface border-b border-border-soft hover:bg-hover transition-all"
+        >
+          <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
+          </svg>
+          Back to Agentic Loop
+        </a>
+      )}
       {deleteTarget && createPortal(
         <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60 backdrop-blur animate-fade-in">
           <div className="bg-surface border border-border rounded-2xl p-6 max-w-sm mx-4 shadow-card animate-scale-in">

--- a/src/frontend/src/components/ThemeProvider.tsx
+++ b/src/frontend/src/components/ThemeProvider.tsx
@@ -5,6 +5,7 @@ import { createContext, useContext, useEffect, useState } from "react";
 export type Mode = "light" | "dark";
 
 export type ThemeName =
+  | "agentic-loop"
   | "tokyo-night"
   | "catppuccin"
   | "rose-pine"
@@ -14,6 +15,7 @@ export type ThemeName =
   | "nord";
 
 export const THEMES: { id: ThemeName; label: string; tagline: string; swatches: [string, string, string] }[] = [
+  { id: "agentic-loop",     label: "Agentic Loop",     tagline: "Aurora purple on near-black", swatches: ["#07080c", "#7c5cff", "#34d2ff"] },
   { id: "newsprint",        label: "Newsprint",        tagline: "Cream paper + ink + red",    swatches: ["#f7f3e9", "#1a1a1a", "#a02929"] },
   { id: "tokyo-night",      label: "Tokyo Night",      tagline: "Midnight + mauve",           swatches: ["#1a1b26", "#bb9af7", "#e0af68"] },
   { id: "catppuccin",       label: "Catppuccin",       tagline: "Pastel-on-dark",             swatches: ["#1e1e2e", "#cba6f7", "#fab387"] },

--- a/src/frontend/src/lib/api.ts
+++ b/src/frontend/src/lib/api.ts
@@ -211,6 +211,50 @@ export async function exportUseCase(name: string): Promise<Blob> {
   return response.blob();
 }
 
+/** Result of a persona import (mirrors backend `PersonaImportResponse`). */
+export interface PersonaImportResult {
+  name: string;
+  displayName: string;
+  description: string;
+  skillCount: number;
+  created: boolean;
+  files: string[];
+}
+
+/**
+ * Import a persona from a threadlight-design-compatible manifest.
+ *
+ * The manifest is built by the host (e.g. agentic-loop-site) and relayed
+ * same-origin via sessionStorage; here it is POSTed to the auth-gated Kratos
+ * import endpoint. Returns the created persona's slug + metadata.
+ */
+export async function importPersona(
+  manifest: unknown,
+  opts: { name?: string; overwrite?: boolean; dedupe?: boolean } = {},
+): Promise<PersonaImportResult> {
+  const payload: Record<string, unknown> = { manifest };
+  if (opts.name) payload.name = opts.name;
+  if (opts.overwrite !== undefined) payload.overwrite = opts.overwrite;
+  if (opts.dedupe !== undefined) payload.dedupe = opts.dedupe;
+
+  const response = await fetch(`${getApiUrl()}/api/use-cases/import`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    let detail = `${response.status}`;
+    try {
+      const body = await response.json();
+      if (body?.detail) detail = String(body.detail);
+    } catch {
+      // Body wasn't JSON — keep the status code as the error.
+    }
+    throw new Error(`Failed to import persona: ${detail}`);
+  }
+  return (await response.json()) as PersonaImportResult;
+}
+
 // ─── Skills Admin API ───
 
 import type { Skill, SkillCreate, SkillUpdate } from "@/types";

--- a/src/frontend/src/lib/config.ts
+++ b/src/frontend/src/lib/config.ts
@@ -6,12 +6,21 @@
  * at runtime using this priority:
  *
  *  1. Build-time env var  — NEXT_PUBLIC_API_URL (set during `next build`)
- *  2. Runtime config file — /config.json  (injected by azd postprovision hook)
- *  3. Same-origin fallback — "" (calls go to the same host, useful behind a proxy)
+ *  2. Runtime config file — <basePath>/config.json  (injected by azd hook)
+ *  3. Same-origin fallback — <basePath> (calls go to the same host under the
+ *     mount path, e.g. "/kratos/api/..." behind Front Door)
  *  4. Local dev fallback  — http://localhost:8000
  */
 
 let _cachedApiUrl: string | null = null;
+
+/**
+ * The sub-path the app is mounted under (e.g. "/kratos"), or "" at the root.
+ * Baked in at build time via next.config.js `env.NEXT_PUBLIC_BASE_PATH`.
+ */
+export function getBasePath(): string {
+  return (process.env.NEXT_PUBLIC_BASE_PATH || "").replace(/\/+$/, "");
+}
 
 export function getApiUrl(): string {
   if (_cachedApiUrl !== null) return _cachedApiUrl;
@@ -33,19 +42,20 @@ export function getApiUrl(): string {
     }
   }
 
-  // 3. Same-origin fallback (works behind a proxy / APIM / SWA linked backend)
-  _cachedApiUrl = "";
+  // 3. Same-origin fallback under the mount path (works behind a proxy / APIM /
+  //    SWA linked backend / Front Door path-mount). At the root this is "".
+  _cachedApiUrl = getBasePath();
   return _cachedApiUrl;
 }
 
 /**
- * Load runtime config from /config.json (if present).
+ * Load runtime config from <basePath>/config.json (if present).
  * Call once at app startup before any API calls.
  */
 export async function loadRuntimeConfig(): Promise<void> {
   if (typeof window === "undefined") return;
   try {
-    const res = await fetch("/config.json", { cache: "no-store" });
+    const res = await fetch(`${getBasePath()}/config.json`, { cache: "no-store" });
     if (res.ok) {
       const cfg = await res.json();
       (window as unknown as Record<string, unknown>).__KRATOS_CONFIG__ = cfg;

--- a/src/frontend/src/lib/embed.ts
+++ b/src/frontend/src/lib/embed.ts
@@ -1,0 +1,84 @@
+/**
+ * Embed-mode support.
+ *
+ * Kratos can be hosted "embedded" under another origin (e.g. agentic-loop-site
+ * behind Front Door at `/kratos/*`). When the host opens the app with
+ * `?embed=1`, Kratos renders chromeless (no marketing sidebar) and reacts to a
+ * small set of URL args so the host can drive it:
+ *
+ *   ?embed=1            — chromeless layout
+ *   &theme=dark         — sync light/dark mode (or a named Kratos theme)
+ *   &persona=<slug>     — open this persona (post-import landing target)
+ *   &prompt=<text>      — auto-start a conversation with this first message
+ *   &import=1           — read a relayed manifest from sessionStorage and POST
+ *                         it to the import API, then settle on ?persona=<slug>
+ *
+ * The manifest is relayed **same-origin** via `sessionStorage` (Variant B in the
+ * design spec): the host writes `sessionStorage['kratos.import']` then navigates
+ * to `/kratos/?embed=1&import=1`. Kratos reads-and-clears it on entry, after its
+ * own EasyAuth login, so the authenticated import POST runs inside Kratos with
+ * no cross-app fetch / CORS / 401-follow.
+ */
+
+export const IMPORT_RELAY_KEY = "kratos.import";
+
+export interface EmbedParams {
+  embed: boolean;
+  theme: string | null;
+  persona: string | null;
+  prompt: string | null;
+  doImport: boolean;
+}
+
+function truthy(value: string | null): boolean {
+  return value === "1" || value === "true" || value === "yes";
+}
+
+/** Parse embed-relevant args from the current URL. SSR-safe (returns defaults). */
+export function readEmbedParams(): EmbedParams {
+  if (typeof window === "undefined") {
+    return { embed: false, theme: null, persona: null, prompt: null, doImport: false };
+  }
+  const p = new URLSearchParams(window.location.search);
+  return {
+    embed: truthy(p.get("embed")),
+    theme: p.get("theme"),
+    persona: p.get("persona"),
+    prompt: p.get("prompt"),
+    doImport: truthy(p.get("import")),
+  };
+}
+
+/**
+ * Read **and clear** the relayed import manifest from sessionStorage.
+ * Returns the parsed object, or null when absent/invalid.
+ */
+export function takeImportManifest(): unknown | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(IMPORT_RELAY_KEY);
+    if (!raw) return null;
+    window.sessionStorage.removeItem(IMPORT_RELAY_KEY);
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Rewrite the URL to the post-import resting state: drop the one-shot
+ * `import`/`prompt` args and pin `persona=<slug>` so a reload re-opens the
+ * imported persona instead of re-triggering the import.
+ */
+export function settlePersonaUrl(persona: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const url = new URL(window.location.href);
+    url.searchParams.delete("import");
+    url.searchParams.delete("prompt");
+    url.searchParams.set("persona", persona);
+    window.history.replaceState({}, "", url.toString());
+  } catch {
+    // history.replaceState can throw in sandboxed iframes — non-fatal.
+  }
+}

--- a/src/frontend/src/lib/embed.ts
+++ b/src/frontend/src/lib/embed.ts
@@ -14,6 +14,8 @@
  *   &prompt=<text>      — auto-start a conversation with this first message
  *   &import=1           — read a relayed manifest from sessionStorage and POST
  *                         it to the import API, then settle on ?persona=<slug>
+ *   &back=<path>        — where the in-sidebar "Back to Agentic Loop" button
+ *                         returns to (same-origin path; default /reference/kratos)
  *
  * The manifest is relayed **same-origin** via `sessionStorage` (Variant B in the
  * design spec): the host writes `sessionStorage['kratos.import']` then navigates
@@ -31,6 +33,7 @@ export interface EmbedParams {
   persona: string | null;
   prompt: string | null;
   doImport: boolean;
+  back: string | null;
 }
 
 function truthy(value: string | null): boolean {
@@ -40,7 +43,7 @@ function truthy(value: string | null): boolean {
 /** Parse embed-relevant args from the current URL. SSR-safe (returns defaults). */
 export function readEmbedParams(): EmbedParams {
   if (typeof window === "undefined") {
-    return { embed: false, theme: null, mode: null, persona: null, prompt: null, doImport: false };
+    return { embed: false, theme: null, mode: null, persona: null, prompt: null, doImport: false, back: null };
   }
   const p = new URLSearchParams(window.location.search);
   return {
@@ -50,6 +53,7 @@ export function readEmbedParams(): EmbedParams {
     persona: p.get("persona"),
     prompt: p.get("prompt"),
     doImport: truthy(p.get("import")),
+    back: p.get("back"),
   };
 }
 

--- a/src/frontend/src/lib/embed.ts
+++ b/src/frontend/src/lib/embed.ts
@@ -8,6 +8,8 @@
  *
  *   ?embed=1            — chromeless layout
  *   &theme=dark         — sync light/dark mode (or a named Kratos theme)
+ *   &mode=dark          — sync light/dark mode independently of a named theme
+ *                         (lets the host pass &theme=agentic-loop&mode=dark)
  *   &persona=<slug>     — open this persona (post-import landing target)
  *   &prompt=<text>      — auto-start a conversation with this first message
  *   &import=1           — read a relayed manifest from sessionStorage and POST
@@ -25,6 +27,7 @@ export const IMPORT_RELAY_KEY = "kratos.import";
 export interface EmbedParams {
   embed: boolean;
   theme: string | null;
+  mode: string | null;
   persona: string | null;
   prompt: string | null;
   doImport: boolean;
@@ -37,12 +40,13 @@ function truthy(value: string | null): boolean {
 /** Parse embed-relevant args from the current URL. SSR-safe (returns defaults). */
 export function readEmbedParams(): EmbedParams {
   if (typeof window === "undefined") {
-    return { embed: false, theme: null, persona: null, prompt: null, doImport: false };
+    return { embed: false, theme: null, mode: null, persona: null, prompt: null, doImport: false };
   }
   const p = new URLSearchParams(window.location.search);
   return {
     embed: truthy(p.get("embed")),
     theme: p.get("theme"),
+    mode: p.get("mode"),
     persona: p.get("persona"),
     prompt: p.get("prompt"),
     doImport: truthy(p.get("import")),


### PR DESCRIPTION
## What

Adds a deterministic **persona import API** and **sub-path / embed hosting** to Kratos so an external site (agentic-loop-site) can create a Kratos persona from a natural-language description and host the Kratos UI embedded — without copying any Kratos files.

## Why

agentic-loop-site lets a user describe an agent in natural language. The site builds a **threadlight-design–compatible persona manifest** and hands it to Kratos, which imports it **deterministically (no LLM on the import path)** and renders the result in an embedded Kratos UI. This keeps a single source of truth (always-latest Kratos) with no duplication.

## Changes

- **`POST /api/use-cases/import`** — accepts a persona manifest (or a prompt), validates it (exactly-one-of manifest/prompt), and writes a use-case folder: `apm.yml`, `.mcp.json`, system prompt. Defaults: `overwrite=false`, `dedupe=true` (duplicate slugs auto-dedupe to `name-2`).
- **Sub-path / embed hosting** — Next.js `basePath` + `?embed=1` mode that syncs theme and, with `?import=1`, reads the manifest from same-origin `sessionStorage['kratos.import']` and POSTs it (Variant B: import runs inside Kratos after its own EasyAuth).
- **Manifest model** — `PersonaManifest` / `ImportMcpServer` compatible with the `threadlight-design` skill's manifest format.

## Review fix (included)

`.mcp.json` is loaded **verbatim** into the Copilot SDK session config, so every entry must be runnable. A registry MCP reference with no `url` would write a non-startable `{"type":"http"}` entry and fail at runtime. `_build_mcp_json` now **skips url-less servers** from `.mcp.json` (they stay in `apm.yml dependencies.mcp` for `apm install` to resolve) and logs an info line. Adds a regression test.

## Testing

- 42/42 backend tests pass (incl. the new url-less-MCP regression test)
- `ruff` clean

## Deploy notes

Pairs with aiappsgbb/agentic-loop-site PR (NL persona builder + embedded handoff + Front Door path-mount). When fronting SWA EasyAuth with Front Door, register Kratos's Entra app redirect URI as `https://<afd-host>/kratos/.auth/login/aad/callback`.