### PR TITLE
Fix exported agent runtime: instance-identity RBAC, telemetry, invoke parsing

### DIFF
--- a/src/backend/app/exporter_templates/README.md.template
+++ b/src/backend/app/exporter_templates/README.md.template
@@ -47,9 +47,17 @@ Cosmos persistence.
 ```bash
 azd auth login
 azd init                            # picks env name + subscription
-azd env set AZURE_LOCATION eastus2  # or your preferred region
+azd env set AZURE_LOCATION eastus2  # or your preferred region — see note below
 azd up
 ```
+
+> **Region note:** Foundry **hosted agents** are not available in every Azure
+> region. Some regions (notably **Central US**) provision all the infra
+> successfully but then fail the hosted-agent deploy step. Pick a region that
+> supports hosted agents — e.g. `eastus2`, `swedencentral`, `westus3`, or
+> `uksouth` — and check the latest
+> [Foundry Agent Service region list](https://learn.microsoft.com/azure/ai-foundry/agents/concepts/model-region-support)
+> if you hit a deploy failure.
 
 `azd up`:
 1. **Provisions** the AI Foundry account/project, Cosmos DB, AI Search,
@@ -60,10 +68,14 @@ azd up
 4. **Runs the post-deploy RBAC hook** (`hooks/postdeploy.sh` on Linux/macOS,
    `hooks/postdeploy.ps1` on Windows — azd picks the right one) to grant the
    data-plane roles (`AcrPull`, `Cognitive Services OpenAI User`,
-   `Cognitive Services User`, `Foundry User`) to the hosted-agent's instance +
-   blueprint managed identities. These identities are created by Foundry
-   **after** Bicep provisioning, so they can't be granted via Bicep — the hook
-   discovers them via `azd ai agent show` and runs `az role assignment create`.
+   `Cognitive Services User`, `Foundry User`, plus `Cosmos DB Data Contributor`,
+   `Storage Blob Data Contributor`, `Key Vault Secrets User`, and
+   `Search Index Data Contributor`) to the hosted-agent's instance + blueprint
+   managed identities. The container runs **as the instance identity**, which
+   Bicep can't grant (those identities are created by Foundry **after** Bicep
+   provisioning), so the hook discovers them via `azd ai agent show` and runs
+   `az role assignment create` (and `az cosmosdb sql role assignment create`
+   for the Cosmos data-plane role).
 5. **Prints** an Agent Playground URL
 
 > **Note:** If the first invocation reports `agent_version_failed` with

--- a/src/backend/app/exporter_templates/azure.yaml.template
+++ b/src/backend/app/exporter_templates/azure.yaml.template
@@ -32,6 +32,9 @@ services:
                     memory: 2Gi
             env:
                 APM_USE_CASES_ROOT: /app/use-cases
+                # Without this, the agentserver framework falls back to a console
+                # OTLP exporter and floods stdout with metric JSON every 60s.
+                APPLICATIONINSIGHTS_CONNECTION_STRING: $${AZURE_APP_INSIGHTS_CONNECTION_STRING}
                 AI_SERVICES_ENDPOINT: $${AZURE_AI_PROJECT_ENDPOINT}
                 AZURE_AI_SEARCH_ENDPOINT: $${AZURE_AI_SEARCH_ENDPOINT}
                 BLOB_SKILLS_CONTAINER: skills

--- a/src/backend/app/exporter_templates/hooks/postdeploy.ps1.template
+++ b/src/backend/app/exporter_templates/hooks/postdeploy.ps1.template
@@ -18,6 +18,13 @@
 # The hook is idempotent — re-running it is safe.
 
 $$ErrorActionPreference = "Stop"
+# `az` is a native command that manages its own exit codes; we inspect
+# $$LASTEXITCODE ourselves after each call. In PowerShell 7.4+,
+# $$PSNativeCommandUseErrorActionPreference defaults to $$true, which would turn
+# a non-zero az exit (e.g. an already-exists / Conflict grant) into a
+# *terminating* error under `Stop` and abort the hook before our check runs.
+# Disable it so the grant functions stay idempotent. (No-op on older pwsh.)
+$$PSNativeCommandUseErrorActionPreference = $$false
 
 Write-Host ""
 Write-Host "=============================================================="

--- a/src/backend/app/exporter_templates/hooks/postdeploy.ps1.template
+++ b/src/backend/app/exporter_templates/hooks/postdeploy.ps1.template
@@ -30,6 +30,10 @@ $$AcrPullRole             = "7f951dda-4ed3-4680-a7ca-43fe172d538d"  # AcrPull
 $$CognitiveOpenAiUserRole = "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd"  # Cognitive Services OpenAI User
 $$CognitiveUserRole       = "a97b65f3-24c7-4388-baec-2e87135dc908"  # Cognitive Services User
 $$FoundryUserRole         = "53ca6127-db72-4b80-b1b0-d745d6d5456d"  # Foundry User (formerly Azure AI User)
+$$StorageBlobDataContributorRole = "ba92f5b4-2d11-453d-a403-e96b0029c9fe"  # Storage Blob Data Contributor
+$$KeyVaultSecretsUserRole        = "4633458b-17de-408a-b874-0445c86b69e6"  # Key Vault Secrets User
+$$SearchIndexDataContributorRole = "8ebe5a00-799e-43f5-93ac-243d3dce84a7"  # Search Index Data Contributor
+$$CosmosDataContributorRole      = "00000000-0000-0000-0000-000000000002"  # Cosmos DB Built-in Data Contributor (data-plane)
 
 # Discover the identities from `azd ai agent show` (JSON output).
 $$AgentRaw = (azd ai agent show 2>$$null | Out-String)
@@ -78,6 +82,19 @@ if (-not $$AiAccountName) {
 }
 $$AcrId = "/subscriptions/$$Sub/resourceGroups/$$Rg/providers/Microsoft.ContainerRegistry/registries/$$AcrName"
 
+# Data-plane scopes. Bicep grants Cosmos/Blob/KV/Search data-plane roles only
+# to the Foundry *account* MI — but the running container authenticates (via
+# DefaultAzureCredential) as the *instance* identity, so those grants don't
+# cover it. Resolve each resource's scope from the azd env outputs (account
+# names are derived from their endpoints where azd only exposes the endpoint).
+$$StorageName = $$env:AZURE_BLOB_STORAGE_ACCOUNT_NAME
+$$CosmosName = if ($$env:AZURE_COSMOS_DB_ENDPOINT -match '^https?://([^.]+)\.') { $$Matches[1] } else { "" }
+$$KvName = if ($$env:AZURE_KEY_VAULT_URI -match '^https?://([^.]+)\.') { $$Matches[1] } else { "" }
+$$SearchName = if ($$env:AZURE_AI_SEARCH_ENDPOINT -match '^https?://([^.]+)\.') { $$Matches[1] } else { "" }
+$$StorageId = "/subscriptions/$$Sub/resourceGroups/$$Rg/providers/Microsoft.Storage/storageAccounts/$$StorageName"
+$$KvId = "/subscriptions/$$Sub/resourceGroups/$$Rg/providers/Microsoft.KeyVault/vaults/$$KvName"
+$$SearchId = "/subscriptions/$$Sub/resourceGroups/$$Rg/providers/Microsoft.Search/searchServices/$$SearchName"
+
 function Invoke-RoleGrant {
     param(
         [string] $$PrincipalId,
@@ -86,17 +103,45 @@ function Invoke-RoleGrant {
         [string] $$Label
     )
     if (-not $$PrincipalId -or -not $$Scope) { return }
-    az role assignment create `
+    $$Short = $$PrincipalId.Substring(0, [Math]::Min(8, $$PrincipalId.Length))
+    # Capture output so a genuine failure (auth, bad scope, MissingSubscription)
+    # is surfaced instead of being hidden behind the same message as a harmless
+    # already-exists.
+    $$Output = (az role assignment create `
         --assignee-object-id $$PrincipalId `
         --assignee-principal-type ServicePrincipal `
         --role $$Role `
         --scope $$Scope `
-        --output none 2>$$null
-    $$Short = $$PrincipalId.Substring(0, [Math]::Min(8, $$PrincipalId.Length))
+        --output none 2>&1 | Out-String)
     if ($$LASTEXITCODE -eq 0) {
         Write-Host "  [ok]   $$Short... -> $$Label"
+    } elseif ($$Output -match "RoleAssignmentExists|already exists|Conflict") {
+        Write-Host "  [skip] $$Short... -> $$Label (already granted)"
     } else {
-        Write-Host "  [skip] $$Short... -> $$Label (exists / skip)"
+        Write-Host "  [FAILED] $$Short... -> $$Label : $$Output"
+    }
+}
+
+function Invoke-CosmosRoleGrant {
+    param([string] $$PrincipalId)
+    if (-not $$PrincipalId -or -not $$CosmosName) { return }
+    $$Short = $$PrincipalId.Substring(0, [Math]::Min(8, $$PrincipalId.Length))
+    # Cosmos DB uses its own SQL role API (not `az role assignment create`);
+    # role-definition 00000000-…-002 is the Built-in Data Contributor, scoped
+    # to the whole account ("/").
+    $$Output = (az cosmosdb sql role assignment create `
+        --account-name $$CosmosName `
+        --resource-group $$Rg `
+        --role-definition-id $$CosmosDataContributorRole `
+        --principal-id $$PrincipalId `
+        --scope "/" `
+        --output none 2>&1 | Out-String)
+    if ($$LASTEXITCODE -eq 0) {
+        Write-Host "  [ok]   $$Short... -> Cosmos DB Data Contributor"
+    } elseif ($$Output -match "RoleAssignmentExists|already exists|Conflict") {
+        Write-Host "  [skip] $$Short... -> Cosmos DB Data Contributor (already granted)"
+    } else {
+        Write-Host "  [FAILED] $$Short... -> Cosmos DB Data Contributor : $$Output"
     }
 }
 
@@ -134,6 +179,14 @@ foreach ($$Principal in @($$InstancePrincipal, $$BlueprintPrincipal)) {
     # surfaces as 401 if missing — see foundry-hosted-agents SKILL.md).
     Invoke-RoleGrant -PrincipalId $$Principal -Role $$FoundryUserRole -Scope $$AiAccountId -Label "Foundry User"
     Invoke-RoleGrant -PrincipalId $$Principal -Role $$FoundryUserRole -Scope $$AiProjectId -Label "Foundry User"
+
+    # App data-plane: the container reads/writes Cosmos (conversation history),
+    # syncs skills from Blob storage, queries Search indexes, and fetches Key
+    # Vault secrets — all as the instance identity, which Bicep does NOT grant.
+    Invoke-CosmosRoleGrant -PrincipalId $$Principal
+    Invoke-RoleGrant -PrincipalId $$Principal -Role $$StorageBlobDataContributorRole -Scope $$StorageId -Label "Storage Blob Data Contributor"
+    Invoke-RoleGrant -PrincipalId $$Principal -Role $$KeyVaultSecretsUserRole -Scope $$KvId -Label "Key Vault Secrets User"
+    Invoke-RoleGrant -PrincipalId $$Principal -Role $$SearchIndexDataContributorRole -Scope $$SearchId -Label "Search Index Data Contributor"
 }
 
 Write-Host ""

--- a/src/backend/app/exporter_templates/hooks/postdeploy.sh.template
+++ b/src/backend/app/exporter_templates/hooks/postdeploy.sh.template
@@ -29,6 +29,10 @@ ACR_PULL_ROLE='7f951dda-4ed3-4680-a7ca-43fe172d538d'                      # AcrP
 COGNITIVE_OPENAI_USER_ROLE='5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'         # Cognitive Services OpenAI User
 COGNITIVE_USER_ROLE='a97b65f3-24c7-4388-baec-2e87135dc908'                # Cognitive Services User
 FOUNDRY_USER_ROLE='53ca6127-db72-4b80-b1b0-d745d6d5456d'                  # Foundry User (formerly Azure AI User)
+STORAGE_BLOB_DATA_CONTRIBUTOR_ROLE='ba92f5b4-2d11-453d-a403-e96b0029c9fe' # Storage Blob Data Contributor
+KEY_VAULT_SECRETS_USER_ROLE='4633458b-17de-408a-b874-0445c86b69e6'        # Key Vault Secrets User
+SEARCH_INDEX_DATA_CONTRIBUTOR_ROLE='8ebe5a00-799e-43f5-93ac-243d3dce84a7' # Search Index Data Contributor
+COSMOS_DATA_CONTRIBUTOR_ROLE='00000000-0000-0000-0000-000000000002'       # Cosmos DB Built-in Data Contributor (data-plane)
 
 # Discover the identities from `azd ai agent show` (JSON output).
 AGENT_JSON="$$(azd ai agent show 2>/dev/null | sed -n '/^{/,/^}/p' || true)"
@@ -63,20 +67,64 @@ if [ -z "$$AI_ACCOUNT_NAME" ]; then
 fi
 ACR_ID="/subscriptions/$$SUB/resourceGroups/$$RG/providers/Microsoft.ContainerRegistry/registries/$$ACR_NAME"
 
+# Data-plane scopes. Bicep grants Cosmos/Blob/KV/Search data-plane roles only
+# to the Foundry *account* MI — but the running container authenticates (via
+# DefaultAzureCredential) as the *instance* identity, so those grants don't
+# cover it. Resolve each resource's scope from the azd env outputs (account
+# names are derived from their endpoints where azd only exposes the endpoint).
+STORAGE_NAME="$${AZURE_BLOB_STORAGE_ACCOUNT_NAME:-}"
+COSMOS_NAME="$$(echo "$${AZURE_COSMOS_DB_ENDPOINT:-}" | sed -E 's#^https?://([^.]+)\..*#\1#')"
+KV_NAME="$$(echo "$${AZURE_KEY_VAULT_URI:-}" | sed -E 's#^https?://([^.]+)\..*#\1#')"
+SEARCH_NAME="$$(echo "$${AZURE_AI_SEARCH_ENDPOINT:-}" | sed -E 's#^https?://([^.]+)\..*#\1#')"
+STORAGE_ID="/subscriptions/$$SUB/resourceGroups/$$RG/providers/Microsoft.Storage/storageAccounts/$$STORAGE_NAME"
+KV_ID="/subscriptions/$$SUB/resourceGroups/$$RG/providers/Microsoft.KeyVault/vaults/$$KV_NAME"
+SEARCH_ID="/subscriptions/$$SUB/resourceGroups/$$RG/providers/Microsoft.Search/searchServices/$$SEARCH_NAME"
+
+# Grant a control-plane RBAC role, surfacing *real* failures. Capturing the
+# command output lets us tell a harmless already-exists apart from a genuine
+# error (auth, bad scope, MissingSubscription) instead of hiding both behind
+# the same "skip" message (which used to mask broken deploys entirely).
 grant() {
     local pid="$$1"
     local role="$$2"
     local scope="$$3"
     local label="$$4"
     if [ -z "$$pid" ] || [ -z "$$scope" ]; then return 0; fi
-    az role assignment create \
+    local out
+    if out="$$(az role assignment create \
         --assignee-object-id "$$pid" \
         --assignee-principal-type ServicePrincipal \
         --role "$$role" \
         --scope "$$scope" \
-        --output none 2>/dev/null \
-        && echo "  ✅ $${pid:0:8}… → $$label @ $${scope##*/}" \
-        || echo "  ⊙  $${pid:0:8}… → $$label @ $${scope##*/} (exists / skip)"
+        --output none 2>&1)"; then
+        echo "  ✅ $${pid:0:8}… → $$label @ $${scope##*/}"
+    elif echo "$$out" | grep -qiE 'RoleAssignmentExists|already exists|Conflict'; then
+        echo "  ⊙  $${pid:0:8}… → $$label @ $${scope##*/} (already granted)"
+    else
+        echo "  ❌ FAILED $${pid:0:8}… → $$label @ $${scope##*/}: $$out"
+    fi
+}
+
+# Grant the Cosmos DB *data-plane* role. Cosmos uses its own SQL role API
+# (not `az role assignment create`); role-definition 00000000-…-002 is the
+# Built-in Data Contributor, scoped to the whole account ("/").
+grant_cosmos() {
+    local pid="$$1"
+    if [ -z "$$pid" ] || [ -z "$$COSMOS_NAME" ]; then return 0; fi
+    local out
+    if out="$$(az cosmosdb sql role assignment create \
+        --account-name "$$COSMOS_NAME" \
+        --resource-group "$$RG" \
+        --role-definition-id "$$COSMOS_DATA_CONTRIBUTOR_ROLE" \
+        --principal-id "$$pid" \
+        --scope "/" \
+        --output none 2>&1)"; then
+        echo "  ✅ $${pid:0:8}… → Cosmos DB Data Contributor"
+    elif echo "$$out" | grep -qiE 'RoleAssignmentExists|already exists|Conflict'; then
+        echo "  ⊙  $${pid:0:8}… → Cosmos DB Data Contributor (already granted)"
+    else
+        echo "  ❌ FAILED $${pid:0:8}… → Cosmos DB Data Contributor: $$out"
+    fi
 }
 
 # ── 1. Grant AcrPull to the Foundry PROJECT MI (the actual image-puller). ──
@@ -117,6 +165,14 @@ for PID in "$$INSTANCE_PID" "$$BLUEPRINT_PID"; do
     # § MAF 1.4.0 breaking changes).
     grant "$$PID" "$$FOUNDRY_USER_ROLE" "$$AI_ACCOUNT_ID" "Foundry User"
     grant "$$PID" "$$FOUNDRY_USER_ROLE" "$$AI_PROJECT_ID" "Foundry User"
+
+    # App data-plane: the container reads/writes Cosmos (conversation history),
+    # syncs skills from Blob storage, queries Search indexes, and fetches Key
+    # Vault secrets — all as the instance identity, which Bicep does NOT grant.
+    grant_cosmos "$$PID"
+    grant "$$PID" "$$STORAGE_BLOB_DATA_CONTRIBUTOR_ROLE" "$$STORAGE_ID" "Storage Blob Data Contributor"
+    grant "$$PID" "$$KEY_VAULT_SECRETS_USER_ROLE" "$$KV_ID" "Key Vault Secrets User"
+    grant "$$PID" "$$SEARCH_INDEX_DATA_CONTRIBUTOR_ROLE" "$$SEARCH_ID" "Search Index Data Contributor"
 done
 
 echo ""

--- a/src/backend/app/hosted_agent_invoke.py
+++ b/src/backend/app/hosted_agent_invoke.py
@@ -1,0 +1,49 @@
+"""Coerce hosted-agent invocation request bodies into a normalized dict.
+
+The Foundry hosted-agent receives invocations through several paths, each of
+which frames the request body differently:
+
+* ``azd ai agent invoke "msg"`` — posts the raw message as ``text/plain``,
+  **not** JSON. Naively calling ``request.json()`` on this raises and the agent
+  used to reject it with a 400, breaking the primary CLI test path.
+* The Kratos backend proxy — posts a JSON object
+  (``{"message": ..., "useCase": ..., "conversationId": ...}``).
+* Platform keep-alive — posts ``{"warmup": true}`` (or an empty body) to reset
+  the idle timer without invoking the model.
+
+This helper is intentionally dependency-free (stdlib ``json`` only) so it can be
+unit-tested without importing the agentserver runtime.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def parse_invoke_payload(raw: bytes) -> dict[str, Any]:
+    """Normalize a raw invocation body into a dict.
+
+    Returns one of:
+      * the JSON object as-is, when the body is a JSON object;
+      * ``{"message": <text>}`` for a JSON string, plain text, or any other
+        non-object JSON value (arrays/numbers are stringified back to text);
+      * ``{"warmup": True}`` for an empty or whitespace-only body.
+    """
+    text = raw.decode("utf-8", "replace").strip() if raw else ""
+    if not text:
+        return {"warmup": True}
+
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        # Plain text (e.g. `azd ai agent invoke "hello"`).
+        return {"message": text}
+
+    if isinstance(parsed, dict):
+        return parsed
+    if isinstance(parsed, str):
+        return {"message": parsed}
+
+    # Any other JSON scalar/array: treat the original text as the message.
+    return {"message": text}

--- a/src/backend/tests/test_hosted_agent_invoke.py
+++ b/src/backend/tests/test_hosted_agent_invoke.py
@@ -1,0 +1,50 @@
+"""Tests for hosted-agent invocation body parsing.
+
+``azd ai agent invoke "msg"`` POSTs the raw message as ``text/plain`` — NOT
+JSON. The hosted agent must accept that, as well as JSON objects (the backend
+proxy path), bare JSON strings, and empty keep-alive pings. The body-coercion
+logic lives in a dependency-free helper so it can be unit-tested without
+importing the full agentserver runtime.
+"""
+
+from __future__ import annotations
+
+from app.hosted_agent_invoke import parse_invoke_payload
+
+
+def test_json_object_is_returned_as_is():
+    raw = b'{"message": "hi there", "useCase": "finance-close"}'
+    assert parse_invoke_payload(raw) == {"message": "hi there", "useCase": "finance-close"}
+
+
+def test_plain_text_becomes_message():
+    # This is what `azd ai agent invoke "hello world"` sends (text/plain).
+    assert parse_invoke_payload(b"hello world") == {"message": "hello world"}
+
+
+def test_bare_json_string_becomes_message():
+    # A JSON-encoded bare string (e.g. body == '"hello"').
+    assert parse_invoke_payload(b'"hello"') == {"message": "hello"}
+
+
+def test_empty_body_is_warmup():
+    assert parse_invoke_payload(b"") == {"warmup": True}
+
+
+def test_whitespace_only_body_is_warmup():
+    assert parse_invoke_payload(b"   \n\t ") == {"warmup": True}
+
+
+def test_explicit_warmup_object_is_preserved():
+    assert parse_invoke_payload(b'{"warmup": true}') == {"warmup": True}
+
+
+def test_json_array_falls_back_to_text_message():
+    # Non-object / non-string JSON scalars & arrays are treated as the message.
+    assert parse_invoke_payload(b"[1, 2, 3]") == {"message": "[1, 2, 3]"}
+
+
+def test_invalid_utf8_does_not_raise():
+    # Should degrade gracefully rather than 500 on a bad byte sequence.
+    result = parse_invoke_payload(b"\xff\xfe bad bytes")
+    assert "message" in result

--- a/src/backend/tests/test_import_persona.py
+++ b/src/backend/tests/test_import_persona.py
@@ -35,9 +35,7 @@ def _manifest(**overrides) -> dict:
             {"name": "fraud-check", "description": "Score fraud risk", "package": "acme/skills/skills/fraud-check"},
             {"name": "no-package-skill", "description": "metadata only"},
         ],
-        "mcpServers": [
-            {"name": "microsoft-learn", "transport": "http", "url": "https://learn.microsoft.com/api/mcp"}
-        ],
+        "mcpServers": [{"name": "microsoft-learn", "transport": "http", "url": "https://learn.microsoft.com/api/mcp"}],
         "traits": ["analysis", "validation"],
         "workflow_model": "agent",
     }

--- a/src/backend/tests/test_project_exporter.py
+++ b/src/backend/tests/test_project_exporter.py
@@ -535,3 +535,107 @@ def test_export_endpoint_rejects_bad_name(export_client: TestClient):
     # FastAPI/Starlette returns 404 for path-traversal attempts in URL path
     # segments; either way the export router never sees an unsafe name.
     assert response.status_code in (400, 404)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — runtime correctness fixes (RBAC, telemetry, region docs)
+# ---------------------------------------------------------------------------
+
+
+def test_assemble_azure_yaml_wires_app_insights(exporter: ProjectExporter, tmp_path: Path):
+    """The container env must carry the App Insights connection string.
+
+    Without ``APPLICATIONINSIGHTS_CONNECTION_STRING`` the agentserver framework
+    falls back to a *console* OTLP exporter and dumps a wall of metric JSON to
+    stdout every 60s, drowning the Agent Playground logs. ``setup_telemetry``
+    only wires Azure Monitor when this var is set, and ``main.bicep`` already
+    outputs it as ``AZURE_APP_INSIGHTS_CONNECTION_STRING``.
+    """
+    out = tmp_path / "out"
+    out.mkdir()
+    exporter.assemble("finance-close", out)
+
+    doc = yaml.safe_load((out / "azure.yaml").read_text())
+    env = doc["services"]["finance-close"]["config"]["env"]
+    assert env.get("APPLICATIONINSIGHTS_CONNECTION_STRING") == "${AZURE_APP_INSIGHTS_CONNECTION_STRING}"
+
+
+def test_postdeploy_grants_dataplane_roles_to_instance_identity(exporter: ProjectExporter, tmp_path: Path):
+    """The hook must grant Cosmos + Blob + KV + Search data-plane roles.
+
+    The running container authenticates via ``DefaultAzureCredential`` as the
+    Foundry *instance* identity. Bicep (role-assignments.bicep) grants the
+    data-plane roles only to the Foundry **account** MI — NOT the instance
+    identity — so without these hook grants the agent gets 403s reading Cosmos
+    history / syncing skills from Blob. The hook discovers the instance +
+    blueprint identities post-deploy and grants them the missing roles.
+    """
+    out = tmp_path / "out"
+    out.mkdir()
+    exporter.assemble("finance-close", out)
+
+    sh = (out / "hooks" / "postdeploy.sh").read_text()
+    ps = (out / "hooks" / "postdeploy.ps1").read_text()
+
+    cosmos_data_contributor = "00000000-0000-0000-0000-000000000002"
+    storage_blob_contributor = "ba92f5b4-2d11-453d-a403-e96b0029c9fe"
+    kv_secrets_user = "4633458b-17de-408a-b874-0445c86b69e6"
+    search_index_contributor = "8ebe5a00-799e-43f5-93ac-243d3dce84a7"
+
+    for content in (sh, ps):
+        # Cosmos uses the data-plane SQL role API, not `az role assignment create`.
+        assert "cosmosdb sql role assignment create" in content
+        assert cosmos_data_contributor in content
+        assert storage_blob_contributor in content
+        assert kv_secrets_user in content
+        assert search_index_contributor in content
+
+
+def test_postdeploy_surfaces_real_grant_failures(exporter: ProjectExporter, tmp_path: Path):
+    """A failed grant must NOT be silently mislabelled as '(exists / skip)'.
+
+    The old hook ran ``az ... 2>/dev/null || echo skip``, hiding genuine
+    failures (auth, bad scope, MissingSubscription) behind the same message as
+    a harmless already-exists. The fix captures the command output and only
+    treats an *already-exists* error as skippable; anything else is reported as
+    a real failure.
+    """
+    out = tmp_path / "out"
+    out.mkdir()
+    exporter.assemble("finance-close", out)
+
+    sh = (out / "hooks" / "postdeploy.sh").read_text()
+    ps = (out / "hooks" / "postdeploy.ps1").read_text()
+
+    for content in (sh, ps):
+        # Special-cases the already-exists error code rather than swallowing all.
+        assert "RoleAssignmentExists" in content
+        # Surfaces a distinct failure marker for real errors.
+        assert "FAILED" in content
+
+
+def test_readme_warns_about_hosted_agent_regions(exporter: ProjectExporter, tmp_path: Path):
+    """README must warn that hosted agents aren't available in every region.
+
+    Several regions (e.g. Central US) provision the infra fine but the hosted
+    agent deploy fails — a trap worth calling out, with a pointer to a known
+    supported region.
+    """
+    out = tmp_path / "out"
+    out.mkdir()
+    exporter.assemble("finance-close", out)
+
+    readme = (out / "README.md").read_text().lower()
+    assert "region" in readme
+    assert "central us" in readme
+
+
+def test_build_zip_includes_invoke_parser_module(exporter: ProjectExporter, tmp_path: Path):
+    """The new invoke-parsing helper must ship with the backend app."""
+    out = tmp_path / "out"
+    out.mkdir()
+    exporter.assemble("finance-close", out)
+    blob = ProjectExporter.build_zip(out)
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        names = set(zf.namelist())
+    assert "src/backend/app/hosted_agent_invoke.py" in names

--- a/src/backend/tests/test_project_exporter.py
+++ b/src/backend/tests/test_project_exporter.py
@@ -614,6 +614,25 @@ def test_postdeploy_surfaces_real_grant_failures(exporter: ProjectExporter, tmp_
         assert "FAILED" in content
 
 
+def test_postdeploy_ps1_does_not_throw_on_nonzero_az_exit(exporter: ProjectExporter, tmp_path: Path):
+    """The ps1 hook must inspect ``$LASTEXITCODE`` itself, not throw.
+
+    The hook sets ``$ErrorActionPreference = 'Stop'``. In PowerShell 7.4+,
+    ``$PSNativeCommandUseErrorActionPreference`` defaults to ``$true``, so a
+    native command (``az``) returning a non-zero exit code raises a
+    *terminating* error under ``Stop`` — which would abort the hook before our
+    ``if ($LASTEXITCODE -eq 0)`` check runs. Because an already-exists / Conflict
+    grant returns non-zero (the case fix #3 handles by design), the hook must
+    disable that behaviour so re-runs stay idempotent.
+    """
+    out = tmp_path / "out"
+    out.mkdir()
+    exporter.assemble("finance-close", out)
+
+    ps = (out / "hooks" / "postdeploy.ps1").read_text()
+    assert "$PSNativeCommandUseErrorActionPreference = $false" in ps
+
+
 def test_readme_warns_about_hosted_agent_regions(exporter: ProjectExporter, tmp_path: Path):
     """README must warn that hosted agents aren't available in every region.
 

--- a/src/hosted-agent/main.py
+++ b/src/hosted-agent/main.py
@@ -46,6 +46,7 @@ if "FOUNDRY_ENDPOINT" not in os.environ:
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
 
 from app.config import Settings, get_settings
+from app.hosted_agent_invoke import parse_invoke_payload
 from app.models import (
     ContentEvent,
     DoneEvent,
@@ -410,17 +411,22 @@ async def handle_invoke(request: Request) -> Response:
     if _copilot_agent is None:
         await _startup()
 
+    # Read the request body exactly once and normalise it. The hosted agent is
+    # invoked through several paths that frame the body differently:
+    #   * ``azd ai agent invoke "msg"`` posts the message as text/plain (NOT JSON)
+    #   * the Kratos backend proxy posts a JSON object
+    #   * the platform keep-alive posts ``{"warmup": true}`` or an empty body
+    # parse_invoke_payload coerces all of these into a dict (empty body → warmup),
+    # so a plain-text CLI invoke no longer 400s on json.loads.
+    data = parse_invoke_payload(await request.body())
+
     # Keep-warm fast-path: the backend pings the hosted agent periodically with
     # ``{"warmup": true}`` to stop the Foundry platform from scaling the container
     # to zero (which causes multi-second cold starts and gateway 408 timeouts on
     # the next real request). Running _startup() above already re-provisions and
     # initialises every service, so we return immediately without invoking the
     # model or persisting anything — this resets the platform idle timer cheaply.
-    try:
-        _warmup_data = await request.json()
-    except (json.JSONDecodeError, ValueError):
-        _warmup_data = None
-    if isinstance(_warmup_data, dict) and _warmup_data.get("warmup") is True:
+    if data.get("warmup") is True:
         return JSONResponse(
             status_code=200,
             content={
@@ -433,10 +439,6 @@ async def handle_invoke(request: Request) -> Response:
         )
 
     try:
-        data = _warmup_data if isinstance(_warmup_data, dict) else await request.json()
-        if not isinstance(data, dict):
-            raise ValueError("body is not a JSON object")
-
         message = data.get("message") or data.get("input")
         if not isinstance(message, str) or not message.strip():
             raise ValueError('missing or empty "message" (or "input") field')


### PR DESCRIPTION
## Why

Hardens the per-use-case **"Download as Foundry Agent"** export against issues discovered running a downstream export (`retail-banking-foundry-agent`) through a real `azd up` deploy. These are runtime-correctness bugs the export shipped that only surface once the hosted agent actually runs.

## What

| # | Area | Fix |
|---|------|-----|
| 1 | **Instance-identity RBAC** (`hooks/postdeploy.sh` + `.ps1`) | Grant **Cosmos DB Data Contributor**, **Storage Blob Data Contributor**, **Key Vault Secrets User**, and **Search Index Data Contributor** to the hosted-agent *instance* identity. |
| 2 | **Grant error surfacing** (`hooks/postdeploy.sh` + `.ps1`) | Stop hiding real failures behind `(exists / skip)`. Capture output; only an *already-exists* error is skippable — everything else is reported as `FAILED`. |
| 3 | **Telemetry** (`azure.yaml`) | Set `APPLICATIONINSIGHTS_CONNECTION_STRING` so the agentserver wires Azure Monitor instead of a console OTLP exporter that floods stdout with metric JSON every 60s. |
| 4 | **Invoke parsing** (`hosted-agent/main.py` + new `app/hosted_agent_invoke.py`) | `azd ai agent invoke "msg"` posts **text/plain**, not JSON. New `parse_invoke_payload` coerces JSON object / JSON string / plain text / empty body into a normalized dict (empty → warmup) so invokes no longer 400. |
| 5 | **README** | Warn that hosted agents aren't in every region (Central US provisions but agent deploy fails) and document the new data-plane grants. |

### Root cause for #1
The container authenticates via `DefaultAzureCredential` → resolves to the Foundry **instance** identity. Bicep (`role-assignments.bicep`) grants the data-plane roles only to the Foundry **account** MI, so reads of Cosmos history / Blob skills / Search / KV secrets `403`'d at runtime. Cosmos uses its own SQL role API (`az cosmosdb sql role assignment create`, role def `…-002`); the others use `az role assignment create`. Scope names are derived from azd env endpoint outputs.

## Verification

- ✅ `uv run --extra dev pytest` — **59 passed** (TDD: 8 new invoke-helper tests + 5 new exporter tests, all RED→GREEN).
- ✅ `ruff check` clean; `py_compile` of `hosted-agent/main.py` + helper OK.
- ✅ Rendered a real `finance-close` export: `bash -n postdeploy.sh` clean, **no `$$` template leftovers**, `az bicep build infra/main.bicep` compiles with zero warnings.
- ✅ Confirmed all referenced azd outputs exist in the exported `infra/main.bicep`.

## Caveat / not covered here

`pwsh` isn't available in this dev env, so `postdeploy.ps1` was validated by render + visual review, not a live parse. And while #1 is backed by tests + bicep compile + the production notes, the one thing **not** exercised here is a live end-to-end `azd up` deploy of an exported use-case. Worth a one-shot live validation before relying on it in a demo.