### PR TITLE
Add post-azd setup verification

### DIFF
--- a/.copilot/skills/e2e-smoke/tests/03-chat.spec.ts
+++ b/.copilot/skills/e2e-smoke/tests/03-chat.spec.ts
@@ -1,5 +1,7 @@
-import { test, expect } from "@playwright/test";
-import { chatOnce, CHAT_TIMEOUT_MS } from "./helpers";
+import { test, expect, request } from "@playwright/test";
+import { BACKEND_URL, chatOnce, CHAT_TIMEOUT_MS, stringValue } from "./helpers";
+
+const INTERNAL_TOOLS = new Set(["ask-user", "report-intent", "skill", "sql"]);
 
 test.describe("chat round-trip", () => {
   test.setTimeout(CHAT_TIMEOUT_MS * 2 + 30_000);
@@ -22,4 +24,67 @@ test.describe("chat round-trip", () => {
       "assistant response should be non-empty",
     ).toBeGreaterThan(0);
   });
+
+  test("agent emits a skill tool_call for a scenario that expects a tool", async () => {
+    const api = await request.newContext();
+    const scenariosResp = await api.get(`${BACKEND_URL}/api/use-cases/generic/evals/scenarios`);
+    expect(scenariosResp.status(), "generic scenarios status").toBe(200);
+    const scenariosBody = await scenariosResp.json();
+    const scenarios: Record<string, unknown>[] = scenariosBody.scenarios ?? [];
+    const scenario = scenarios.find((candidate) => stringValue(candidate.name) === "code-interpreter-math");
+
+    expect(
+      scenario,
+      "generic should include the code-interpreter-math scenario",
+    ).toBeTruthy();
+
+    const expectedTools = (scenario!.expected_tool_calls as unknown[])
+      .map((tool) => stringValue(tool))
+      .map(normalizeToolName)
+      .filter(Boolean);
+    const prompt = stringValue(scenario!.input_message);
+    expect(prompt, "scenario input_message").toBeTruthy();
+    console.log(
+      `skill scenario=${stringValue(scenario!.name)} expected=${expectedTools.join(",")}`,
+    );
+
+    const { events, ok, status, text } = await chatOnce(prompt, "generic");
+    const eventNames = events.map((event) => event.event);
+    const toolNames = events
+      .filter((event) => event.event === "tool_call")
+      .map((event) =>
+        stringValue(event.data.skillName) ||
+        stringValue(event.data.skill_name) ||
+        stringValue(event.data.name) ||
+        stringValue(event.data.tool_name) ||
+        stringValue(event.data.tool),
+      )
+      .filter(Boolean);
+    const normalizedToolNames = [...new Set(toolNames.map(normalizeToolName))];
+    const userFacingToolNames = normalizedToolNames.filter((tool) => !INTERNAL_TOOLS.has(tool));
+
+    console.log(`observed events=${eventNames.join(",") || "(none)"}`);
+    console.log(`observed tools=${toolNames.join(",") || "(none)"}`);
+    console.log(`observed user-facing tools=${userFacingToolNames.join(",") || "(none)"}`);
+
+    const errorEvents = events.filter((event) => event.event === "error");
+    expect(
+      errorEvents.map((event) => stringValue(event.data.code) || stringValue(event.data.message)),
+      `chat should not emit error events (status=${status}, text snippet="${text.slice(0, 200)}")`,
+    ).toEqual([]);
+    expect(ok, `chat should complete successfully (status=${status})`).toBe(true);
+    expect(userFacingToolNames.length, "should observe at least one user-facing tool_call event").toBeGreaterThan(0);
+    expect(
+      userFacingToolNames.some((tool) => expectedTools.includes(tool)),
+      `expected one of ${expectedTools.join(",")} in observed tools ${userFacingToolNames.join(",")}`,
+    ).toBe(true);
+  });
 });
+
+function normalizeToolName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/^mcp-tools-/, "")
+    .replace(/_/g, "-")
+    .replace(/^mcp-tools-/, "");
+}

--- a/.copilot/skills/e2e-smoke/tests/helpers.ts
+++ b/.copilot/skills/e2e-smoke/tests/helpers.ts
@@ -29,6 +29,11 @@ export const USE_CASES = (process.env.KRATOS_USE_CASES || "generic")
 export const CHAT_TIMEOUT_MS = Number(process.env.CHAT_TIMEOUT_MS || 60_000);
 export const TRACES_LOOKBACK_HOURS = Number(process.env.TRACES_LOOKBACK_HOURS || 6);
 
+export type ChatEvent = {
+  event: string;
+  data: Record<string, unknown>;
+};
+
 /**
  * Stream-aware POST to /api/agent/chat that aggregates the SSE response into
  * a single concatenated text. The backend yields lines like:
@@ -40,7 +45,7 @@ export async function chatOnce(
   prompt: string,
   useCase: string,
   timeoutMs = CHAT_TIMEOUT_MS,
-): Promise<{ text: string; ok: boolean; status: number }> {
+): Promise<{ text: string; ok: boolean; status: number; events: ChatEvent[] }> {
   const conversationId = `e2e-smoke-${Date.now()}`;
   const ac = new AbortController();
   const to = setTimeout(() => ac.abort(), timeoutMs);
@@ -62,45 +67,93 @@ export async function chatOnce(
 
     if (!resp.ok || !resp.body) {
       const body = resp.body ? await resp.text() : "";
-      return { text: body, ok: false, status: resp.status };
+      return { text: body, ok: false, status: resp.status, events: [] };
     }
 
-    const reader = resp.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
+    const events = await readSseEvents(resp.body);
     let collected = "";
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed.startsWith("data:")) continue;
-        const payload = trimmed.slice(5).trim();
-        if (!payload || payload === "[DONE]") continue;
-        try {
-          const evt = JSON.parse(payload);
-          const ev = evt.event ?? evt.type;
-          if (ev === "content") {
-            collected += evt.data?.content ?? evt.content ?? "";
-          } else if (ev === "done") {
-            return { text: collected, ok: true, status: resp.status };
-          } else if (ev === "error") {
-            return {
-              text: collected + `\n[error: ${evt.data?.message ?? evt.message ?? "unknown"}]`,
-              ok: false,
-              status: resp.status,
-            };
-          }
-        } catch {
-          /* ignore non-JSON keepalive lines */
-        }
+    for (const evt of events) {
+      if (evt.event === "content") {
+        collected += stringValue(evt.data.content);
+      } else if (evt.event === "done") {
+        return { text: collected, ok: true, status: resp.status, events };
+      } else if (evt.event === "error") {
+        return {
+          text: collected + `\n[error: ${stringValue(evt.data.message) || "unknown"}]`,
+          ok: false,
+          status: resp.status,
+          events,
+        };
       }
     }
-    return { text: collected, ok: collected.length > 0, status: resp.status };
+    return { text: collected, ok: collected.length > 0, status: resp.status, events };
   } finally {
     clearTimeout(to);
   }
+}
+
+export async function readSseEvents(
+  body: ReadableStream<Uint8Array>,
+): Promise<ChatEvent[]> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const events: ChatEvent[] = [];
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    buffer = buffer.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+    const blocks = buffer.split("\n\n");
+    buffer = blocks.pop() ?? "";
+    for (const block of blocks) {
+      const evt = parseSseBlock(block);
+      if (evt) events.push(evt);
+    }
+  }
+
+  buffer += decoder.decode();
+  buffer = buffer.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const trailing = parseSseBlock(buffer);
+  if (trailing) events.push(trailing);
+  return events;
+}
+
+function parseSseBlock(block: string): ChatEvent | null {
+  let eventName = "";
+  const dataLines: string[] = [];
+
+  for (const line of block.split("\n")) {
+    if (line.startsWith("event:")) {
+      eventName = line.slice("event:".length).trim();
+    } else if (line.startsWith("data:")) {
+      const value = line.slice("data:".length).trim();
+      if (value && value !== "[DONE]") dataLines.push(value);
+    }
+  }
+
+  if (dataLines.length === 0) return null;
+  const rawData = dataLines.join("\n");
+  try {
+    const parsed = JSON.parse(rawData) as Record<string, unknown>;
+    const nestedData = parsed.data;
+    if (!eventName) {
+      eventName = stringValue(parsed.event) || stringValue(parsed.type);
+    }
+    return {
+      event: eventName || "message",
+      data: isRecord(nestedData) ? nestedData : parsed,
+    };
+  } catch {
+    return { event: eventName || "message", data: { content: rawData } };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,10 @@ on:
         description: "Upload use-case skills to blob storage (needs network access to the storage account)"
         type: boolean
         default: false
+      deploy_health_model:
+        description: "Deploy Azure Monitor health model infrastructure (DEPLOY_HEALTH_MODEL)"
+        type: boolean
+        default: true
       run_integration_tests:
         description: "Run integration tests after deploying"
         type: boolean
@@ -113,6 +117,7 @@ jobs:
           AZURE_ENV_NAME: ${{ inputs.environment }}
           AZURE_LOCATION: ${{ vars.AZURE_LOCATION || 'eastus2' }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          DEPLOY_HEALTH_MODEL: ${{ inputs.deploy_health_model && 'true' || 'false' }}
         run: azd provision --no-prompt
 
       - name: Refresh environment outputs
@@ -144,6 +149,7 @@ jobs:
             echo "| Result | ${{ job.status }} |"
             echo "| Commit | \`${{ github.sha }}\` |"
             echo "| Provisioned | ${{ inputs.provision }} |"
+            echo "| Health model deployed | ${{ inputs.provision && inputs.deploy_health_model }} |"
             echo "| Skills uploaded | ${{ inputs.upload_use_cases }} |"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ SKIP_BROWSER=1 ./run.sh  # API-only, skips the Chromium download
 `run.sh` reads `AZURE_STATIC_WEB_APP_URL` and `AGENT_SERVICE_URL` from `azd env get-values`, so it always follows whichever environment is currently selected. Override with `KRATOS_FRONTEND_URL` / `KRATOS_BACKEND_URL` to point it elsewhere. It fails fast rather than falling back to a stale default.
 
 See [`.copilot/skills/e2e-smoke/SKILL.md`](./.copilot/skills/e2e-smoke/SKILL.md) for the spec catalogue, env-var reference, and tips for running just the API or just the UX project.
+See [`docs/runbooks/post-azd-setup-manual.md`](./docs/runbooks/post-azd-setup-manual.md) for the full post-`azd up` setup and verification checklist.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,34 @@ Per-environment settings are set with `azd env set` while that environment is ac
 `azd env set DEPLOY_OBO false` to skip the on-behalf-of stack in an experiment. Values set this way
 land in that environment's `.env` only, never in another's.
 
+#### Azure Monitor health model
+
+`infra/` can deploy an Azure Monitor health model (`Microsoft.CloudHealth/healthmodels`, preview) that
+models health as advisor (one entity per use case) → tool → downstream-service → Azure resource.
+
+The model is enabled by default (`DEPLOY_HEALTH_MODEL=true`). Set it to `false` to skip creating it:
+
+```bash
+azd env set DEPLOY_HEALTH_MODEL false
+```
+
+Prerequisites (one-time):
+
+```bash
+az provider register -n Microsoft.CloudHealth
+az extension add -n health-models
+```
+
+Region notes:
+
+- This is a preview resource and region-limited.
+- `healthModelLocation` defaults to `centralus`.
+- Supported regions are the ones returned by `az provider show -n Microsoft.CloudHealth`.
+- `eastus2` is not supported.
+- The health model can live in a different region than the monitored resources.
+
+`azd` and ARM deployments are incremental. On a fresh deployment with `DEPLOY_HEALTH_MODEL=false`, no health model is created. If a health model already exists, turning the flag off later does not delete it, and removing entities from topology input does not delete already-deployed entities. Delete the health model resource explicitly (or redeploy fresh) to reconcile.
+
 ### Register the Agent in Foundry (One-Time Manual Step)
 
 After `azd up`, register the agent in the Foundry portal so traces appear in the Operate tab:

--- a/docs/runbooks/post-azd-setup-manual.md
+++ b/docs/runbooks/post-azd-setup-manual.md
@@ -1,0 +1,148 @@
+# Post-azd setup and verification
+
+Use this after `azd up` to finish the manual setup and prove the deployed app is working. Do not paste deployment endpoints, subscription IDs, tenant IDs, resource group names, connection strings, tokens, screenshots, traces, or Playwright artifacts into git.
+
+## 1. Confirm the selected environment
+
+```bash
+azd env get-value AZURE_ENV_NAME
+azd env get-values | grep -E '^(AZURE_STATIC_WEB_APP_URL|AGENT_SERVICE_URL|AZURE_AI_PROJECT_ID)='
+git check-ignore -v .azure .env.local .copilot/skills/e2e-smoke/playwright-report .copilot/skills/e2e-smoke/test-results
+```
+
+`AZURE_STATIC_WEB_APP_URL` is the frontend. `AGENT_SERVICE_URL` is the backend Container App. The e2e runner reads both from the active `azd` environment unless `KRATOS_FRONTEND_URL` or `KRATOS_BACKEND_URL` is explicitly exported.
+
+## 2. Register the custom agent in Foundry
+
+1. Open Microsoft Foundry.
+2. Select the deployed project.
+3. Go to **Operate** > **Agents**.
+4. Choose **+ Register agent** and **Custom Agent**.
+5. Set the name to `kratos-agent`.
+6. Set the endpoint to the value of `AGENT_SERVICE_URL`.
+7. Set the API path to `kratos-agent`.
+
+This registration makes the custom agent visible in the Foundry Operate experience. Application Insights ingestion is configured by infrastructure separately.
+
+## 3. Confirm deployed API surfaces
+
+```bash
+BACKEND="$(azd env get-value AGENT_SERVICE_URL)"
+
+curl -fsS "$BACKEND/health" | jq '{status}'
+curl -fsS "$BACKEND/api/use-cases" | jq '{total:(.useCases|length), curated:[.useCases[]|select(.curated==true)|.name]}'
+curl -fsS "$BACKEND/api/admin/skills?use_case=generic" | jq '{count:(.skills|length), sample:[.skills[:5][]|{name,enabled,source}]}'
+```
+
+The curated personas are the frontend picker target. Non-curated personas may still exist in the API.
+
+## 4. Seed an eval run before the smoke suite
+
+The smoke suite expects at least one eval run across curated personas. A fresh environment can have zero.
+
+```bash
+BACKEND="$(azd env get-value AGENT_SERVICE_URL)"
+
+for uc in generic insurance retail-banking wealth-management; do
+  curl -fsS "$BACKEND/api/use-cases/$uc/evals/runs" | jq --arg uc "$uc" '{useCase:$uc,count:(.runs|length)}'
+done
+
+cd src/backend
+BACKEND_URL="$BACKEND" uv run python ../../scripts/run_evals.py --use-case generic --mode validation
+```
+
+Then recheck:
+
+```bash
+curl -fsS "$BACKEND/api/use-cases/generic/evals/runs" | jq '.runs[0] | {run_id,status,mode}'
+```
+
+The run detail endpoint must return a `run_id`. If the run status is `failed`, the eval prerequisite is present but agent health is not proven.
+
+## 5. Verify chat and skill execution
+
+Run a normal chat first:
+
+```bash
+BACKEND="$(azd env get-value AGENT_SERVICE_URL)"
+
+curl -N -sS "$BACKEND/api/agent/chat" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream' \
+  -d '{"message":"Reply with one short sentence confirming you are online.","useCase":"generic","conversationId":"manual-chat-check"}'
+```
+
+Then use a scenario that expects a tool:
+
+```bash
+curl -fsS "$BACKEND/api/use-cases/generic/evals/scenarios" \
+  | jq -r '.scenarios[] | select((.expected_tool_calls // []) | length > 0) | [.name, .input_message, (.expected_tool_calls|join(","))] | @tsv' \
+  | head -1
+```
+
+Send that `input_message` through `/api/agent/chat`. The stream must contain at least one `event: tool_call` frame and no terminating `event: error` frame. A skill catalogue response alone proves registration, not execution.
+
+## 6. Verify telemetry in Application Insights
+
+Generate a chat or eval operation first. Then query the app traces API:
+
+```bash
+BACKEND="$(azd env get-value AGENT_SERVICE_URL)"
+
+curl -fsS "$BACKEND/api/traces/operations?hours=1&limit=5" \
+  | jq '{error:(.summary.error // ""), operations:(.operations|length), first:(.operations[0] // null)}'
+```
+
+Pass requires:
+
+- `summary.error` is empty.
+- `operations` is greater than 0.
+- A detail query for one operation has a non-empty `spans` array.
+
+A skipped `05-traces.spec.ts` is not proof. It only means there were zero operations in the lookback window.
+
+Use a direct Application Insights query as the independent proof:
+
+```bash
+RG="$(azd env get-value AZURE_RESOURCE_GROUP)"
+APP_ID="$(az resource list -g "$RG" --resource-type microsoft.insights/components --query '[0].id' -o tsv)"
+
+az monitor app-insights query --ids "$APP_ID" \
+  --analytics-query "union dependencies, requests, traces | where timestamp > ago(1h) | summarize rows=count(), operations=dcount(operation_Id), roles=dcount(cloud_RoleName)" \
+  -o json
+```
+
+For a specific conversation, filter on `customDimensions['kratos.conversation_id']`.
+
+## 7. Run the included Playwright smoke tests
+
+```bash
+cd .copilot/skills/e2e-smoke
+SKIP_BROWSER=1 ./run.sh
+./run.sh
+jq '{unexpected:.stats.unexpected, skipped:.stats.skipped}' test-results/results.json
+```
+
+API-only mode skips browser specs. The full run should pass without failures. Treat a traces skip as inconclusive for telemetry unless the direct checks above already passed.
+
+## 8. Copilot token, local mode only
+
+Cloud deployment uses Azure Managed Identity and Foundry. It should not need a Copilot token.
+
+For local mode:
+
+1. Create a GitHub token with Copilot access from your GitHub account settings.
+2. Copy `.env.local.example` to `.env.local`.
+3. Set `COPILOT_GITHUB_TOKEN` in `.env.local`.
+4. Keep `.env.local` uncommitted.
+
+## 9. Recovery paths
+
+| Symptom | Action |
+|---------|--------|
+| Hosted-agent identity not found or roles missing | Re-run `azd deploy kratos-agent` or `azd up`, then run `./hooks/assign-agent-roles.sh` from the repo root. |
+| OBO admin consent skipped | Ask an Entra admin to run `az ad app permission admin-consent --id <server-app-client-id>` or grant consent in the app registration portal. |
+| Skills upload skipped because blob storage is private | This does not block the baked-in use cases. To upload edited skills without redeploying, run `./hooks/postdeploy.sh` from a host inside the VNet or from the running backend container. |
+| Foundry custom agent missing in Operate | Register the custom agent again with name `kratos-agent`, endpoint from `AGENT_SERVICE_URL`, and API path `kratos-agent`. |
+| Backend chat SSE returns provider HTTP 401 | Verify the backend Container App system-assigned identity has `Cognitive Services OpenAI User` and `Cognitive Services User` on the AI Services account, then wait for data-plane propagation. Do not set `AZURE_CLIENT_ID` on `agent-service`; its user-assigned identity is for ACR pull only. |
+| Hosted-agent chat SSE returns provider HTTP 401 | Re-run `./hooks/assign-agent-roles.sh`, wait for data-plane propagation, then redeploy `kratos-agent` if needed. Capture the SSE `error.code` and backend logs before changing unrelated settings. |

--- a/infra/abbreviations.json
+++ b/infra/abbreviations.json
@@ -12,6 +12,7 @@
   "searchSearchServices": "srch-",
   "cognitiveServicesAccounts": "oai-",
   "bingSearchAccounts": "bing-",
+  "cloudHealthHealthModels": "hm-",
   "webStaticSites": "stapp-",
   "storageAccounts": "st"
 }

--- a/infra/health-model/signals.json
+++ b/infra/health-model/signals.json
@@ -1,0 +1,438 @@
+{
+  "Microsoft.CognitiveServices/accounts": [
+    {
+      "name": "success-rate",
+      "metricName": "SuccessRate",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Percent",
+      "degradedRule": {
+        "operator": "LessThan",
+        "threshold": 99
+      },
+      "unhealthyRule": {
+        "operator": "LessThan",
+        "threshold": 95
+      }
+    },
+    {
+      "name": "time-to-response",
+      "metricName": "TimeToResponse",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "MilliSeconds",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 2000
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 5000
+      }
+    },
+    {
+      "name": "total-errors",
+      "metricName": "TotalErrors",
+      "aggregationType": "Total",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Count",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 2
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 10
+      }
+    }
+  ],
+  "Microsoft.DocumentDB/databaseAccounts": [
+    {
+      "name": "service-availability",
+      "metricName": "ServiceAvailability",
+      "aggregationType": "Minimum",
+      "timeGrain": "PT1H",
+      "refreshInterval": "PT1H",
+      "dataUnit": "Percent",
+      "degradedRule": {
+        "operator": "LessThan",
+        "threshold": 99
+      },
+      "unhealthyRule": {
+        "operator": "LessThan",
+        "threshold": 95
+      }
+    },
+    {
+      "name": "server-side-latency",
+      "metricName": "ServerSideLatency",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "MilliSeconds",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 100
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 500
+      }
+    },
+    {
+      "name": "normalized-ru-consumption",
+      "metricName": "NormalizedRUConsumption",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Percent",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 70
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 90
+      }
+    }
+  ],
+  "Microsoft.App/containerApps": [
+    {
+      "name": "response-time",
+      "metricName": "ResponseTime",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "MilliSeconds",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 1000
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 3000
+      }
+    },
+    {
+      "name": "restart-count",
+      "metricName": "RestartCount",
+      "aggregationType": "Total",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Count",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 2
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 5
+      }
+    },
+    {
+      "name": "cpu-percentage",
+      "metricName": "CpuPercentage",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Percent",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 80
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 95
+      }
+    }
+  ],
+  "Microsoft.ContainerRegistry/registries": [
+    {
+      "name": "total-pull-count",
+      "metricName": "TotalPullCount",
+      "aggregationType": "Total",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Count",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 100
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 500
+      }
+    },
+    {
+      "name": "storage-used",
+      "metricName": "StorageUsed",
+      "aggregationType": "Average",
+      "timeGrain": "PT1H",
+      "refreshInterval": "PT1H",
+      "dataUnit": "Bytes",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 8000000000
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 9500000000
+      }
+    }
+  ],
+  "Microsoft.Storage/storageAccounts": [
+    {
+      "name": "storage-availability",
+      "metricName": "Availability",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Percent",
+      "degradedRule": {
+        "operator": "LessThan",
+        "threshold": 99
+      },
+      "unhealthyRule": {
+        "operator": "LessThan",
+        "threshold": 95
+      }
+    },
+    {
+      "name": "success-e2e-latency",
+      "metricName": "SuccessE2ELatency",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "MilliSeconds",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 1000
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 3000
+      }
+    }
+  ],
+  "Microsoft.KeyVault/vaults": [
+    {
+      "name": "keyvault-availability",
+      "metricName": "Availability",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Percent",
+      "degradedRule": {
+        "operator": "LessThan",
+        "threshold": 99
+      },
+      "unhealthyRule": {
+        "operator": "LessThan",
+        "threshold": 95
+      }
+    },
+    {
+      "name": "service-api-latency",
+      "metricName": "ServiceApiLatency",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "MilliSeconds",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 500
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 2000
+      }
+    }
+  ],
+  "Microsoft.Insights/components": [
+    {
+      "name": "server-exceptions",
+      "metricName": "exceptions/server",
+      "aggregationType": "Count",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Count",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 2
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 10
+      }
+    },
+    {
+      "name": "requests-duration",
+      "metricName": "requests/duration",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "MilliSeconds",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 1000
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 3000
+      }
+    },
+    {
+      "name": "requests-failed",
+      "metricName": "requests/failed",
+      "aggregationType": "Count",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Count",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 2
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 25
+      }
+    }
+  ],
+  "Microsoft.OperationalInsights/workspaces": [
+    {
+      "name": "query-availability-rate",
+      "metricName": "AvailabilityRate_Query",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Percent",
+      "degradedRule": {
+        "operator": "LessThan",
+        "threshold": 99
+      },
+      "unhealthyRule": {
+        "operator": "LessThan",
+        "threshold": 95
+      }
+    },
+    {
+      "name": "query-failure-count",
+      "metricName": "Query Failure Count",
+      "aggregationType": "Count",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Count",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 2
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 10
+      }
+    },
+    {
+      "name": "ingestion-time",
+      "metricName": "Ingestion Time",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Seconds",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 180
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 300
+      }
+    }
+  ],
+  "Microsoft.ApiManagement/service": [
+    {
+      "name": "failed-requests",
+      "metricName": "FailedRequests",
+      "aggregationType": "Total",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Count",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 5
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 100
+      }
+    },
+    {
+      "name": "gateway-duration",
+      "metricName": "Duration",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "MilliSeconds",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 1000
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 3000
+      }
+    },
+    {
+      "name": "gateway-capacity",
+      "metricName": "Capacity",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Percent",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 80
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 95
+      }
+    }
+  ],
+  "Microsoft.Search/searchServices": [
+    {
+      "name": "search-latency",
+      "metricName": "SearchLatency",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Seconds",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 1
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 2
+      }
+    },
+    {
+      "name": "throttled-search-queries-percentage",
+      "metricName": "ThrottledSearchQueriesPercentage",
+      "aggregationType": "Average",
+      "timeGrain": "PT5M",
+      "refreshInterval": "PT5M",
+      "dataUnit": "Percent",
+      "degradedRule": {
+        "operator": "GreaterThan",
+        "threshold": 5
+      },
+      "unhealthyRule": {
+        "operator": "GreaterThan",
+        "threshold": 15
+      }
+    }
+  ]
+}

--- a/infra/health-model/topology.json
+++ b/infra/health-model/topology.json
@@ -1,0 +1,1127 @@
+{
+  "advisors": [
+    {
+      "key": "clinician-visit-prep",
+      "displayName": "Clinician Visit Prep",
+      "curated": false,
+      "tools": [
+        {
+          "key": "mcp:epic",
+          "displayName": "epic",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "epic-fhir-api",
+              "displayName": "Epic FHIR API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "platform:llm",
+          "displayName": "Platform LLM",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "platform:state",
+          "displayName": "Platform state",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "cosmos",
+              "displayName": "Conversation store",
+              "kind": "AzureResource",
+              "resourceKey": "cosmos"
+            }
+          ]
+        },
+        {
+          "key": "skill:file-sharing",
+          "displayName": "file-sharing",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "storage",
+              "displayName": "File storage",
+              "kind": "AzureResource",
+              "resourceKey": "storage"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "finance-close",
+      "displayName": "Finance Close Controller",
+      "curated": false,
+      "tools": [
+        {
+          "key": "mcp:m365-graph",
+          "displayName": "m365-graph",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "microsoft-graph",
+              "displayName": "Microsoft Graph API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "mcp:sap-s4",
+          "displayName": "sap-s4",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "sap-s4-api",
+              "displayName": "SAP S/4 API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "mcp:workday",
+          "displayName": "workday",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "workday-api",
+              "displayName": "Workday API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "platform:llm",
+          "displayName": "Platform LLM",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "platform:state",
+          "displayName": "Platform state",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "cosmos",
+              "displayName": "Conversation store",
+              "kind": "AzureResource",
+              "resourceKey": "cosmos"
+            }
+          ]
+        },
+        {
+          "key": "skill:file-sharing",
+          "displayName": "file-sharing",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "storage",
+              "displayName": "File storage",
+              "kind": "AzureResource",
+              "resourceKey": "storage"
+            }
+          ]
+        },
+        {
+          "key": "skill:variance-analysis",
+          "displayName": "variance-analysis",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "local-data-compute",
+              "displayName": "Local data/compute",
+              "kind": "External"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "generic",
+      "displayName": "Generic Assistant",
+      "curated": true,
+      "tools": [
+        {
+          "key": "mcp:microsoft-learn",
+          "displayName": "microsoft-learn",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "microsoft-learn-api",
+              "displayName": "Microsoft Learn API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "platform:llm",
+          "displayName": "Platform LLM",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "platform:state",
+          "displayName": "Platform state",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "cosmos",
+              "displayName": "Conversation store",
+              "kind": "AzureResource",
+              "resourceKey": "cosmos"
+            }
+          ]
+        },
+        {
+          "key": "skill:code-interpreter",
+          "displayName": "code-interpreter",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "agent-runtime",
+              "displayName": "Agent runtime",
+              "kind": "AzureResource",
+              "resourceKey": "agentApp"
+            }
+          ]
+        },
+        {
+          "key": "skill:data-analysis",
+          "displayName": "data-analysis",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "skill:document-summary",
+          "displayName": "document-summary",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "skill:docx-editor",
+          "displayName": "docx-editor",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "local-data-compute",
+              "displayName": "Local data/compute",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "skill:email-draft",
+          "displayName": "email-draft",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "skill:file-sharing",
+          "displayName": "file-sharing",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "storage",
+              "displayName": "File storage",
+              "kind": "AzureResource",
+              "resourceKey": "storage"
+            }
+          ]
+        },
+        {
+          "key": "skill:pptx-editor",
+          "displayName": "pptx-editor",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "local-data-compute",
+              "displayName": "Local data/compute",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "skill:rag-search",
+          "displayName": "rag-search",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "search",
+              "displayName": "Knowledge base search",
+              "kind": "AzureResource",
+              "resourceKey": "search"
+            }
+          ]
+        },
+        {
+          "key": "skill:web-search",
+          "displayName": "web-search",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "hr-onboarding",
+      "displayName": "HR Onboarding Specialist",
+      "curated": false,
+      "tools": [
+        {
+          "key": "mcp:m365-graph",
+          "displayName": "m365-graph",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "microsoft-graph",
+              "displayName": "Microsoft Graph API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "mcp:servicenow",
+          "displayName": "servicenow",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "servicenow-api",
+              "displayName": "ServiceNow API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "mcp:workday",
+          "displayName": "workday",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "workday-api",
+              "displayName": "Workday API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "platform:llm",
+          "displayName": "Platform LLM",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "platform:state",
+          "displayName": "Platform state",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "cosmos",
+              "displayName": "Conversation store",
+              "kind": "AzureResource",
+              "resourceKey": "cosmos"
+            }
+          ]
+        },
+        {
+          "key": "skill:file-sharing",
+          "displayName": "file-sharing",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "storage",
+              "displayName": "File storage",
+              "kind": "AzureResource",
+              "resourceKey": "storage"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "insurance",
+      "displayName": "Insurance Service Advisor",
+      "curated": true,
+      "tools": [
+        {
+          "key": "platform:llm",
+          "displayName": "Platform LLM",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "platform:state",
+          "displayName": "Platform state",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "cosmos",
+              "displayName": "Conversation store",
+              "kind": "AzureResource",
+              "resourceKey": "cosmos"
+            }
+          ]
+        },
+        {
+          "key": "skill:claims-mgmt",
+          "displayName": "claims-mgmt",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "local-data-compute",
+              "displayName": "Local data/compute",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "skill:code-interpreter",
+          "displayName": "code-interpreter",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "agent-runtime",
+              "displayName": "Agent runtime",
+              "kind": "AzureResource",
+              "resourceKey": "agentApp"
+            }
+          ]
+        },
+        {
+          "key": "skill:crm",
+          "displayName": "crm",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "local-data-compute",
+              "displayName": "Local data/compute",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "skill:data-analysis",
+          "displayName": "data-analysis",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "skill:document-summary",
+          "displayName": "document-summary",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "skill:email-draft",
+          "displayName": "email-draft",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "skill:file-sharing",
+          "displayName": "file-sharing",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "storage",
+              "displayName": "File storage",
+              "kind": "AzureResource",
+              "resourceKey": "storage"
+            }
+          ]
+        },
+        {
+          "key": "skill:rag-search",
+          "displayName": "rag-search",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "search",
+              "displayName": "Knowledge base search",
+              "kind": "AzureResource",
+              "resourceKey": "search"
+            }
+          ]
+        },
+        {
+          "key": "skill:web-search",
+          "displayName": "web-search",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "it-service-desk",
+      "displayName": "IT Service Desk L1",
+      "curated": false,
+      "tools": [
+        {
+          "key": "mcp:m365-graph",
+          "displayName": "m365-graph",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "microsoft-graph",
+              "displayName": "Microsoft Graph API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "mcp:servicenow",
+          "displayName": "servicenow",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "servicenow-api",
+              "displayName": "ServiceNow API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "mcp:workday",
+          "displayName": "workday",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "workday-api",
+              "displayName": "Workday API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "platform:llm",
+          "displayName": "Platform LLM",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "platform:state",
+          "displayName": "Platform state",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "cosmos",
+              "displayName": "Conversation store",
+              "kind": "AzureResource",
+              "resourceKey": "cosmos"
+            }
+          ]
+        },
+        {
+          "key": "skill:file-sharing",
+          "displayName": "file-sharing",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "storage",
+              "displayName": "File storage",
+              "kind": "AzureResource",
+              "resourceKey": "storage"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "plant-floor-supervisor",
+      "displayName": "Plant Floor Supervisor",
+      "curated": false,
+      "tools": [
+        {
+          "key": "mcp:azure-iot",
+          "displayName": "azure-iot",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "azure-iot-api",
+              "displayName": "Azure IoT API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "mcp:m365-graph",
+          "displayName": "m365-graph",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "microsoft-graph",
+              "displayName": "Microsoft Graph API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "mcp:sap-s4",
+          "displayName": "sap-s4",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "sap-s4-api",
+              "displayName": "SAP S/4 API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "mcp:servicenow",
+          "displayName": "servicenow",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "servicenow-api",
+              "displayName": "ServiceNow API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "mcp:workday",
+          "displayName": "workday",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "workday-api",
+              "displayName": "Workday API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "platform:llm",
+          "displayName": "Platform LLM",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "platform:state",
+          "displayName": "Platform state",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "cosmos",
+              "displayName": "Conversation store",
+              "kind": "AzureResource",
+              "resourceKey": "cosmos"
+            }
+          ]
+        },
+        {
+          "key": "skill:file-sharing",
+          "displayName": "file-sharing",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "storage",
+              "displayName": "File storage",
+              "kind": "AzureResource",
+              "resourceKey": "storage"
+            }
+          ]
+        },
+        {
+          "key": "skill:oee-analysis",
+          "displayName": "oee-analysis",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "local-data-compute",
+              "displayName": "Local data/compute",
+              "kind": "External"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "retail-banking",
+      "displayName": "Retail Banking Assistant",
+      "curated": true,
+      "tools": [
+        {
+          "key": "mcp:faker",
+          "displayName": "faker",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "core-banking-api",
+              "displayName": "Core Banking API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "platform:llm",
+          "displayName": "Platform LLM",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "platform:state",
+          "displayName": "Platform state",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "cosmos",
+              "displayName": "Conversation store",
+              "kind": "AzureResource",
+              "resourceKey": "cosmos"
+            }
+          ]
+        },
+        {
+          "key": "skill:code-interpreter",
+          "displayName": "code-interpreter",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "agent-runtime",
+              "displayName": "Agent runtime",
+              "kind": "AzureResource",
+              "resourceKey": "agentApp"
+            }
+          ]
+        },
+        {
+          "key": "skill:data-analysis",
+          "displayName": "data-analysis",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "skill:document-summary",
+          "displayName": "document-summary",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "skill:email-draft",
+          "displayName": "email-draft",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "skill:file-sharing",
+          "displayName": "file-sharing",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "storage",
+              "displayName": "File storage",
+              "kind": "AzureResource",
+              "resourceKey": "storage"
+            }
+          ]
+        },
+        {
+          "key": "skill:web-search",
+          "displayName": "web-search",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "sales-account-review",
+      "displayName": "Sales Account Review",
+      "curated": false,
+      "tools": [
+        {
+          "key": "mcp:salesforce",
+          "displayName": "salesforce",
+          "kind": "mcp",
+          "downstreams": [
+            {
+              "key": "salesforce-api",
+              "displayName": "Salesforce API",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "platform:llm",
+          "displayName": "Platform LLM",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "platform:state",
+          "displayName": "Platform state",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "cosmos",
+              "displayName": "Conversation store",
+              "kind": "AzureResource",
+              "resourceKey": "cosmos"
+            }
+          ]
+        },
+        {
+          "key": "skill:file-sharing",
+          "displayName": "file-sharing",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "storage",
+              "displayName": "File storage",
+              "kind": "AzureResource",
+              "resourceKey": "storage"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "key": "wealth-management",
+      "displayName": "Wealth Management Advisor",
+      "curated": true,
+      "tools": [
+        {
+          "key": "platform:llm",
+          "displayName": "Platform LLM",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "platform:state",
+          "displayName": "Platform state",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "cosmos",
+              "displayName": "Conversation store",
+              "kind": "AzureResource",
+              "resourceKey": "cosmos"
+            }
+          ]
+        },
+        {
+          "key": "skill:code-interpreter",
+          "displayName": "code-interpreter",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "agent-runtime",
+              "displayName": "Agent runtime",
+              "kind": "AzureResource",
+              "resourceKey": "agentApp"
+            }
+          ]
+        },
+        {
+          "key": "skill:crm",
+          "displayName": "crm",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "local-data-compute",
+              "displayName": "Local data/compute",
+              "kind": "External"
+            }
+          ]
+        },
+        {
+          "key": "skill:data-analysis",
+          "displayName": "data-analysis",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "skill:document-summary",
+          "displayName": "document-summary",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "skill:email-draft",
+          "displayName": "email-draft",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        },
+        {
+          "key": "skill:file-sharing",
+          "displayName": "file-sharing",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "storage",
+              "displayName": "File storage",
+              "kind": "AzureResource",
+              "resourceKey": "storage"
+            }
+          ]
+        },
+        {
+          "key": "skill:rag-search",
+          "displayName": "rag-search",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "search",
+              "displayName": "Knowledge base search",
+              "kind": "AzureResource",
+              "resourceKey": "search"
+            }
+          ]
+        },
+        {
+          "key": "skill:web-search",
+          "displayName": "web-search",
+          "kind": "skill",
+          "downstreams": [
+            {
+              "key": "foundry",
+              "displayName": "LLM inference",
+              "kind": "AzureResource",
+              "resourceKey": "foundry"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "layoutOrder": {
+    "advisor": [
+      "clinician-visit-prep",
+      "finance-close",
+      "generic",
+      "hr-onboarding",
+      "insurance",
+      "it-service-desk",
+      "plant-floor-supervisor",
+      "retail-banking",
+      "sales-account-review",
+      "wealth-management"
+    ],
+    "tool": [
+      "mcp:epic",
+      "skill:variance-analysis",
+      "mcp:microsoft-learn",
+      "skill:docx-editor",
+      "skill:pptx-editor",
+      "mcp:sap-s4",
+      "mcp:m365-graph",
+      "mcp:workday",
+      "skill:claims-mgmt",
+      "platform:llm",
+      "platform:state",
+      "skill:file-sharing",
+      "mcp:servicenow",
+      "skill:rag-search",
+      "skill:code-interpreter",
+      "skill:data-analysis",
+      "skill:document-summary",
+      "skill:email-draft",
+      "skill:web-search",
+      "mcp:azure-iot",
+      "skill:oee-analysis",
+      "skill:crm",
+      "mcp:faker",
+      "mcp:salesforce"
+    ],
+    "service": [
+      "epic-fhir-api",
+      "microsoft-learn-api",
+      "sap-s4-api",
+      "microsoft-graph",
+      "workday-api",
+      "local-data-compute",
+      "cosmos",
+      "storage",
+      "servicenow-api",
+      "search",
+      "agent-runtime",
+      "foundry",
+      "azure-iot-api",
+      "core-banking-api",
+      "salesforce-api"
+    ],
+    "resource": [
+      "cosmos",
+      "storage",
+      "search",
+      "agentApp",
+      "foundry"
+    ]
+  }
+}

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -35,6 +35,35 @@ param agentApiPath string = 'kratos-agent'
 @description('Deploy the OBO MCP server and its Entra app registrations. Requires directory permission to register Entra applications. Set to false in tenants/subscriptions where the deploying identity cannot create app registrations.')
 param deployObo bool = true
 
+@description('Deploy the Azure Monitor health model resources')
+param deployHealthModel bool = true
+
+@description('Location for Azure Monitor health model resources')
+@allowed([
+  'uksouth'
+  'canadacentral'
+  'centralus'
+  'swedencentral'
+  'southeastasia'
+  'switzerlandnorth'
+  'italynorth'
+  'northeurope'
+  'germanywestcentral'
+  'australiaeast'
+  'eastasia'
+  'japanwest'
+])
+param healthModelLocation string = 'centralus'
+
+@description('Optional health model name override')
+param healthModelName string = ''
+
+@description('Optional Azure AI Search resource id for health model wiring. Must be in this deployment resource group because the health-model identity is granted Monitoring Reader on the RG only. For out-of-RG targets, add Monitoring Reader at that scope.')
+param aiSearchResourceId string = ''
+
+@description('Optional APIM resource id for health model wiring. Must be in this deployment resource group because the health-model identity is granted Monitoring Reader on the RG only. For out-of-RG targets, add Monitoring Reader at that scope.')
+param apimResourceId string = ''
+
 @description('Location for the Static Web App (must be one of: centralus, eastus2, westus2, westeurope, eastasia)')
 @allowed([
   'centralus'
@@ -51,6 +80,32 @@ var resourceToken = toLower(uniqueString(subscription().id, environmentName, loc
 var namePrefix = empty(resourcePrefix) ? '' : '${resourcePrefix}-'
 var namePrefixNoHyphen = empty(resourcePrefix) ? '' : toLower(resourcePrefix)
 var tags = { 'azd-env-name': environmentName, project: 'kratos-agent' }
+var resourceCatalog = {
+  foundry: {
+    azureResourceId: aiFoundry.outputs.id
+    metricNamespace: 'Microsoft.CognitiveServices/accounts'
+  }
+  cosmos: {
+    azureResourceId: cosmosDb.outputs.id
+    metricNamespace: 'Microsoft.DocumentDB/databaseAccounts'
+  }
+  agentApp: {
+    azureResourceId: agentService.outputs.id
+    metricNamespace: 'Microsoft.App/containerApps'
+  }
+  storage: {
+    azureResourceId: blobStorage.outputs.id
+    metricNamespace: 'Microsoft.Storage/storageAccounts'
+  }
+  search: {
+    azureResourceId: aiSearchResourceId
+    metricNamespace: 'Microsoft.Search/searchServices'
+  }
+  apim: {
+    azureResourceId: apimResourceId
+    metricNamespace: 'Microsoft.ApiManagement/service'
+  }
+}
 
 // ─── Resource Group ───
 resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
@@ -217,6 +272,17 @@ module staticWebApp './modules/static-web-app.bicep' = {
   }
 }
 
+module healthModel './modules/health-model.bicep' = if (deployHealthModel) {
+  name: 'health-model'
+  scope: rg
+  params: {
+    name: !empty(healthModelName) ? healthModelName : '${namePrefix}${abbrs.cloudHealthHealthModels}${resourceToken}'
+    location: healthModelLocation
+    tags: tags
+    resourceCatalog: resourceCatalog
+  }
+}
+
 // ─── OBO MCP Server: identity, Entra apps, container app ───
 // One user-assigned managed identity is the ACR-pull identity, the container
 // runtime identity, AND the federated subject the OBO server app trusts.
@@ -325,6 +391,8 @@ output FOUNDRY_PROJECT_ENDPOINT string = aiFoundry.outputs.projectEndpoint
 output AZURE_AI_PROJECT_ID string = aiFoundry.outputs.projectId
 output AZURE_BLOB_STORAGE_ENDPOINT string = blobStorage.outputs.endpoint
 output AZURE_BLOB_STORAGE_ACCOUNT_NAME string = blobStorage.outputs.name
+output AZURE_HEALTH_MODEL_ID string = deployHealthModel ? healthModel.outputs.id : ''
+output AZURE_HEALTH_MODEL_NAME string = deployHealthModel ? healthModel.outputs.name : ''
 
 // ─── OBO MCP server outputs ───
 output OBO_MCP_SERVER_URL string = deployObo ? oboMcpServer.outputs.url : ''

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -16,6 +16,9 @@
     },
     "deployObo": {
       "value": "${DEPLOY_OBO=true}"
+    },
+    "deployHealthModel": {
+      "value": "${DEPLOY_HEALTH_MODEL=true}"
     }
   }
 }

--- a/infra/modules/health-model.bicep
+++ b/infra/modules/health-model.bicep
@@ -1,0 +1,289 @@
+@description('Name of the Azure Monitor health model')
+param name string
+
+@description('Location of the Azure Monitor health model')
+param location string
+
+@description('Resource tags')
+param tags object = {}
+
+@description('Resource catalog keyed by logical downstream key')
+param resourceCatalog object
+
+@description('Topology graph for advisors, tools, downstream services, and resources')
+param topology object = loadJsonContent('../health-model/topology.json')
+
+@description('Signal catalog keyed by metric namespace')
+param signalCatalog object = loadJsonContent('../health-model/signals.json')
+
+var monitoringReaderRoleId = '43d0d8ad-25c7-4714-9337-8ba259a9fe05'
+var authSettingName = 'auth-health-model'
+var Y_STEP = 193
+var CENTER_X = 0
+var X_STEP = 250
+
+// Sanitize a topology key into a valid CloudHealth entity name segment.
+// Also neutralize ARM reserved words (microsoft/azure/windows) which are
+// rejected in resource names; the human-readable name stays in displayName.
+func collapseDashes(s string) string => replace(replace(replace(replace(replace(replace(s, '--', '-'), '--', '-'), '--', '-'), '--', '-'), '--', '-'), '--', '-')
+func san(s string) string => collapseDashes(replace(replace(replace(replace(replace(replace(replace(replace(trim(toLower(s)), ':', '-'), '/', '-'), '.', '-'), '_', '-'), ' ', '-'), 'microsoft', 'msft'), 'azure', 'az'), 'windows', 'win'))
+
+func canvasX(order array, key string) int => CENTER_X + ((2 * indexOf(order, key) - (length(order) - 1)) * X_STEP) / 2
+
+var advisorToolEntries = flatten(map(topology.advisors, advisor => map(advisor.tools, tool => {
+  advisorKey: advisor.key
+  toolKey: tool.key
+  toolDisplayName: tool.displayName
+  toolKind: tool.kind
+  downstreams: tool.downstreams
+})))
+
+var toolDisplayNameMap = reduce(advisorToolEntries, {}, (cur, tool) => union(cur, {
+  '${tool.toolKey}': tool.toolDisplayName
+}))
+
+var serviceEntries = flatten(map(advisorToolEntries, tool => map(tool.downstreams, downstream => {
+  toolKey: tool.toolKey
+  serviceKey: downstream.key
+  serviceDisplayName: downstream.displayName
+  serviceKind: downstream.kind
+  resourceKey: downstream.?resourceKey
+})))
+
+var serviceMap = reduce(serviceEntries, {}, (cur, service) => union(cur, {
+  '${service.serviceKey}': {
+    displayName: service.serviceDisplayName
+    kind: service.serviceKind
+    resourceKey: service.resourceKey
+  }
+}))
+
+var rootToAdvisorRels = [for advisor in topology.advisors: {
+  parent: healthModel.name
+  child: 'adv-${advisor.key}'
+}]
+
+var advisorToToolCandidates = flatten(map(topology.advisors, advisor => map(advisor.tools, tool => {
+  parent: 'adv-${advisor.key}'
+  child: 'tool-${san(tool.key)}'
+})))
+
+var advisorToToolMap = reduce(advisorToToolCandidates, {}, (cur, rel) => union(cur, {
+  '${rel.parent}|${rel.child}': rel
+}))
+
+var advisorToToolRels = [for rel in items(advisorToToolMap): rel.value]
+
+var toolToServiceCandidates = map(serviceEntries, service => {
+  parent: 'tool-${san(service.toolKey)}'
+  child: 'svc-${san(service.serviceKey)}'
+})
+
+var toolToServiceMap = reduce(toolToServiceCandidates, {}, (cur, rel) => union(cur, {
+  '${rel.parent}|${rel.child}': rel
+}))
+
+var toolToServiceRels = [for rel in items(toolToServiceMap): rel.value]
+
+var serviceToResourceCandidates = map(filter(items(serviceMap), service => service.value.kind == 'AzureResource' && !empty(resourceCatalog[?service.value.resourceKey].?azureResourceId)), service => {
+  parent: 'svc-${san(service.key)}'
+  child: 'res-${service.value.resourceKey}'
+  serviceKey: service.key
+  resourceKey: service.value.resourceKey
+})
+
+var resolvedServiceKeys = map(serviceToResourceCandidates, rel => rel.serviceKey)
+
+var serviceToResourceMap = reduce(serviceToResourceCandidates, {}, (cur, rel) => union(cur, {
+  '${rel.parent}|${rel.child}': {
+    parent: rel.parent
+    child: rel.child
+  }
+}))
+
+var serviceToResourceRels = [for rel in items(serviceToResourceMap): rel.value]
+
+var relationshipCandidates = concat(rootToAdvisorRels, advisorToToolRels, toolToServiceRels, serviceToResourceRels)
+
+var relationshipMap = reduce(relationshipCandidates, {}, (cur, rel) => union(cur, {
+  '${rel.parent}|${rel.child}': rel
+}))
+
+var relationships = [for rel in items(relationshipMap): rel.value]
+
+var resourceKeys = filter(topology.layoutOrder.resource, resourceKey => !empty(resourceCatalog[?resourceKey].?azureResourceId))
+
+resource uami 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: 'id-${name}'
+  location: location
+  tags: tags
+}
+
+resource uamiRgRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, uami.id, monitoringReaderRoleId)
+  scope: resourceGroup()
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', monitoringReaderRoleId)
+    principalId: uami.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource healthModel 'Microsoft.CloudHealth/healthmodels@2026-05-01-preview' = {
+  name: name
+  location: location
+  tags: tags
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${uami.id}': {}
+    }
+  }
+  properties: {}
+}
+
+resource authSetting 'Microsoft.CloudHealth/healthmodels/authenticationsettings@2026-05-01-preview' = {
+  parent: healthModel
+  name: authSettingName
+  properties: {
+    authenticationKind: 'ManagedIdentity'
+    managedIdentityName: uami.id
+  }
+}
+
+// Root entity = the model itself (advisor edges use parentEntityName == the model
+// name). Declared explicitly so it is positioned centered above the advisor tier;
+// without an explicit canvasPosition the root defaults to (0,0), far left of the graph.
+resource rootEnt 'Microsoft.CloudHealth/healthmodels/entities@2026-05-01-preview' = {
+  parent: healthModel
+  name: name
+  properties: {
+    displayName: 'Kratos agent'
+    impact: 'Standard'
+    tags: {
+      tier: 'root'
+    }
+    canvasPosition: {
+      x: CENTER_X
+      y: 0
+    }
+    signalGroups: {
+      dependencies: {
+        aggregationType: 'WorstOf'
+      }
+    }
+  }
+}
+
+resource advisorEnt 'Microsoft.CloudHealth/healthmodels/entities@2026-05-01-preview' = [for advisor in topology.advisors: {
+  parent: healthModel
+  name: 'adv-${advisor.key}'
+  properties: {
+    displayName: advisor.displayName
+    impact: 'Standard'
+    tags: {
+      tier: 'advisor'
+    }
+    canvasPosition: {
+      x: canvasX(topology.layoutOrder.advisor, advisor.key)
+      y: Y_STEP
+    }
+    signalGroups: {
+      dependencies: {
+        aggregationType: 'WorstOf'
+      }
+    }
+  }
+}]
+
+resource toolEnt 'Microsoft.CloudHealth/healthmodels/entities@2026-05-01-preview' = [for toolKey in topology.layoutOrder.tool: {
+  parent: healthModel
+  name: 'tool-${san(toolKey)}'
+  properties: {
+    displayName: string(toolDisplayNameMap[toolKey])
+    impact: 'Standard'
+    tags: {
+      tier: 'tool'
+    }
+    canvasPosition: {
+      x: canvasX(topology.layoutOrder.tool, toolKey)
+      y: 2 * Y_STEP
+    }
+    signalGroups: {
+      dependencies: {
+        aggregationType: 'WorstOf'
+      }
+    }
+  }
+}]
+
+resource svcEnt 'Microsoft.CloudHealth/healthmodels/entities@2026-05-01-preview' = [for serviceKey in topology.layoutOrder.service: {
+  parent: healthModel
+  name: 'svc-${san(serviceKey)}'
+  properties: {
+    displayName: string(serviceMap[serviceKey].displayName)
+    impact: contains(resolvedServiceKeys, serviceKey) ? 'Standard' : 'Limited'
+    tags: {
+      tier: 'service'
+    }
+    canvasPosition: {
+      x: canvasX(topology.layoutOrder.service, serviceKey)
+      y: 3 * Y_STEP
+    }
+  }
+}]
+
+resource resEnt 'Microsoft.CloudHealth/healthmodels/entities@2026-05-01-preview' = [for resourceKey in resourceKeys: {
+  parent: healthModel
+  name: 'res-${resourceKey}'
+  properties: {
+    displayName: resourceKey
+    impact: 'Standard'
+    tags: {
+      tier: 'resource'
+    }
+    canvasPosition: {
+      x: canvasX(resourceKeys, resourceKey)
+      y: 4 * Y_STEP
+    }
+    signalGroups: {
+      azureResource: {
+        authenticationSetting: authSetting.name
+        azureResourceId: resourceCatalog[resourceKey].azureResourceId
+        signals: [for s in (signalCatalog[?resourceCatalog[resourceKey].metricNamespace] ?? []): {
+          name: s.name
+          signalKind: 'AzureResourceMetric'
+          metricNamespace: resourceCatalog[resourceKey].metricNamespace
+          metricName: s.metricName
+          aggregationType: s.aggregationType
+          timeGrain: s.timeGrain
+          refreshInterval: s.refreshInterval
+          dataUnit: s.dataUnit
+          evaluationRules: {
+            degradedRule: s.degradedRule
+            unhealthyRule: s.unhealthyRule
+          }
+        }]
+      }
+    }
+  }
+}]
+
+resource rels 'Microsoft.CloudHealth/healthmodels/relationships@2026-05-01-preview' = [for rel in relationships: {
+  parent: healthModel
+  name: 'rel-${uniqueString(rel.parent, rel.child)}'
+  properties: {
+    parentEntityName: rel.parent
+    childEntityName: rel.child
+  }
+  dependsOn: [
+    rootEnt
+    advisorEnt
+    toolEnt
+    svcEnt
+    resEnt
+  ]
+}]
+
+output id string = healthModel.id
+output name string = healthModel.name

--- a/scripts/gen_health_topology.py
+++ b/scripts/gen_health_topology.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover
+    yaml = None
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+USE_CASES_DIR = REPO_ROOT / "use-cases"
+TOPOLOGY_PATH = REPO_ROOT / "infra" / "health-model" / "topology.json"
+NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{1,258}[A-Za-z0-9]$")
+
+FUNCTIONAL_SKILLS = {
+    "web-search",
+    "rag-search",
+    "code-interpreter",
+    "data-analysis",
+    "crm",
+    "claims-mgmt",
+    "email-draft",
+    "document-summary",
+    "file-sharing",
+    "docx-editor",
+    "pptx-editor",
+    "oee-analysis",
+    "variance-analysis",
+}
+
+
+def sanitize_key(value: str) -> str:
+    sanitized = re.sub(r"[:/._\s]+", "-", value.strip().lower())
+    sanitized = re.sub(r"[^a-z0-9-]+", "-", sanitized)
+    sanitized = sanitized.replace("microsoft", "msft").replace("azure", "az").replace("windows", "win")
+    sanitized = re.sub(r"-{2,}", "-", sanitized).strip("-")
+    if not sanitized:
+        sanitized = "x-name"
+    if not sanitized[0].isalnum():
+        sanitized = f"a{sanitized}"
+    if not sanitized[-1].isalnum():
+        sanitized = f"{sanitized}a"
+    if len(sanitized) < 3:
+        sanitized = f"{sanitized}-x"
+    if len(sanitized) > 260:
+        sanitized = sanitized[:260]
+        sanitized = sanitized.rstrip("-")
+        if len(sanitized) < 3:
+            sanitized = f"{sanitized}x"
+        if not sanitized[-1].isalnum():
+            sanitized = f"{sanitized}a"
+    return sanitized
+
+
+def _frontmatter(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8").replace("\r\n", "\n")
+    match = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    if not match:
+        return {}
+    block = match.group(1)
+    if yaml is not None:
+        loaded = yaml.safe_load(block) or {}
+        return loaded if isinstance(loaded, dict) else {}
+    result: dict[str, Any] = {}
+    for line in block.splitlines():
+        if ":" not in line:
+            continue
+        key, raw_value = line.split(":", 1)
+        value = raw_value.strip()
+        if value.lower() == "true":
+            result[key.strip()] = True
+        elif value.lower() == "false":
+            result[key.strip()] = False
+        else:
+            result[key.strip()] = value
+    return result
+
+
+def _bool_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() == "true"
+    return False
+
+
+def _load_apm_lock(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8").replace("\r\n", "\n")
+    if yaml is not None:
+        loaded = yaml.safe_load(text) or {}
+        return loaded if isinstance(loaded, dict) else {}
+
+    result: dict[str, Any] = {}
+    servers: list[str] = []
+    in_mcp_servers = False
+    for line in text.splitlines():
+        if re.match(r"^\s*mcp_servers\s*:\s*$", line):
+            in_mcp_servers = True
+            continue
+        if in_mcp_servers:
+            if re.match(r"^\s*-\s*", line):
+                servers.append(line.split("-", 1)[1].strip())
+                continue
+            if line.strip() and not line.startswith(" "):
+                in_mcp_servers = False
+    if servers:
+        result["mcp_servers"] = servers
+    return result
+
+
+def _azure_downstream(key: str, display_name: str, resource_key: str) -> dict[str, str]:
+    return {
+        "key": key,
+        "displayName": display_name,
+        "kind": "AzureResource",
+        "resourceKey": resource_key,
+    }
+
+
+def _external_downstream(key: str, display_name: str) -> dict[str, str]:
+    return {
+        "key": key,
+        "displayName": display_name,
+        "kind": "External",
+    }
+
+
+DOWNSTREAM_FOUNDRY = _azure_downstream("foundry", "LLM inference", "foundry")
+DOWNSTREAM_SEARCH = _azure_downstream("search", "Knowledge base search", "search")
+DOWNSTREAM_STORAGE = _azure_downstream("storage", "File storage", "storage")
+DOWNSTREAM_AGENT_RUNTIME = _azure_downstream("agent-runtime", "Agent runtime", "agentApp")
+DOWNSTREAM_COSMOS = _azure_downstream("cosmos", "Conversation store", "cosmos")
+DOWNSTREAM_LOCAL = _external_downstream("local-data-compute", "Local data/compute")
+DOWNSTREAM_M365_GRAPH = _external_downstream("microsoft-graph", "Microsoft Graph API")
+
+MCP_DOWNSTREAMS: dict[str, dict[str, str]] = {
+    "m365-graph": DOWNSTREAM_M365_GRAPH,
+    "salesforce": _external_downstream("salesforce-api", "Salesforce API"),
+    "workday": _external_downstream("workday-api", "Workday API"),
+    "servicenow": _external_downstream("servicenow-api", "ServiceNow API"),
+    "sap-s4": _external_downstream("sap-s4-api", "SAP S/4 API"),
+    "epic-fhir": _external_downstream("epic-fhir-api", "Epic FHIR API"),
+    "epic": _external_downstream("epic-fhir-api", "Epic FHIR API"),
+    "azure-iot": _external_downstream("azure-iot-api", "Azure IoT API"),
+    "faker": _external_downstream("core-banking-api", "Core Banking API"),
+    "core-banking": _external_downstream("core-banking-api", "Core Banking API"),
+    "microsoft-learn": _external_downstream("microsoft-learn-api", "Microsoft Learn API"),
+}
+
+
+def map_skill_to_downstreams(skill_name: str) -> list[dict[str, str]]:
+    skill = skill_name.strip().lower()
+    if skill == "web-search":
+        return [DOWNSTREAM_FOUNDRY]
+    if skill == "rag-search":
+        return [DOWNSTREAM_SEARCH]
+    if skill == "file-sharing":
+        return [DOWNSTREAM_STORAGE]
+    if skill == "code-interpreter":
+        return [DOWNSTREAM_AGENT_RUNTIME]
+    if skill in {"data-analysis", "email-draft", "document-summary", "foundry-agent"}:
+        return [DOWNSTREAM_FOUNDRY]
+    if skill.endswith("-pdf") or skill.endswith("-report"):
+        return [DOWNSTREAM_FOUNDRY]
+    if skill in MCP_DOWNSTREAMS:
+        return [MCP_DOWNSTREAMS[skill]]
+    return [DOWNSTREAM_LOCAL]
+
+
+def map_mcp_to_downstreams(server_name: str) -> list[dict[str, str]]:
+    normalized = server_name.strip().lower()
+    downstream = MCP_DOWNSTREAMS.get(normalized)
+    if downstream:
+        return [downstream]
+    display = f"{server_name} API"
+    key = f"{sanitize_key(server_name)}-api"
+    return [_external_downstream(key, display)]
+
+
+def _enabled_skills(use_case_dir: Path) -> list[str]:
+    skills: list[str] = []
+    for skill_file in sorted(use_case_dir.glob("skills/*/SKILL.md")):
+        meta = _frontmatter(skill_file)
+        if _bool_value(meta.get("enabled", False)):
+            skills.append(skill_file.parent.name)
+    return skills
+
+
+def _configured_mcp_servers(use_case_dir: Path) -> list[str]:
+    servers: set[str] = set()
+    mcp_file = use_case_dir / ".mcp.json"
+    if mcp_file.exists():
+        text = mcp_file.read_text(encoding="utf-8").strip()
+        if text:
+            loaded = json.loads(text)
+            if isinstance(loaded, dict):
+                servers.update(str(key) for key in loaded.keys())
+
+    apm_lock = _load_apm_lock(use_case_dir / "apm.lock.yaml")
+    for server in apm_lock.get("mcp_servers") or []:
+        if isinstance(server, str):
+            servers.add(server)
+    return sorted(servers)
+
+
+def _sorted_unique_downstreams(downstreams: list[dict[str, str]]) -> list[dict[str, str]]:
+    by_key: dict[str, dict[str, str]] = {}
+    for downstream in downstreams:
+        by_key[downstream["key"]] = dict(downstream)
+    return [by_key[key] for key in sorted(by_key.keys())]
+
+
+def _is_functional_tool(tool_key: str) -> bool:
+    if tool_key.startswith("mcp:"):
+        return True
+    if tool_key.startswith("platform:"):
+        return True
+    if tool_key.startswith("skill:"):
+        return tool_key.split(":", 1)[1] in FUNCTIONAL_SKILLS
+    return False
+
+
+def _mean(values: list[int]) -> float:
+    return sum(values) / len(values)
+
+
+def _build_layout_order(advisors: list[dict[str, Any]]) -> dict[str, list[str]]:
+    advisor_order = [advisor["key"] for advisor in advisors]
+    advisor_index = {key: idx for idx, key in enumerate(advisor_order)}
+
+    tool_to_advisor_indices: dict[str, list[int]] = {}
+    tool_to_service_keys: dict[str, set[str]] = {}
+    service_to_tool_indices: dict[str, list[int]] = {}
+    service_to_resource_keys: dict[str, set[str]] = {}
+
+    for advisor in advisors:
+        a_idx = advisor_index[advisor["key"]]
+        for tool in advisor["tools"]:
+            tool_key = tool["key"]
+            tool_to_advisor_indices.setdefault(tool_key, []).append(a_idx)
+            service_keys = tool_to_service_keys.setdefault(tool_key, set())
+            for downstream in tool["downstreams"]:
+                service_key = downstream["key"]
+                service_keys.add(service_key)
+
+    tool_order = sorted(
+        tool_to_advisor_indices.keys(),
+        key=lambda key: (_mean(tool_to_advisor_indices[key]), key),
+    )
+    tool_index = {key: idx for idx, key in enumerate(tool_order)}
+
+    for tool_key in tool_order:
+        t_idx = tool_index[tool_key]
+        for service_key in sorted(tool_to_service_keys.get(tool_key, set())):
+            service_to_tool_indices.setdefault(service_key, []).append(t_idx)
+
+    service_order = sorted(
+        service_to_tool_indices.keys(),
+        key=lambda key: (_mean(service_to_tool_indices[key]), key),
+    )
+    service_index = {key: idx for idx, key in enumerate(service_order)}
+
+    resource_to_service_indices: dict[str, list[int]] = {}
+    for service_key in service_order:
+        s_idx = service_index[service_key]
+        for advisor in advisors:
+            for tool in advisor["tools"]:
+                for downstream in tool["downstreams"]:
+                    if downstream["key"] != service_key:
+                        continue
+                    if downstream.get("kind") == "AzureResource" and downstream.get("resourceKey"):
+                        resource_key = str(downstream["resourceKey"])
+                        service_to_resource_keys.setdefault(service_key, set()).add(resource_key)
+                        resource_to_service_indices.setdefault(resource_key, []).append(s_idx)
+
+    resource_order = sorted(
+        resource_to_service_indices.keys(),
+        key=lambda key: (_mean(resource_to_service_indices[key]), key),
+    )
+
+    return {
+        "advisor": advisor_order,
+        "tool": tool_order,
+        "service": service_order,
+        "resource": resource_order,
+    }
+
+
+def _validate_scope_uniqueness(
+    keys: list[str],
+    scope: str,
+    *,
+    require_raw_name_valid: bool = False,
+) -> None:
+    by_sanitized: dict[str, str] = {}
+    for key in keys:
+        if require_raw_name_valid and not NAME_RE.fullmatch(key):
+            raise ValueError(f"Key {key!r} is not a valid emitted entity name in {scope}")
+        sanitized = sanitize_key(key)
+        if not NAME_RE.fullmatch(sanitized):
+            raise ValueError(f"Key {key!r} sanitizes to invalid entity name {sanitized!r}")
+        existing = by_sanitized.get(sanitized)
+        if existing is not None and existing != key:
+            raise ValueError(
+                f"Sanitized name collision in {scope}: {existing!r} and {key!r} -> {sanitized!r}"
+            )
+        by_sanitized[sanitized] = key
+
+
+def _validate_topology(topology: dict[str, Any]) -> None:
+    advisors = topology["advisors"]
+    layout = topology["layoutOrder"]
+
+    advisor_keys = [advisor["key"] for advisor in advisors]
+    _validate_scope_uniqueness(advisor_keys, "advisors", require_raw_name_valid=True)
+    if layout["advisor"] != advisor_keys:
+        raise ValueError("layoutOrder.advisor does not match advisor keys")
+
+    for advisor in advisors:
+        tool_keys = [tool["key"] for tool in advisor["tools"]]
+        _validate_scope_uniqueness(tool_keys, f"tools for advisor {advisor['key']}")
+        for tool in advisor["tools"]:
+            downstream_keys = [downstream["key"] for downstream in tool["downstreams"]]
+            _validate_scope_uniqueness(
+                downstream_keys,
+                f"downstreams for tool {tool['key']} in advisor {advisor['key']}",
+            )
+
+    for tier in ("advisor", "tool", "service", "resource"):
+        values = layout[tier]
+        if len(values) != len(set(values)):
+            raise ValueError(f"layoutOrder.{tier} contains duplicates")
+        _validate_scope_uniqueness(list(values), f"layoutOrder.{tier}")
+
+    used_tool_keys = {
+        tool["key"]
+        for advisor in advisors
+        for tool in advisor["tools"]
+    }
+    if used_tool_keys != set(layout["tool"]):
+        raise ValueError("layoutOrder.tool does not match used tool keys")
+
+    used_service_keys = {
+        downstream["key"]
+        for advisor in advisors
+        for tool in advisor["tools"]
+        for downstream in tool["downstreams"]
+    }
+    if used_service_keys != set(layout["service"]):
+        raise ValueError("layoutOrder.service does not match used service keys")
+
+    used_resource_keys = {
+        str(downstream["resourceKey"])
+        for advisor in advisors
+        for tool in advisor["tools"]
+        for downstream in tool["downstreams"]
+        if downstream.get("kind") == "AzureResource" and downstream.get("resourceKey")
+    }
+    if used_resource_keys != set(layout["resource"]):
+        raise ValueError("layoutOrder.resource does not match used resource keys")
+
+    _validate_scope_uniqueness(
+        [f"adv-{key}" for key in advisor_keys],
+        "emitted advisor entity names",
+        require_raw_name_valid=True,
+    )
+    _validate_scope_uniqueness(
+        [f"tool-{sanitize_key(key)}" for key in layout["tool"]],
+        "emitted tool entity names",
+        require_raw_name_valid=True,
+    )
+    _validate_scope_uniqueness(
+        [f"svc-{sanitize_key(key)}" for key in layout["service"]],
+        "emitted service entity names",
+        require_raw_name_valid=True,
+    )
+    _validate_scope_uniqueness(
+        [f"res-{key}" for key in layout["resource"]],
+        "emitted resource entity names",
+        require_raw_name_valid=True,
+    )
+
+
+def build_topology(use_cases_dir: Path = USE_CASES_DIR) -> dict[str, Any]:
+    advisors: list[dict[str, Any]] = []
+    for use_case_dir in sorted(p for p in use_cases_dir.iterdir() if p.is_dir()):
+        system_prompt = use_case_dir / "SYSTEM_PROMPT.md"
+        if not system_prompt.exists():
+            continue
+
+        meta = _frontmatter(system_prompt)
+        advisor_key = sanitize_key(use_case_dir.name)
+        display_name = str(meta.get("name", advisor_key))
+        curated = _bool_value(meta.get("curated", False))
+
+        tools_by_key: dict[str, dict[str, Any]] = {}
+        for skill_name in _enabled_skills(use_case_dir):
+            tool_key = f"skill:{skill_name}"
+            if not _is_functional_tool(tool_key):
+                continue
+            tools_by_key[tool_key] = {
+                "key": tool_key,
+                "displayName": skill_name,
+                "kind": "skill",
+                "downstreams": _sorted_unique_downstreams(map_skill_to_downstreams(skill_name)),
+            }
+
+        for server_name in _configured_mcp_servers(use_case_dir):
+            tool_key = f"mcp:{server_name}"
+            tools_by_key[tool_key] = {
+                "key": tool_key,
+                "displayName": server_name,
+                "kind": "mcp",
+                "downstreams": _sorted_unique_downstreams(map_mcp_to_downstreams(server_name)),
+            }
+
+        tools_by_key["platform:llm"] = {
+            "key": "platform:llm",
+            "displayName": "Platform LLM",
+            "kind": "skill",
+            "downstreams": [dict(DOWNSTREAM_FOUNDRY)],
+        }
+        tools_by_key["platform:state"] = {
+            "key": "platform:state",
+            "displayName": "Platform state",
+            "kind": "skill",
+            "downstreams": [dict(DOWNSTREAM_COSMOS)],
+        }
+
+        tools = [tools_by_key[key] for key in sorted(tools_by_key.keys())]
+        for tool in tools:
+            tool["downstreams"] = _sorted_unique_downstreams(tool["downstreams"])
+
+        advisors.append(
+            {
+                "key": advisor_key,
+                "displayName": display_name,
+                "curated": curated,
+                "tools": tools,
+            }
+        )
+
+    advisors = sorted(advisors, key=lambda advisor: advisor["key"])
+    layout_order = _build_layout_order(advisors)
+    topology = {
+        "advisors": advisors,
+        "layoutOrder": layout_order,
+    }
+    _validate_topology(topology)
+    return topology
+
+
+def render_topology_json(topology: dict[str, Any]) -> str:
+    return json.dumps(topology, indent=2) + "\n"
+
+
+def _counts(topology: dict[str, Any]) -> tuple[int, int]:
+    advisor_count = len(topology.get("advisors", []))
+    tool_count = len(topology.get("layoutOrder", {}).get("tool", []))
+    return advisor_count, tool_count
+
+
+def write_topology_file(output_path: Path = TOPOLOGY_PATH, use_cases_dir: Path = USE_CASES_DIR) -> dict[str, Any]:
+    topology = build_topology(use_cases_dir)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(render_topology_json(topology), encoding="utf-8")
+    return topology
+
+
+def check_topology_file(output_path: Path = TOPOLOGY_PATH, use_cases_dir: Path = USE_CASES_DIR) -> bool:
+    expected = render_topology_json(build_topology(use_cases_dir))
+    if not output_path.exists():
+        return False
+    actual = output_path.read_text(encoding="utf-8")
+    return actual == expected
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate health model topology from use-case config.")
+    parser.add_argument("--check", action="store_true", help="Fail if topology.json is stale")
+    args = parser.parse_args()
+
+    if args.check:
+        if check_topology_file():
+            topology = build_topology(USE_CASES_DIR)
+            advisor_count, tool_count = _counts(topology)
+            print(
+                f"topology.json is up to date (advisors={advisor_count}, distinctTools={tool_count})."
+            )
+            return 0
+        print("topology.json is stale. Run: python3 scripts/gen_health_topology.py")
+        return 1
+
+    topology = write_topology_file()
+    advisor_count, tool_count = _counts(topology)
+    relative = TOPOLOGY_PATH.relative_to(REPO_ROOT)
+    print(f"Wrote {relative} (advisors={advisor_count}, distinctTools={tool_count}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_gen_health_topology.py
+++ b/scripts/test_gen_health_topology.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+USE_CASES_DIR = REPO_ROOT / "use-cases"
+GENERATOR_PATH = REPO_ROOT / "scripts" / "gen_health_topology.py"
+
+DROPPED_SKILLS = {
+    "skill:account-brief-pdf",
+    "skill:loan-calculator",
+    "skill:it-policy-reference",
+    "skill:ticket-actions",
+    "skill:portfolio-review",
+}
+
+
+def _load_generator_module():
+    spec = importlib.util.spec_from_file_location("gen_health_topology", GENERATOR_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load generator module from {GENERATOR_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _frontmatter(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8").replace("\r\n", "\n")
+    if not text.startswith("---\n"):
+        return {}
+    _, yaml_block, _ = text.split("---\n", 2)
+    loaded = yaml.safe_load(yaml_block) or {}
+    if not isinstance(loaded, dict):
+        return {}
+    return loaded
+
+
+def _expected_use_case_dirs() -> list[Path]:
+    return sorted(
+        p for p in USE_CASES_DIR.iterdir() if p.is_dir() and (p / "SYSTEM_PROMPT.md").exists()
+    )
+
+
+def _configured_mcp_servers(use_case_dir: Path) -> set[str]:
+    servers: set[str] = set()
+    mcp_path = use_case_dir / ".mcp.json"
+    if mcp_path.exists():
+        text = mcp_path.read_text(encoding="utf-8").strip()
+        if text:
+            loaded = json.loads(text)
+            if isinstance(loaded, dict):
+                servers.update(str(key) for key in loaded.keys())
+
+    apm_lock_path = use_case_dir / "apm.lock.yaml"
+    if apm_lock_path.exists():
+        lock_text = apm_lock_path.read_text(encoding="utf-8").replace("\r\n", "\n")
+        loaded = yaml.safe_load(lock_text) or {}
+        if isinstance(loaded, dict):
+            for server in loaded.get("mcp_servers") or []:
+                if isinstance(server, str):
+                    servers.add(server)
+    return servers
+
+
+def _all_tool_keys(topology: dict[str, Any]) -> set[str]:
+    return {
+        tool["key"]
+        for advisor in topology["advisors"]
+        for tool in advisor["tools"]
+    }
+
+
+def test_advisors_match_use_cases_and_persona_names():
+    generator = _load_generator_module()
+    topology = generator.build_topology(USE_CASES_DIR)
+
+    expected_dirs = _expected_use_case_dirs()
+    advisors = topology["advisors"]
+    assert len(advisors) == len(expected_dirs)
+
+    advisors_by_key = {advisor["key"]: advisor for advisor in advisors}
+    expected_keys = [generator.sanitize_key(path.name) for path in expected_dirs]
+    assert topology["layoutOrder"]["advisor"] == sorted(expected_keys)
+
+    for use_case_dir in expected_dirs:
+        key = generator.sanitize_key(use_case_dir.name)
+        persona = str(_frontmatter(use_case_dir / "SYSTEM_PROMPT.md").get("name", key))
+        assert advisors_by_key[key]["displayName"] == persona
+
+
+def test_dropped_skills_are_absent_and_functional_insurance_tools_present():
+    generator = _load_generator_module()
+    topology = generator.build_topology(USE_CASES_DIR)
+    all_tool_keys = _all_tool_keys(topology)
+
+    assert DROPPED_SKILLS.isdisjoint(all_tool_keys)
+
+    advisors_by_key = {advisor["key"]: advisor for advisor in topology["advisors"]}
+    insurance_tools = {tool["key"] for tool in advisors_by_key["insurance"]["tools"]}
+    assert {"skill:rag-search", "skill:web-search", "skill:crm", "platform:llm"}.issubset(
+        insurance_tools
+    )
+
+
+def test_layout_order_tool_is_deduped_and_covers_all_used_tools():
+    generator = _load_generator_module()
+    topology = generator.build_topology(USE_CASES_DIR)
+
+    layout_tools = topology["layoutOrder"]["tool"]
+    used_tools = _all_tool_keys(topology)
+
+    assert len(layout_tools) == len(set(layout_tools))
+    assert set(layout_tools) == used_tools
+
+
+def test_disabled_skill_is_not_emitted_from_synthetic_tree(tmp_path: Path):
+    generator = _load_generator_module()
+
+    uc_dir = tmp_path / "use-cases" / "azure_iot"
+    (uc_dir / "skills" / "web-search").mkdir(parents=True)
+    (uc_dir / "skills" / "code-interpreter").mkdir(parents=True)
+
+    (uc_dir / "SYSTEM_PROMPT.md").write_text(
+        "---\nname: Demo Case\ncurated: false\n---\nDemo\n",
+        encoding="utf-8",
+    )
+    (uc_dir / ".mcp.json").write_text("{\n}\n", encoding="utf-8")
+    (uc_dir / "skills" / "web-search" / "SKILL.md").write_text(
+        "---\nname: web-search\nenabled: true\n---\n",
+        encoding="utf-8",
+    )
+    (uc_dir / "skills" / "code-interpreter" / "SKILL.md").write_text(
+        "---\nname: code-interpreter\nenabled: false\n---\n",
+        encoding="utf-8",
+    )
+
+    topology = generator.build_topology(tmp_path / "use-cases")
+    advisor = topology["advisors"][0]
+    tools = {tool["key"] for tool in advisor["tools"]}
+    assert advisor["key"] == "az-iot"
+    assert "skill:web-search" in tools
+    assert "skill:code-interpreter" not in tools
+
+
+def test_mcp_tool_with_underscore_emits_valid_entity_name(tmp_path: Path):
+    generator = _load_generator_module()
+
+    uc_dir = tmp_path / "use-cases" / "generic"
+    uc_dir.mkdir(parents=True)
+    (uc_dir / "SYSTEM_PROMPT.md").write_text(
+        "---\nname: Generic\ncurated: false\n---\nDemo\n",
+        encoding="utf-8",
+    )
+    (uc_dir / ".mcp.json").write_text('{"sap_s4": {}}\n', encoding="utf-8")
+
+    topology = generator.build_topology(tmp_path / "use-cases")
+    advisor = topology["advisors"][0]
+    tool_keys = {tool["key"] for tool in advisor["tools"]}
+    assert "mcp:sap_s4" in tool_keys
+
+    emitted_tool_name = f"tool-{generator.sanitize_key('mcp:sap_s4')}"
+    assert generator.NAME_RE.fullmatch(emitted_tool_name)
+    assert "_" not in emitted_tool_name
+    assert generator.sanitize_key("mcp:Microsoft-Learn") == "mcp-msft-learn"
+
+
+def test_empty_mcp_config_yields_no_mcp_tools():
+    generator = _load_generator_module()
+    topology = generator.build_topology(USE_CASES_DIR)
+    advisors_by_key = {advisor["key"]: advisor for advisor in topology["advisors"]}
+
+    wealth_tools = {tool["key"] for tool in advisors_by_key["wealth-management"]["tools"]}
+    assert _configured_mcp_servers(USE_CASES_DIR / "wealth-management") == set()
+    assert not any(tool.startswith("mcp:") for tool in wealth_tools)
+
+
+def test_check_topology_file_is_stable_for_generated_content(tmp_path: Path):
+    generator = _load_generator_module()
+    output_path = tmp_path / "topology.json"
+
+    generator.write_topology_file(output_path=output_path, use_cases_dir=USE_CASES_DIR)
+    assert generator.check_topology_file(output_path=output_path, use_cases_dir=USE_CASES_DIR)
+
+    output_path.write_text("{}\n", encoding="utf-8")
+    assert not generator.check_topology_file(output_path=output_path, use_cases_dir=USE_CASES_DIR)
+
+
+def test_repo_topology_file_is_in_sync():
+    generator = _load_generator_module()
+    assert generator.check_topology_file()

--- a/src/backend/app/exporter_templates/agent.yaml.template
+++ b/src/backend/app/exporter_templates/agent.yaml.template
@@ -19,11 +19,9 @@ environment_variables:
   # Model deployment (referenced in CopilotAgent._build_provider_config)
   - name: MODEL_DEPLOYMENT_NAME
     value: $${FOUNDRY_MODEL_DEPLOYMENT}
-  # AI Services project endpoint (full path with /api/projects/<proj>).
-  # Hosted-agent main.py derives the FOUNDRY_ENDPOINT base URL from this
-  # since FOUNDRY_* env var names are reserved by the platform.
+  # AI Services base URL (fallback if platform doesn't inject FOUNDRY_ENDPOINT).
   - name: AI_SERVICES_ENDPOINT
-    value: $${AZURE_AI_PROJECT_ENDPOINT}
+    value: $${FOUNDRY_ENDPOINT}
   # Azure service endpoints (injected by Bicep / azd env)
   - name: COSMOS_DB_ENDPOINT
     value: $${AZURE_COSMOS_DB_ENDPOINT}

--- a/src/backend/app/exporter_templates/azure.yaml.template
+++ b/src/backend/app/exporter_templates/azure.yaml.template
@@ -35,7 +35,7 @@ services:
                 # Without this, the agentserver framework falls back to a console
                 # OTLP exporter and floods stdout with metric JSON every 60s.
                 APPLICATIONINSIGHTS_CONNECTION_STRING: $${AZURE_APP_INSIGHTS_CONNECTION_STRING}
-                AI_SERVICES_ENDPOINT: $${AZURE_AI_PROJECT_ENDPOINT}
+                AI_SERVICES_ENDPOINT: $${FOUNDRY_ENDPOINT}
                 BLOB_SKILLS_CONTAINER: skills
                 BLOB_STORAGE_ENDPOINT: $${AZURE_BLOB_STORAGE_ENDPOINT}
                 COSMOS_DB_DATABASE: kratos-agent-${slug}

--- a/src/backend/tests/test_project_exporter.py
+++ b/src/backend/tests/test_project_exporter.py
@@ -144,6 +144,8 @@ def test_assemble_renders_agent_yaml_with_persona(exporter: ProjectExporter, tmp
     assert "kind: hosted" in agent_yaml
     assert "protocols:" in agent_yaml
     assert "environment_variables:" in agent_yaml
+    assert "value: ${FOUNDRY_ENDPOINT}" in agent_yaml
+    assert "value: ${AZURE_AI_PROJECT_ENDPOINT}" not in agent_yaml
     # Cosmos DB database is per-export to avoid collisions.
     assert "kratos-agent-finance-close" in agent_yaml
 
@@ -164,6 +166,8 @@ def test_assemble_renders_azure_yaml_with_slug(exporter: ProjectExporter, tmp_pa
     assert "language: docker" in azure_yaml
     assert "context: ../.." in azure_yaml
     assert "azure.ai.agents:" in azure_yaml  # required extension
+    assert "AI_SERVICES_ENDPOINT: ${FOUNDRY_ENDPOINT}" in azure_yaml
+    assert "AI_SERVICES_ENDPOINT: ${AZURE_AI_PROJECT_ENDPOINT}" not in azure_yaml
 
 
 def test_assemble_copies_backend_app_recursively(exporter: ProjectExporter, tmp_path: Path):

--- a/src/hosted-agent/agent.yaml
+++ b/src/hosted-agent/agent.yaml
@@ -18,7 +18,7 @@ environment_variables:
     value: ${FOUNDRY_MODEL_DEPLOYMENT}
   # AI Services base URL (fallback if platform doesn't inject FOUNDRY_ENDPOINT)
   - name: AI_SERVICES_ENDPOINT
-    value: ${AZURE_AI_PROJECT_ENDPOINT}
+    value: ${FOUNDRY_ENDPOINT}
   # Capture prompts + completions (gen_ai.input/output.messages) on the
   # invoke_agent span so the Foundry Traces tab shows the LLM interaction
   # details. Off by default in OTel; we opt in here.


### PR DESCRIPTION
## Summary

- Added a post-`azd up` runbook for the last setup steps: Foundry custom-agent registration, smoke-test order, telemetry checks, skill execution checks, local-only Copilot token setup, and recovery paths.
- Extended the e2e smoke chat spec so it proves skill execution. The test now reads a scenario that expects `code-interpreter`, parses SSE events, filters backend-internal tools, and requires the expected user-facing tool call.
- Hardened hosted-agent endpoint fallback config so `AI_SERVICES_ENDPOINT` uses the AI Services base URL, not the project URL. Exported-agent templates now match that behavior.
- Added exporter assertions so future exported agents keep the base URL fallback.

## Validation

- `cd .copilot/skills/e2e-smoke && npx tsc --noEmit`
- `cd .copilot/skills/e2e-smoke && SKIP_BROWSER=1 ./run.sh`
- `cd .copilot/skills/e2e-smoke && ./run.sh`
- `cd src/backend && .venv/bin/python -m pytest tests/test_project_exporter.py -q`

## Notes

- Full deployed smoke run passed: `23 passed`, `unexpected=0`, `skipped=0`.
- API-only smoke run passed: `16 passed`, `unexpected=0`, `skipped=0`.
- Direct Application Insights query returned rows and operations after a chat run.
