### PR TITLE
feat(voice): opt-in voice/mic mode for chat (GPT Realtime)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,20 @@ FOUNDRY_PROJECT_NAME=
 # In production this is read from Key Vault via Managed Identity at startup
 FOUNDRY_API_KEY=
 
+# ── Voice mode (GPT Realtime) — opt-in speech-to-speech ─────────────────────
+# Off by default. When enabled, the chat shows a mic button; speech is
+# transcribed and sent through the normal /api/agent/chat path, and the
+# assistant's final reply is spoken back over WebRTC. The Realtime key never
+# reaches the browser — the backend mints a short-lived ephemeral token with
+# Managed Identity (see src/backend/app/routers/voice.py).
+VOICE_ENABLED=false
+# AIServices account hosting the gpt-realtime deployment. Empty = reuse
+# FOUNDRY_ENDPOINT above.
+VOICE_ENDPOINT=
+VOICE_DEPLOYMENT=gpt-realtime
+# Output voice (e.g. marin, alloy, echo)
+VOICE_VOICE=marin
+
 # ── Azure Cosmos DB ─────────────────────────────────────────────────────────
 # e.g. https://<account>.documents.azure.com:443/
 COSMOS_DB_ENDPOINT=

--- a/azure.yaml
+++ b/azure.yaml
@@ -79,6 +79,14 @@ services:
                       node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync('out/config.json','utf8'));c.auth=JSON.parse(process.argv[1]);fs.writeFileSync('out/config.json',JSON.stringify(c));" "$AUTH_JSON"
                       echo "Merged OBO auth config into config.json (scope=${SCOPE})"
                     fi
+                    # Surface the opt-in voice flag to the static frontend so the
+                    # mic button only appears when VOICE_ENABLED=true server-side.
+                    if [ -n "${VOICE_ENABLED}" ]; then
+                      [ -f out/config.json ] || echo "{}" > out/config.json
+                      VE="$(printf '%s' "${VOICE_ENABLED}" | tr '[:upper:]' '[:lower:]')"
+                      node -e "const fs=require('fs');const c=JSON.parse(fs.readFileSync('out/config.json','utf8'));c.voiceEnabled=(process.argv[1]==='true');fs.writeFileSync('out/config.json',JSON.stringify(c));" "$VE"
+                      echo "Merged voiceEnabled=${VE} into config.json"
+                    fi
                     # Emit a basePath-aware staticwebapp.config.json into out/ so the
                     # SWA EasyAuth 401 redirect + /api/* gating stay inside the mount
                     # path (e.g. /kratos) when hosted behind Front Door. Empty base

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -30,6 +30,9 @@ param storageAccountName string = ''
 @description('Optional prefix prepended to generated resource names. Empty (default) yields names identical to the base template, so the canonical/prod deployment is unaffected. Set per-subscription (e.g. via AZURE_RESOURCE_PREFIX) to avoid cross-subscription resource name collisions.')
 param resourcePrefix string = ''
 
+@description('Enable opt-in voice mode (deploys gpt-realtime + flags backend/frontend)')
+param voiceEnabled bool = false
+
 @description('Path prefix for the agent API on the gateway (set during Foundry portal registration)')
 param agentApiPath string = 'kratos-agent'
 
@@ -142,6 +145,7 @@ module aiFoundry './modules/ai-services.bicep' = {
     tags: tags
     appInsightsId: appInsights.outputs.id
     appInsightsConnectionString: appInsights.outputs.connectionString
+    deployRealtime: voiceEnabled
   }
 }
 
@@ -208,6 +212,8 @@ module agentService './modules/agent-service.bicep' = {
     keyVaultUri: keyVault.outputs.uri
     foundryEndpoint: aiFoundry.outputs.endpoint
     foundryModelDeployment: aiFoundry.outputs.modelDeploymentName
+    voiceEnabled: voiceEnabled
+    voiceDeployment: aiFoundry.outputs.realtimeDeploymentName
     foundryProjectName: aiFoundry.outputs.projectName
     foundryProjectEndpoint: aiFoundry.outputs.projectEndpoint
     bingSearchEndpoint: bingSearch.outputs.endpoint

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -11,6 +11,9 @@
     "resourcePrefix": {
       "value": "${AZURE_RESOURCE_PREFIX}"
     },
+    "voiceEnabled": {
+      "value": "${VOICE_ENABLED=false}"
+    },
     "principalId": {
       "value": "${AZURE_PRINCIPAL_ID}"
     }

--- a/infra/modules/agent-service.bicep
+++ b/infra/modules/agent-service.bicep
@@ -28,6 +28,12 @@ param aiSearchEndpoint string
 @description('Key Vault URI')
 param keyVaultUri string
 
+@description('Voice mode flag (opt-in speech-to-speech)')
+param voiceEnabled bool = false
+
+@description('gpt-realtime deployment name for voice mode')
+param voiceDeployment string = ''
+
 @description('Microsoft Foundry endpoint')
 param foundryEndpoint string
 
@@ -132,6 +138,8 @@ resource agentService 'Microsoft.App/containerApps@2024-03-01' = {
             { name: 'KEY_VAULT_URI', value: keyVaultUri }
             { name: 'FOUNDRY_ENDPOINT', value: foundryEndpoint }
             { name: 'FOUNDRY_MODEL_DEPLOYMENT', value: foundryModelDeployment }
+            { name: 'VOICE_ENABLED', value: string(voiceEnabled) }
+            { name: 'VOICE_DEPLOYMENT', value: voiceDeployment }
             { name: 'FOUNDRY_PROJECT_NAME', value: foundryProjectName }
             { name: 'FOUNDRY_PROJECT_ENDPOINT', value: foundryProjectEndpoint }
             { name: 'FOUNDRY_AGENT_NAME', value: foundryAgentName }

--- a/infra/modules/ai-services.bicep
+++ b/infra/modules/ai-services.bicep
@@ -22,6 +22,21 @@ param modelVersion string = '2026-03-05'
 @description('Deployment SKU capacity (thousands of tokens per minute)')
 param modelCapacity int = 350
 
+@description('Deploy a gpt-realtime model for opt-in voice mode')
+param deployRealtime bool = false
+
+@description('Name of the gpt-realtime deployment (voice mode)')
+param realtimeDeploymentName string = 'gpt-realtime'
+
+@description('Realtime model name')
+param realtimeModelName string = 'gpt-realtime'
+
+@description('Realtime model version')
+param realtimeModelVersion string = '2025-08-28'
+
+@description('Realtime deployment capacity (RPM/TPM units)')
+param realtimeCapacity int = 1
+
 @description('Application Insights resource ID to connect to the project (powers the Foundry Traces tab). Empty = no connection.')
 param appInsightsId string = ''
 
@@ -74,6 +89,25 @@ resource modelDeployment 'Microsoft.CognitiveServices/accounts/deployments@2025-
   }
 }
 
+// Opt-in gpt-realtime deployment for voice mode (STT + TTS over WebRTC).
+// Sequenced after the main deployment — model deployments must serialize.
+resource realtimeDeployment 'Microsoft.CognitiveServices/accounts/deployments@2025-06-01' = if (deployRealtime) {
+  parent: aiFoundry
+  name: realtimeDeploymentName
+  dependsOn: [modelDeployment]
+  sku: {
+    name: 'GlobalStandard'
+    capacity: realtimeCapacity
+  }
+  properties: {
+    model: {
+      format: 'OpenAI'
+      name: realtimeModelName
+      version: realtimeModelVersion
+    }
+  }
+}
+
 // Connect Application Insights to the project so the Foundry portal Traces tab
 // has a data source AND the platform injects the trace connection string into
 // hosted agents (their OpenTelemetry gen_ai spans land here).
@@ -99,6 +133,7 @@ output id string = aiFoundry.id
 output name string = aiFoundry.name
 output endpoint string = aiFoundry.properties.endpoint
 output modelDeploymentName string = modelDeployment.name
+output realtimeDeploymentName string = deployRealtime ? realtimeDeployment.name : ''
 output projectName string = project.name
 output projectEndpoint string = '${aiFoundry.properties.endpoint}api/projects/${project.name}'
 output projectId string = project.id

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -42,6 +42,17 @@ class Settings(BaseSettings):
     keep_warm_interval_s: int = 300  # ping cadence; must be shorter than the per-session 15-min idle timeout
     warm_pool_size: int = 2  # number of pre-warmed, unclaimed sandboxes kept ready for new conversations
 
+    # ── Voice (GPT Realtime) — opt-in speech-to-speech for chat ──────────
+    # Generic voice mode: STT + TTS via Azure GPT Realtime; the agent is
+    # unchanged. The Realtime key never ships to the browser — backend mints
+    # an ephemeral session token with Managed Identity (see routers/voice.py).
+    voice_enabled: bool = False
+    voice_endpoint: str = ""  # AIServices endpoint; falls back to foundry_endpoint
+    voice_deployment: str = "gpt-realtime"
+    voice_voice: str = "marin"
+    voice_instructions: str = "You are a helpful voice assistant. Keep replies brief and conversational."
+    voice_token_scope: str = "https://cognitiveservices.azure.com/.default"  # noqa: S105
+
     # Azure Blob Storage for skills
     blob_storage_endpoint: str = ""
     blob_skills_container: str = "skills"

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -27,6 +27,7 @@ from app.routers import (
     settings,
     traces,
     use_cases,
+    voice,
 )
 from app.services.apm_service import ApmError, ApmService
 from app.services.blob_skill_service import BlobSkillService
@@ -252,3 +253,4 @@ app.include_router(evals.router, prefix="/api/use-cases", tags=["evals"])
 app.include_router(traces.router, prefix="/api/traces", tags=["traces"])
 app.include_router(files.router, prefix="/api/files", tags=["files"])
 app.include_router(copilot_studio.router, prefix="/api/copilot-studio", tags=["copilot-studio"])
+app.include_router(voice.router, prefix="/api/voice", tags=["voice"])

--- a/src/backend/app/models.py
+++ b/src/backend/app/models.py
@@ -228,6 +228,7 @@ class AIServiceStatus(BaseModel):
     configured: bool = False
     foundryEndpoint: str = ""
     foundryModelDeployment: str = ""
+    voiceEnabled: bool = False
     code: str = "INTERNAL_ERROR"
 
 

--- a/src/backend/app/routers/settings.py
+++ b/src/backend/app/routers/settings.py
@@ -20,4 +20,5 @@ async def get_settings_endpoint(request: Request) -> AIServiceStatus:
         configured=bool(settings.foundry_endpoint),
         foundryEndpoint=settings.foundry_endpoint,
         foundryModelDeployment=settings.foundry_model_deployment,
+        voiceEnabled=settings.voice_enabled,
     )

--- a/src/backend/app/routers/voice.py
+++ b/src/backend/app/routers/voice.py
@@ -1,0 +1,103 @@
+"""Voice (GPT Realtime) endpoint — mints ephemeral Realtime session tokens.
+
+Loosely coupled, opt-in (``VOICE_ENABLED``) helper for the browser's
+speech-to-speech mode. The Realtime API key never reaches the browser: the
+backend authenticates with Managed Identity / ``DefaultAzureCredential`` and
+returns a short-lived ephemeral token plus the public WebRTC target. The chat
+path (``/api/agent/chat``) is unchanged — Realtime is used for STT + TTS only.
+"""
+
+import logging
+
+import httpx
+from azure.identity.aio import DefaultAzureCredential
+from fastapi import APIRouter, HTTPException
+
+from app.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_credential: DefaultAzureCredential | None = None
+_http_client: httpx.AsyncClient | None = None
+
+
+def _get_credential() -> DefaultAzureCredential:
+    global _credential
+    if _credential is None:
+        _credential = DefaultAzureCredential()
+    return _credential
+
+
+def _get_http_client() -> httpx.AsyncClient:
+    global _http_client
+    if _http_client is None or _http_client.is_closed:
+        _http_client = httpx.AsyncClient(timeout=30.0)
+    return _http_client
+
+
+@router.get("/session")
+async def create_voice_session() -> dict:
+    """Return an ephemeral Realtime session token + WebRTC target.
+
+    The browser uses ``token`` to open a WebRTC call to
+    ``{endpoint}/openai/v1/realtime/calls?model={deployment}`` — the long-lived
+    key stays server-side. Gated behind ``VOICE_ENABLED``.
+    """
+    settings = get_settings()
+    if not settings.voice_enabled:
+        raise HTTPException(status_code=404, detail="Voice mode is disabled")
+
+    endpoint = (settings.voice_endpoint or settings.foundry_endpoint).rstrip("/")
+    if not endpoint:
+        raise HTTPException(status_code=503, detail="Voice endpoint not configured")
+
+    deployment = settings.voice_deployment
+    voice = settings.voice_voice
+
+    # Bake the session config at creation so the browser cannot inject a late
+    # session.update race; STT + server-side VAD on, TTS voice fixed.
+    session_config = {
+        "session": {
+            "type": "realtime",
+            "model": deployment,
+            "instructions": settings.voice_instructions,
+            "audio": {
+                "input": {
+                    "transcription": {"model": "whisper-1"},
+                    "turn_detection": {"type": "server_vad", "create_response": False},
+                },
+                "output": {"voice": voice},
+            },
+        }
+    }
+
+    try:
+        token = await _get_credential().get_token(settings.voice_token_scope)
+    except Exception as exc:  # pragma: no cover - infra failure
+        logger.error("Voice token auth failed: %s", exc)
+        raise HTTPException(status_code=503, detail="Authentication failed") from exc
+
+    url = f"{endpoint}/openai/v1/realtime/client_secrets"
+    headers = {"Authorization": f"Bearer {token.token}", "Content-Type": "application/json"}
+    try:
+        resp = await _get_http_client().post(url, headers=headers, json=session_config)
+        resp.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.error("Voice session create failed: %s", exc)
+        raise HTTPException(status_code=502, detail="Failed to create voice session") from exc
+
+    data = resp.json()
+    ephemeral = data.get("value") or data.get("client_secret", {}).get("value", "")
+    if not ephemeral:
+        logger.error("No ephemeral token in Realtime response: %s", data)
+        raise HTTPException(status_code=502, detail="No ephemeral token returned")
+
+    return {
+        "token": ephemeral,
+        "endpoint": endpoint,
+        "deployment": deployment,
+        "voice": voice,
+        "expiresAt": data.get("expires_at"),
+    }

--- a/src/backend/tests/test_voice.py
+++ b/src/backend/tests/test_voice.py
@@ -1,0 +1,63 @@
+"""Tests for the voice (GPT Realtime) session endpoint."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import Settings, get_settings
+
+
+@pytest.fixture
+def client():
+    from app.main import app
+
+    app.state.cosmos_service = MagicMock()
+    app.state.skill_registry = MagicMock()
+    app.state.copilot_agent = MagicMock()
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_voice_disabled_returns_404(client):
+    get_settings.cache_clear()
+    client.app.dependency_overrides.clear()
+    response = client.get("/api/voice/session")
+    assert response.status_code == 404
+    get_settings.cache_clear()
+
+
+def test_voice_session_returns_ephemeral_token(client, monkeypatch):
+    from app.routers import voice
+
+    monkeypatch.setattr(
+        voice,
+        "get_settings",
+        lambda: Settings(
+            voice_enabled=True,
+            voice_endpoint="https://acct.cognitiveservices.azure.com/",
+            voice_deployment="gpt-realtime",
+            voice_voice="marin",
+        ),
+    )
+
+    cred = MagicMock()
+    cred.get_token = AsyncMock(return_value=MagicMock(token="aad-tok"))  # noqa: S106
+    monkeypatch.setattr(voice, "_get_credential", lambda: cred)
+
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value={"value": "ephem-123", "expires_at": 999})
+    http = MagicMock()
+    http.post = AsyncMock(return_value=resp)
+    monkeypatch.setattr(voice, "_get_http_client", lambda: http)
+
+    response = client.get("/api/voice/session")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["token"] == "ephem-123"  # noqa: S105
+    assert body["deployment"] == "gpt-realtime"
+    assert body["voice"] == "marin"
+    assert body["endpoint"] == "https://acct.cognitiveservices.azure.com"
+
+    called_url = http.post.call_args[0][0]
+    assert called_url.endswith("/openai/v1/realtime/client_secrets")

--- a/src/frontend/src/components/ChatWindow.tsx
+++ b/src/frontend/src/components/ChatWindow.tsx
@@ -5,6 +5,9 @@ import { Conversation, ChatMessage, ToolCallInfo, RunStats, Attachment } from "@
 import { streamAgentChat, getConversationMessages, updateConversation } from "@/lib/api";
 import { MessageBubble } from "./MessageBubble";
 import { ThoughtChain } from "./ThoughtChain";
+import { VoiceOrb } from "./VoiceOrb";
+import { useRealtime } from "@/lib/voice";
+import { getVoiceEnabled } from "@/lib/config";
 
 interface UserInputPrompt {
   requestId: string;
@@ -317,6 +320,10 @@ export function ChatWindow({ conversation, onTitleChange, initialMessage, onOpen
         }
         setIsStreaming(false);
         setUserInputPrompt(null);
+        // Speak the final answer (not the raw stream) when voice mode is active.
+        if (voiceRef.current.active && assistantContent.trim()) {
+          voiceRef.current.speak(assistantContent);
+        }
       },
       currentAttachments,
       conversation.useCase
@@ -326,6 +333,19 @@ export function ChatWindow({ conversation, onTitleChange, initialMessage, onOpen
   // Auto-send initial message (e.g. from sample question click)
   const handleSendRef = useRef(handleSend);
   handleSendRef.current = handleSend;
+
+  // Voice mode (opt-in): mic speech → transcript → existing send path; final
+  // assistant reply spoken back. Loosely coupled — invisible unless flagged on.
+  // Reactive so the button appears once runtime config.json resolves the flag.
+  const [voiceEnabled, setVoiceEnabled] = useState(getVoiceEnabled());
+  useEffect(() => {
+    const update = () => setVoiceEnabled(getVoiceEnabled());
+    window.addEventListener("kratos:config-loaded", update);
+    return () => window.removeEventListener("kratos:config-loaded", update);
+  }, []);
+  const voice = useRealtime({ onTranscript: (text) => handleSendRef.current(text) });
+  const voiceRef = useRef(voice);
+  voiceRef.current = voice;
   const initialMessageSentRef = useRef<string | null>(null);
   useEffect(() => {
     if (initialMessage && initialMessageSentRef.current !== `${conversation.id}:${initialMessage}` && messages.length === 0) {
@@ -588,6 +608,23 @@ export function ChatWindow({ conversation, onTitleChange, initialMessage, onOpen
                 <path strokeLinecap="round" strokeLinejoin="round" d="M18.375 12.739l-7.693 7.693a4.5 4.5 0 01-6.364-6.364l10.94-10.94A3 3 0 1119.5 7.372L8.552 18.32m.009-.01l-.01.01m5.699-9.941l-7.81 7.81a1.5 1.5 0 002.112 2.13" />
               </svg>
             </button>
+            {voiceEnabled && (
+              <button
+                onClick={() => (voice.active ? voice.stop() : voice.start())}
+                title={voice.active ? "Stop voice mode" : "Start voice mode"}
+                aria-label={voice.active ? "Stop voice mode" : "Start voice mode"}
+                aria-pressed={voice.active}
+                className={`p-2 rounded-lg hover:bg-hover transition-all duration-200 active:scale-95 ${voice.active ? "text-accent" : "text-muted hover:text-accent"}`}
+              >
+                {voice.active ? (
+                  <VoiceOrb status={voice.status} />
+                ) : (
+                  <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z" />
+                  </svg>
+                )}
+              </button>
+            )}
             <textarea
               value={input}
               onChange={(e) => setInput(e.target.value)}

--- a/src/frontend/src/components/VoiceOrb.tsx
+++ b/src/frontend/src/components/VoiceOrb.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { VoiceStatus } from "@/lib/voice";
+
+/**
+ * Small self-contained orb that reflects voice mode state:
+ * idle (dim), connecting (pulse), listening (accent ring), speaking (ripple).
+ * No external deps — pure CSS so it can be removed by hiding one button.
+ */
+export function VoiceOrb({ status }: { status: VoiceStatus }) {
+  const speaking = status === "speaking";
+  const listening = status === "listening";
+  const connecting = status === "connecting";
+
+  return (
+    <span className="relative inline-flex items-center justify-center w-6 h-6" aria-hidden>
+      {(listening || speaking) && (
+        <span
+          className={`absolute inset-0 rounded-full ${speaking ? "bg-accent/40" : "bg-accent/25"} animate-ping`}
+        />
+      )}
+      <span
+        className={`relative rounded-full transition-all duration-300 ${
+          connecting
+            ? "w-3 h-3 bg-accent animate-pulse"
+            : listening
+            ? "w-3.5 h-3.5 bg-accent shadow-[0_0_10px_var(--accent)]"
+            : speaking
+            ? "w-4 h-4 bg-accent shadow-[0_0_14px_var(--accent)]"
+            : "w-2.5 h-2.5 bg-muted"
+        }`}
+      />
+    </span>
+  );
+}

--- a/src/frontend/src/lib/config.ts
+++ b/src/frontend/src/lib/config.ts
@@ -49,6 +49,21 @@ export function getApiUrl(): string {
 }
 
 /**
+ * Whether voice mode is enabled. Reads NEXT_PUBLIC_VOICE_ENABLED at build time
+ * or `voiceEnabled` from runtime config.json. Off by default (opt-in).
+ */
+export function getVoiceEnabled(): boolean {
+  if (process.env.NEXT_PUBLIC_VOICE_ENABLED === "true") return true;
+  if (typeof window !== "undefined") {
+    const cfg = (window as unknown as Record<string, unknown>).__KRATOS_CONFIG__ as
+      | Record<string, unknown>
+      | undefined;
+    if (cfg?.voiceEnabled === true) return true;
+  }
+  return false;
+}
+
+/**
  * MSAL / OBO sign-in config for the agent.
  *
  * The signed-in user's token (scoped to the Entra-protected OBO MCP server) is

--- a/src/frontend/src/lib/voice.ts
+++ b/src/frontend/src/lib/voice.ts
@@ -1,0 +1,147 @@
+/**
+ * Realtime voice hook — STT + TTS over WebRTC against Azure GPT Realtime.
+ *
+ * The agent stays the brain: we only transcribe the user's speech (→ onTranscript,
+ * which feeds the normal chat send path) and speak final assistant replies.
+ * turn_detection has create_response:false server-side so Realtime never answers.
+ *
+ * Token + endpoint come from /api/voice/session — the long-lived key never
+ * reaches the browser. Loosely coupled: hide the button and it's gone.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getApiUrl } from "@/lib/config";
+
+export type VoiceStatus = "idle" | "connecting" | "listening" | "speaking" | "error";
+
+interface VoiceSession {
+  token: string;
+  endpoint: string;
+  deployment: string;
+  voice: string;
+}
+
+interface UseRealtimeOpts {
+  onTranscript: (text: string) => void;
+}
+
+export function useRealtime({ onTranscript }: UseRealtimeOpts) {
+  const [status, setStatus] = useState<VoiceStatus>("idle");
+  const [active, setActive] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const pcRef = useRef<RTCPeerConnection | null>(null);
+  const dcRef = useRef<RTCDataChannel | null>(null);
+  const micRef = useRef<MediaStream | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const transcriptRef = useRef(onTranscript);
+  transcriptRef.current = onTranscript;
+
+  const stop = useCallback(() => {
+    dcRef.current?.close();
+    pcRef.current?.close();
+    micRef.current?.getTracks().forEach((t) => t.stop());
+    if (audioRef.current) {
+      audioRef.current.srcObject = null;
+      audioRef.current.remove();
+    }
+    dcRef.current = null;
+    pcRef.current = null;
+    micRef.current = null;
+    audioRef.current = null;
+    setActive(false);
+    setStatus("idle");
+  }, []);
+
+  const start = useCallback(async () => {
+    try {
+      setError(null);
+      setStatus("connecting");
+      const res = await fetch(`${getApiUrl()}/api/voice/session`);
+      if (!res.ok) throw new Error(`voice session ${res.status}`);
+      const s: VoiceSession = await res.json();
+
+      const pc = new RTCPeerConnection();
+      pcRef.current = pc;
+
+      const audio = document.createElement("audio");
+      audio.autoplay = true;
+      document.body.appendChild(audio);
+      audioRef.current = audio;
+      pc.ontrack = (e) => {
+        if (e.streams[0]) audio.srcObject = e.streams[0];
+      };
+
+      const mic = await navigator.mediaDevices.getUserMedia({ audio: true });
+      micRef.current = mic;
+      pc.addTrack(mic.getAudioTracks()[0]);
+
+      const dc = pc.createDataChannel("realtime-channel");
+      dcRef.current = dc;
+      dc.addEventListener("message", (ev) => {
+        let evt: { type?: string; transcript?: string };
+        try {
+          evt = JSON.parse(ev.data);
+        } catch {
+          return;
+        }
+        switch (evt.type) {
+          case "input_audio_buffer.speech_started":
+            // Barge-in: stop assistant TTS the moment the user starts talking.
+            try {
+              dc.send(JSON.stringify({ type: "response.cancel" }));
+            } catch {
+              /* ignore */
+            }
+            setStatus("listening");
+            break;
+          case "conversation.item.input_audio_transcription.completed":
+            if (evt.transcript?.trim()) transcriptRef.current(evt.transcript.trim());
+            break;
+          case "response.output_audio_transcript.delta":
+            setStatus("speaking");
+            break;
+          case "response.output_audio_transcript.done":
+            setStatus("listening");
+            break;
+        }
+      });
+
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+      const sdpRes = await fetch(
+        `${s.endpoint}/openai/v1/realtime/calls?model=${encodeURIComponent(s.deployment)}&webrtcfilter=on`,
+        {
+          method: "POST",
+          body: offer.sdp,
+          headers: { Authorization: `Bearer ${s.token}`, "Content-Type": "application/sdp" },
+        }
+      );
+      if (!sdpRes.ok) throw new Error(`sdp ${sdpRes.status}`);
+      await pc.setRemoteDescription({ type: "answer", sdp: await sdpRes.text() });
+
+      setActive(true);
+      setStatus("listening");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setStatus("error");
+      stop();
+    }
+  }, [stop]);
+
+  // Speak the assistant's final answer (not the raw stream) for smooth TTS.
+  const speak = useCallback((text: string) => {
+    const dc = dcRef.current;
+    if (!dc || dc.readyState !== "open" || !text.trim()) return;
+    dc.send(
+      JSON.stringify({
+        type: "response.create",
+        response: { instructions: `Read this reply aloud verbatim: ${text}` },
+      })
+    );
+    setStatus("speaking");
+  }, []);
+
+  useEffect(() => stop, [stop]);
+
+  return { status, active, error, start, stop, speak };
+}


### PR DESCRIPTION
## Generic voice mode for Kratos chat (opt-in)

Adds a mic button + orb to the existing chat. Click → speak → your speech becomes text in the chat and goes through the **existing** `POST /api/agent/chat`; the agent's final reply is spoken back. Real-time STT + TTS via Azure **GPT Realtime** over WebRTC. The agent stays the brain — Realtime does speech only.

**Opt-in**: invisible unless `VOICE_ENABLED=true`. No change to the agent loop, skills, or the chat send path.

### How it bolts on
```
Mic ⇄ GPT Realtime (browser, WebRTC) → transcript → setInput → handleSend → /api/agent/chat (existing)
                                          ↑ assistant final spoken via Realtime TTS ←
```
- **Token**: backend mints a short-lived ephemeral session token with Managed Identity; the long-lived key never reaches the browser.
- **Loose coupling**: hide one button and it's gone.

### Changes
- **Backend** — new `GET /api/voice/session` router (`routers/voice.py`) returning `{token, endpoint, deployment, voice}`; gated behind `VOICE_ENABLED`; session config baked at creation (STT + server VAD with `create_response:false`, TTS voice). Surfaced via `/api/settings`. Chat path untouched.
- **Frontend** — `lib/voice.ts` `useRealtime()` hook (token → WebRTC → `onTranscript` / `speak`, barge-in), `components/VoiceOrb.tsx`, and a flag-gated mic button in `ChatWindow.tsx`. Final answer is spoken (not the raw stream) for smooth TTS.
- **Infra** — opt-in `gpt-realtime` deployment added to `infra/modules/ai-services.bicep` (`deployRealtime`), `VOICE_ENABLED`/`VOICE_DEPLOYMENT` threaded to the backend Container App, and the SWA predeploy hook surfaces `voiceEnabled` into `config.json`. Rides the existing `azd up`; **hosted-agent untouched**. Net Azure add: 1 model deployment + 1 flagged endpoint.

### Tests / verification
- `pytest tests/test_voice.py` — disabled → 404; enabled → mints token, posts to `/openai/v1/realtime/client_secrets`. Backend ruff + frontend tsc/eslint clean; bicep compiles.
- **Real end-to-end against Azure GPT Realtime** (headless Chromium, fake-mic WAV, agent reply stubbed):
  - `/api/voice/session` → 200, WebRTC `calls` → 201
  - Event trace: `speech_started → speech_stopped → input_audio_transcription.completed → response.output_audio_transcript.done → output_audio_buffer.stopped` (**STT_OK + TTS_OK**)
  - Spoken question transcribed into the chat and the assistant reply spoken back. Mic button/orb render in the composer.

### Open questions (defaults chosen)
- Ephemeral token via **proxy through Kratos** (Managed Identity) — recommended for auth. ✅
- Server-VAD auto-turn; assistant replies spoken only while voice mode is active. ✅
