### PR TITLE
Remove private VNet from exported agent demo (public networking)

### DIFF
--- a/src/backend/app/exporter_templates/infra/main.bicep
+++ b/src/backend/app/exporter_templates/infra/main.bicep
@@ -7,6 +7,10 @@
 //   * ai-gateway          — no APIM
 //   * static-web-app      — no frontend
 //   * bing-search         — optional capability, omitted
+//   * network (VNet)      — the demo keeps every service publicly reachable
+//                           (RBAC still governs access); a Foundry hosted
+//                           agent isn't injected into a VNet, so private
+//                           endpoints would break its data-plane access.
 //
 // The Foundry hosted-agent's system-assigned managed identity replaces the
 // Container App MI as the principal for all data-plane RBAC (Cosmos / KV /
@@ -34,7 +38,6 @@ param aiServicesName string = ''
 param keyVaultName string = ''
 param appInsightsName string = ''
 param logAnalyticsName string = ''
-param vnetName string = ''
 param storageAccountName string = ''
 
 // ─── Resource Naming ───
@@ -47,17 +50,6 @@ resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
   name: 'rg-${environmentName}'
   location: location
   tags: tags
-}
-
-// ─── Networking ───
-module network './modules/network.bicep' = {
-  name: 'network'
-  scope: rg
-  params: {
-    name: !empty(vnetName) ? vnetName : '${abbrs.networkVirtualNetworks}${resourceToken}'
-    location: location
-    tags: tags
-  }
 }
 
 // ─── Log Analytics ───
@@ -91,9 +83,6 @@ module keyVault './modules/key-vault.bicep' = {
     name: !empty(keyVaultName) ? keyVaultName : '${abbrs.keyVaultVaults}${resourceToken}'
     location: location
     tags: tags
-    principalId: principalId
-    subnetId: network.outputs.privateEndpointSubnetId
-    vnetId: network.outputs.id
   }
 }
 
@@ -105,9 +94,6 @@ module cosmosDb './modules/cosmos-db.bicep' = {
     name: !empty(cosmosDbAccountName) ? cosmosDbAccountName : '${abbrs.documentDBDatabaseAccounts}${resourceToken}'
     location: location
     tags: tags
-    subnetId: network.outputs.privateEndpointSubnetId
-    vnetId: network.outputs.id
-    keyVaultName: keyVault.outputs.name
   }
 }
 
@@ -119,8 +105,6 @@ module aiSearch './modules/ai-search.bicep' = {
     name: !empty(aiSearchName) ? aiSearchName : '${abbrs.searchSearchServices}${resourceToken}'
     location: location
     tags: tags
-    subnetId: network.outputs.privateEndpointSubnetId
-    vnetId: network.outputs.id
   }
 }
 

--- a/src/backend/app/exporter_templates/infra/modules/ai-search.bicep
+++ b/src/backend/app/exporter_templates/infra/modules/ai-search.bicep
@@ -1,0 +1,43 @@
+// Demo export copy of Kratos's ai-search module.
+//
+// Diverges from the repo-root infra/modules/ai-search.bicep: the standalone
+// hosted-agent demo keeps AI Search publicly reachable (RBAC via the
+// aadOrApiKey auth options still governs access) instead of
+// `publicNetworkAccess: disabled` + a private endpoint behind a VNet. A
+// Foundry hosted agent isn't injected into the export's network, so a private
+// endpoint would leave the agent unable to reach Search after `azd up`. For a
+// production deployment, re-enable private networking (see the repo-root
+// module).
+
+@description('Name of the AI Search service')
+param name string
+
+@description('Location')
+param location string
+
+@description('Tags')
+param tags object = {}
+
+resource aiSearch 'Microsoft.Search/searchServices@2023-11-01' = {
+  name: name
+  location: location
+  tags: tags
+  sku: {
+    name: 'basic'
+  }
+  properties: {
+    replicaCount: 1
+    partitionCount: 1
+    hostingMode: 'default'
+    publicNetworkAccess: 'enabled'
+    authOptions: {
+      aadOrApiKey: {
+        aadAuthFailureMode: 'http401WithBearerChallenge'
+      }
+    }
+  }
+}
+
+output id string = aiSearch.id
+output name string = aiSearch.name
+output endpoint string = 'https://${aiSearch.name}.search.windows.net'

--- a/src/backend/app/exporter_templates/infra/modules/cosmos-db.bicep
+++ b/src/backend/app/exporter_templates/infra/modules/cosmos-db.bicep
@@ -1,0 +1,168 @@
+// Demo export copy of Kratos's cosmos-db module.
+//
+// This intentionally diverges from the repo-root infra/modules/cosmos-db.bicep:
+// the standalone hosted-agent demo keeps Cosmos publicly reachable (RBAC still
+// governs all access via disableLocalAuth) instead of locking it behind a VNet
+// + private endpoint. A Foundry hosted agent is NOT injected into the export's
+// network, so a private endpoint would make the agent unable to reach its own
+// data plane after `azd up`. For a production deployment, re-enable private
+// networking (see the repo-root module).
+
+@description('Name of the Cosmos DB account')
+param name string
+
+@description('Location')
+param location string
+
+@description('Tags')
+param tags object = {}
+
+resource cosmosDb 'Microsoft.DocumentDB/databaseAccounts@2024-02-15-preview' = {
+  name: name
+  location: location
+  tags: tags
+  kind: 'GlobalDocumentDB'
+  properties: {
+    databaseAccountOfferType: 'Standard'
+    locations: [
+      {
+        locationName: location
+        failoverPriority: 0
+        isZoneRedundant: false
+      }
+    ]
+    capabilities: [
+      {
+        name: 'EnableServerless'
+      }
+    ]
+    consistencyPolicy: {
+      defaultConsistencyLevel: 'Session'
+    }
+    publicNetworkAccess: 'Enabled'
+    disableLocalAuth: true
+  }
+}
+
+// Database
+resource database 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-02-15-preview' = {
+  parent: cosmosDb
+  name: 'kratos-agent'
+  properties: {
+    resource: {
+      id: 'kratos-agent'
+    }
+  }
+}
+
+// Conversations container with userId partition key
+resource conversationsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-02-15-preview' = {
+  parent: database
+  name: 'conversations'
+  properties: {
+    resource: {
+      id: 'conversations'
+      partitionKey: {
+        paths: ['/userId']
+        kind: 'Hash'
+        version: 2
+      }
+      indexingPolicy: {
+        indexingMode: 'consistent'
+        automatic: true
+        includedPaths: [
+          { path: '/*' }
+        ]
+        excludedPaths: [
+          { path: '/"_etag"/?' }
+        ]
+      }
+      defaultTtl: -1
+    }
+  }
+}
+
+// Messages container
+resource messagesContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-02-15-preview' = {
+  parent: database
+  name: 'messages'
+  properties: {
+    resource: {
+      id: 'messages'
+      partitionKey: {
+        paths: ['/conversationId']
+        kind: 'Hash'
+        version: 2
+      }
+      indexingPolicy: {
+        indexingMode: 'consistent'
+        automatic: true
+        includedPaths: [
+          { path: '/*' }
+        ]
+        excludedPaths: [
+          { path: '/"_etag"/?' }
+        ]
+      }
+      defaultTtl: -1
+    }
+  }
+}
+
+// Settings container — stores system prompt and other admin config
+resource settingsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-02-15-preview' = {
+  parent: database
+  name: 'settings'
+  properties: {
+    resource: {
+      id: 'settings'
+      partitionKey: {
+        paths: ['/category']
+        kind: 'Hash'
+        version: 2
+      }
+      indexingPolicy: {
+        indexingMode: 'consistent'
+        automatic: true
+        includedPaths: [
+          { path: '/*' }
+        ]
+        excludedPaths: [
+          { path: '/"_etag"/?' }
+        ]
+      }
+      defaultTtl: -1
+    }
+  }
+}
+
+// Sessions container — stores SDK session ID ↔ conversation ID mapping
+resource sessionsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-02-15-preview' = {
+  parent: database
+  name: 'sessions'
+  properties: {
+    resource: {
+      id: 'sessions'
+      partitionKey: {
+        paths: ['/conversationId']
+        kind: 'Hash'
+        version: 2
+      }
+      indexingPolicy: {
+        indexingMode: 'consistent'
+        automatic: true
+        includedPaths: [
+          { path: '/*' }
+        ]
+        excludedPaths: [
+          { path: '/"_etag"/?' }
+        ]
+      }
+      defaultTtl: -1
+    }
+  }
+}
+
+output id string = cosmosDb.id
+output name string = cosmosDb.name
+output endpoint string = cosmosDb.properties.documentEndpoint

--- a/src/backend/app/exporter_templates/infra/modules/key-vault.bicep
+++ b/src/backend/app/exporter_templates/infra/modules/key-vault.bicep
@@ -1,0 +1,39 @@
+// Demo export copy of Kratos's key-vault module.
+//
+// Diverges from the repo-root infra/modules/key-vault.bicep: the standalone
+// hosted-agent demo keeps the vault publicly reachable (RBAC authorization
+// still governs every secret) instead of a `defaultAction: Deny` firewall +
+// private endpoint behind a VNet. A Foundry hosted agent isn't injected into
+// the export's network, and the operator running `azd up` needs data-plane
+// reach too. For a production deployment, re-enable private networking (see
+// the repo-root module).
+
+@description('Name of the Key Vault')
+param name string
+
+@description('Location')
+param location string
+
+@description('Tags')
+param tags object = {}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    tenantId: subscription().tenantId
+    enableRbacAuthorization: true
+    enableSoftDelete: true
+    softDeleteRetentionInDays: 7
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+output id string = keyVault.id
+output name string = keyVault.name
+output uri string = keyVault.properties.vaultUri

--- a/src/backend/app/services/project_exporter.py
+++ b/src/backend/app/services/project_exporter.py
@@ -26,17 +26,24 @@ ZIP layout
     ├── use-cases/<chosen>/              ← the chosen use-case ONLY
     ├── mocks/                           ← copied verbatim (package.json + packages/*)
     └── infra/                           (vendored trimmed Bicep + Kratos modules)
-        ├── main.bicep                   ← vendored trimmed copy
+        ├── main.bicep                   ← vendored trimmed copy (no VNet)
         ├── main.parameters.json         ← vendored
         ├── abbreviations.json           ← copied from Kratos infra/
         └── modules/
             ├── role-assignments.bicep   ← vendored trimmed copy
-            └── (9 others)               ← copied from Kratos infra/modules/
+            ├── cosmos-db.bicep          ← vendored public-network copy
+            ├── key-vault.bicep          ← vendored public-network copy
+            ├── ai-search.bicep          ← vendored public-network copy
+            └── (5 others)               ← copied from Kratos infra/modules/
 
 The vendored Bicep lives under ``app/exporter_templates/infra/`` so it ships
-inside the wheel; the other 9 modules + abbreviations.json are read from the
+inside the wheel; the other 5 modules + abbreviations.json are read from the
 checkout via ``self.repo_root`` (defaults to cwd) to stay in sync with any
-Kratos infra changes.
+Kratos infra changes. ``network`` is dropped entirely and ``cosmos-db`` /
+``key-vault`` / ``ai-search`` are vendored (not copied) because the demo
+export keeps those services publicly reachable instead of isolating them in a
+VNet behind private endpoints — a Foundry hosted agent isn't VNet-injected and
+could not otherwise reach its own data plane.
 """
 
 from __future__ import annotations
@@ -126,21 +133,35 @@ _PARAMETERIZED: frozenset[str] = frozenset(
 # Files in ``src/hosted-agent/`` copied verbatim into the export.
 _HOSTED_AGENT_VERBATIM: tuple[str, ...] = ("main.py", "pyproject.toml", "Dockerfile")
 
-# Infra/modules files copied verbatim from the Kratos checkout. Five modules
-# from Kratos's main.bicep are intentionally dropped because the exported
-# agent doesn't need them (no Container App backend, no APIM, no frontend,
-# no Bing): ``agent-service``, ``container-apps-env``, ``ai-gateway``,
-# ``static-web-app``, ``bing-search``.
+# Infra/modules files copied verbatim from the Kratos checkout. Several
+# modules from Kratos's main.bicep are intentionally dropped because the
+# exported agent doesn't need them (no Container App backend, no APIM, no
+# frontend, no Bing): ``agent-service``, ``container-apps-env``,
+# ``ai-gateway``, ``static-web-app``, ``bing-search``. ``network`` is dropped
+# too — the demo export keeps every service publicly reachable (RBAC still
+# governs access) rather than provisioning a VNet + private endpoints, which a
+# Foundry hosted agent (not VNet-injected) can't reach anyway.
+#
+# ``cosmos-db``, ``key-vault``, and ``ai-search`` are NOT copied from Kratos:
+# the repo-root versions hard-code private networking, so the export ships
+# its own public-network variants (see ``_INFRA_MODULES_VENDORED`` below).
 _INFRA_MODULES_FROM_KRATOS: tuple[str, ...] = (
-    "network.bicep",
     "log-analytics.bicep",
     "app-insights.bicep",
-    "key-vault.bicep",
-    "cosmos-db.bicep",
-    "ai-search.bicep",
     "ai-services.bicep",
     "blob-storage.bicep",
     "container-registry.bicep",
+)
+
+# Trimmed/diverged Bicep modules vendored from the templates package (inside
+# the wheel) instead of copied from the Kratos checkout. ``role-assignments``
+# drops the Container App principal; the three data-service modules drop
+# private networking so the demo deploys without a VNet.
+_INFRA_MODULES_VENDORED: tuple[str, ...] = (
+    "role-assignments.bicep",
+    "cosmos-db.bicep",
+    "key-vault.bicep",
+    "ai-search.bicep",
 )
 
 
@@ -327,19 +348,20 @@ class ProjectExporter:
         """Copy the trimmed infra/ subtree.
 
         Sources:
-        * ``main.bicep`` + ``main.parameters.json`` + ``modules/role-assignments.bicep``
-          come from the wheel (``app/exporter_templates/infra/``) — these
-          are the *trimmed* versions that drop the modules the export
-          doesn't need.
-        * ``abbreviations.json`` + 9 other modules come from the Kratos
-          checkout (``infra/`` and ``infra/modules/``) so they stay in sync
-          with any Kratos infra changes.
+        * ``main.bicep`` + ``main.parameters.json`` + the modules in
+          ``_INFRA_MODULES_VENDORED`` come from the wheel
+          (``app/exporter_templates/infra/``) — these are the *trimmed* /
+          *diverged* versions (drop unused modules, drop the Container App
+          principal, drop private networking).
+        * ``abbreviations.json`` + the modules in ``_INFRA_MODULES_FROM_KRATOS``
+          come from the Kratos checkout (``infra/`` and ``infra/modules/``) so
+          they stay in sync with any Kratos infra changes.
         """
         dst_infra = dst_dir / "infra"
         dst_modules = dst_infra / "modules"
         dst_modules.mkdir(parents=True, exist_ok=True)
 
-        # 1. Vendored trimmed Bicep (3 files) from the templates package.
+        # 1. Vendored trimmed Bicep from the templates package.
         vendored = resources.files(_TEMPLATES_PACKAGE).joinpath("infra")
         (dst_infra / "main.bicep").write_text(
             vendored.joinpath("main.bicep").read_text(encoding="utf-8"), encoding="utf-8"
@@ -347,10 +369,11 @@ class ProjectExporter:
         (dst_infra / "main.parameters.json").write_text(
             vendored.joinpath("main.parameters.json").read_text(encoding="utf-8"), encoding="utf-8"
         )
-        (dst_modules / "role-assignments.bicep").write_text(
-            vendored.joinpath("modules/role-assignments.bicep").read_text(encoding="utf-8"),
-            encoding="utf-8",
-        )
+        for module_name in _INFRA_MODULES_VENDORED:
+            (dst_modules / module_name).write_text(
+                vendored.joinpath(f"modules/{module_name}").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
 
         # 2. Verbatim copies from the Kratos checkout.
         kratos_infra = self.infra_dir

--- a/src/backend/tests/test_project_exporter.py
+++ b/src/backend/tests/test_project_exporter.py
@@ -223,9 +223,9 @@ def test_assemble_writes_trimmed_infra(exporter: ProjectExporter, tmp_path: Path
     assert (out / "infra" / "main.parameters.json").is_file()
     assert (out / "infra" / "abbreviations.json").is_file()
 
-    # The 10 expected modules are present.
+    # The 9 expected modules are present. ``network.bicep`` is dropped because
+    # the demo export no longer provisions a VNet / private endpoints.
     expected_modules = {
-        "network.bicep",
         "log-analytics.bicep",
         "app-insights.bicep",
         "key-vault.bicep",
@@ -239,7 +239,8 @@ def test_assemble_writes_trimmed_infra(exporter: ProjectExporter, tmp_path: Path
     actual_modules = {p.name for p in (out / "infra" / "modules").iterdir() if p.suffix == ".bicep"}
     assert actual_modules == expected_modules
 
-    # Trimmed main.bicep does NOT reference the 5 dropped modules.
+    # Trimmed main.bicep does NOT reference the 6 dropped modules (network is
+    # now dropped too — no VNet in the demo export).
     main_bicep = (out / "infra" / "main.bicep").read_text()
     for dropped in (
         "agent-service.bicep",
@@ -247,6 +248,7 @@ def test_assemble_writes_trimmed_infra(exporter: ProjectExporter, tmp_path: Path
         "ai-gateway.bicep",
         "static-web-app.bicep",
         "bing-search.bicep",
+        "network.bicep",
     ):
         assert dropped not in main_bicep, f"main.bicep still references dropped module {dropped}"
 
@@ -346,6 +348,51 @@ def test_assemble_writes_windows_postdeploy_hook(exporter: ProjectExporter, tmp_
     # Persona name substituted; no leftover azure.yaml ``$$`` escapes.
     assert "Finance Close Controller" in content
     assert "$$" not in content, "ps1 should be plain PowerShell (no $$ azure.yaml escapes)"
+
+
+def test_assemble_infra_has_no_private_networking(exporter: ProjectExporter, tmp_path: Path):
+    """The demo export must NOT provision a VNet / private endpoints.
+
+    Regression test for the over-isolated export: Cosmos, Key Vault, and AI
+    Search used to ship with ``publicNetworkAccess: Disabled`` + private
+    endpoints + private DNS zones, behind a VNet. That is (a) excessive for a
+    demo and (b) a correctness bug — a Foundry *hosted* agent isn't injected
+    into the VNet, so it could not reach its own data plane after ``azd up``.
+    The demo export now keeps every service publicly reachable (RBAC still
+    governs access) and drops the VNet entirely.
+    """
+    out = tmp_path / "out"
+    out.mkdir()
+    exporter.assemble("finance-close", out)
+
+    modules_dir = out / "infra" / "modules"
+    main_bicep = (out / "infra" / "main.bicep").read_text()
+
+    # main.bicep no longer wires up any networking.
+    assert "module network" not in main_bicep, "main.bicep still instantiates the network module"
+    assert "param vnetName" not in main_bicep, "main.bicep still declares the dead vnetName param"
+    assert "subnetId" not in main_bicep, "main.bicep still passes subnetId to data services"
+    assert "vnetId" not in main_bicep, "main.bicep still passes vnetId to data services"
+
+    # No exported module may create a VNet, private endpoint, or private DNS.
+    for bicep in modules_dir.glob("*.bicep"):
+        text = bicep.read_text()
+        assert "Microsoft.Network/privateEndpoints" not in text, f"{bicep.name} still creates a private endpoint"
+        assert "Microsoft.Network/privateDnsZones" not in text, f"{bicep.name} still creates a private DNS zone"
+        assert "Microsoft.Network/virtualNetworks" not in text, f"{bicep.name} still creates a VNet"
+
+    # The three formerly-isolated data services are publicly reachable.
+    cosmos = (modules_dir / "cosmos-db.bicep").read_text()
+    assert "publicNetworkAccess: 'Enabled'" in cosmos
+    assert "privatelink.documents" not in cosmos
+
+    key_vault = (modules_dir / "key-vault.bicep").read_text()
+    assert "defaultAction: 'Deny'" not in key_vault, "Key Vault firewall must not deny public access in the demo export"
+    assert "privatelink.vaultcore" not in key_vault
+
+    ai_search = (modules_dir / "ai-search.bicep").read_text()
+    assert "publicNetworkAccess: 'enabled'" in ai_search
+    assert "privatelink.search" not in ai_search
 
 
 def test_assemble_unknown_use_case_raises(exporter: ProjectExporter, tmp_path: Path):


### PR DESCRIPTION
## Problem

The per-use-case **Download as Foundry Agent** export inherited the parent repo's *production* network isolation. The exported `infra/` deployed:

- a **VNet** + **private endpoints** + **private DNS zones** for Cosmos DB, Key Vault, and AI Search
- with **public network access disabled / firewalled** (`publicNetworkAccess: Disabled`, Key Vault `networkAcls.defaultAction: Deny`)

For a standalone demo this is wrong on three counts:

1. **Excessive** — extra cost and `azd up` spin-up time (3 PEs + 3 private DNS zones + VNet) for a throwaway demo.
2. **A correctness bug** — a Foundry **hosted** agent is *not* injected into the export's VNet, so private endpoints + disabled public access leave the agent unable to reach its own data plane (Cosmos / Search / Key Vault) after `azd up`.
3. **Half-isolated + dead config** — Foundry and Blob were already public, so the result was neither locked down nor simple, and it left dead `vnetName` / subnet wiring (plus unused `keyVaultName` / `principalId` params).

## Fix

Keep every service **publicly reachable** (RBAC — via `disableLocalAuth` / `enableRbacAuthorization` — still governs all access) and drop the VNet entirely from the demo export. **The repo-root production modules are left untouched.**

- **Vendor public-network copies** of `cosmos-db` / `key-vault` / `ai-search` under `app/exporter_templates/infra/modules/`: `publicNetworkAccess: Enabled`, no private endpoints / DNS zones, no Key Vault `Deny` firewall. Consistent with how `main.bicep` and `role-assignments.bicep` are already vendored.
- **Trim `main.bicep`**: remove the `network` module, the `vnetName` param, and all subnet/vnet wiring (plus the unused `keyVaultName` / `principalId` args).
- **`project_exporter.py`**: drop `network` / `cosmos-db` / `key-vault` / `ai-search` from the copied-from-Kratos module list; vendor the three public variants instead.

## Verification

- 37 backend tests pass (added `test_assemble_infra_has_no_private_networking`; updated the trimmed-infra test for the new 9-module set).
- `ruff check` clean.
- Rendered a real export and compiled it with **`az bicep build`** — zero warnings/errors.

> Note: a live `azd up` on a real subscription wasn't run here (no Azure env in this workspace); the change is validated by unit tests + Bicep compilation.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>