### PR TITLE
Add FOUNDRY_PROJECT_ENDPOINT output to main Bicep file

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -324,6 +324,11 @@ output AGENT_SERVICE_URL string = agentService.outputs.url
 output FOUNDRY_ENDPOINT string = aiFoundry.outputs.endpoint
 output FOUNDRY_MODEL_DEPLOYMENT string = aiFoundry.outputs.modelDeploymentName
 output AZURE_AI_PROJECT_ENDPOINT string = aiFoundry.outputs.projectEndpoint
+// Extension contract drift (per foundry-hosted-agents skill): azure.ai.agents
+// extension v0.1.31+ reads FOUNDRY_PROJECT_ENDPOINT, older versions read
+// AZURE_AI_PROJECT_ENDPOINT. Emit both with the same value until the
+// extension settles on one name.
+output FOUNDRY_PROJECT_ENDPOINT string = aiFoundry.outputs.projectEndpoint
 // Full ARM resource ID of the Foundry project. Surfacing it as an azd output
 // writes AZURE_AI_PROJECT_ID into the environment during `azd provision`, so the
 // `azure.ai.agent` extension can deploy the hosted agent without a manual


### PR DESCRIPTION
This pull request updates the Bicep infrastructure output variables to ensure compatibility with different versions of the `azure.ai.agents` extension. Specifically, it adds a new output variable to address naming drift between extension versions.

Solves issue #38 

**Infrastructure compatibility:**

* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R327-R331): Added a new output variable `FOUNDRY_PROJECT_ENDPOINT` that emits the same value as `AZURE_AI_PROJECT_ENDPOINT` to support both newer and older versions of the `azure.ai.agents` extension, which expect different variable names. This helps prevent deployment issues as the extension migrates to the new naming convention.